### PR TITLE
ISSUE #513 Change startedType for The Shimmering Frond to monster.

### DIFF
--- a/!Questie/Database/addendum.lua
+++ b/!Questie/Database/addendum.lua
@@ -12387,7 +12387,7 @@ QuestieHashMap = {
  },
  [866040024]={
   ['name']="The Shimmering Frond",
-  ['startedType']="object",
+  ['startedType']="monster",
   ['finishedType']="monster",
   ['startedBy']="Strange Fronded Plant",
   ['finishedBy']="Denalan",

--- a/!Questie/Database/monsters.lua
+++ b/!Questie/Database/monsters.lua
@@ -51614,6 +51614,13 @@ QuestieMonsters = {
     ["locationCount"] = 1,
     ["faction"] = 1
   },
+  ["Strange Fronded Plant"] = {
+    ["locations"] = {
+        [1] = {24.0, 0.3460, 0.2880, 100.0}
+    },
+    ["locationCount"] = 1,
+    ["faction"] = 1
+  },
   ["Fel Cannon Destroyed"] = {
     ["locations"] = {
       [1] = {56.0, 0.7262, 0.2156, 100.0},


### PR DESCRIPTION
This pull request will change the `startedType` for The Shimmering Frond quest to monster and adds the Strange Fronded Plant object to the `monsters.lua` file. The aim is to fix the bug reported in issue #513.

✔️ runs without errors
✔️ tested locally and passes