### PR TITLE
Fix [10864] A Burden of Souls

### DIFF
--- a/Database/Corrections/QuestieTBCFixes.lua
+++ b/Database/Corrections/QuestieTBCFixes.lua
@@ -805,6 +805,16 @@ function QuestieTBCFixes:Load()
                 },
             }},
         },
+        [10864]={
+            [questKeys.objectives] = {
+                {
+                    {16878,"Shattered Hand Souls Reaped"},
+                    {19413,"Shattered Hand Souls Reaped"},
+                    {19414,"Shattered Hand Souls Reaped"},
+                    {19415, "Shattered Hand Souls Reaped"}
+                }
+            }
+        },
         [10710]={
             [questKeys.triggerEnd] = {"Throw caution to the wind.", {
                 [3522]={


### PR DESCRIPTION
Add real mobs to creature objective.

https://tbc.wowhead.com/quest=10864/a-burden-of-souls doesn't have any real mobs associated with it, but https://tbc.wowhead.com/npc=16878/shattered-hand-berserker, https://tbc.wowhead.com/npc=19414/shattered-hand-guard, and https://tbc.wowhead.com/npc=19415/shattered-hand-acolyte give credit.