### PR TITLE
Create dummy creature objectives using corrected quest data

### DIFF
--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -575,3 +575,39 @@ function QuestieLib:UnpackBinary(val)
     end
     return ret
 end
+
+function QuestieLib:PrintTable(keyToPrint, value, debugLevel, seen)
+    if seen and seen[value] then return end
+    -- New table; mark it as seen and iterate recursively
+    local s = seen or {}
+    local d = debugLevel or DEBUG_SPAM
+    s[value] = true
+
+    if (type(value) ~= "table") then
+        Questie:Debug(d, keyToPrint .. ": " .. tostring(value))
+    else
+        for k, v in pairs(value) do
+            local key = keyToPrint .. "." .. k
+            QuestieLib:PrintTable(key, v, d, s)
+        end
+    end
+end
+
+-- Source: https://gist.github.com/tylerneylon/81333721109155b2d244
+local function _DeepCopy(object, seen)
+    -- Handle non-tables and previously-seen tables.
+    if type(object) ~= 'table' then return object
+    end
+    if seen and seen[object] then return seen[object] end
+
+    -- New table; mark it as seen and copy recursively.
+    local s = seen or {}
+    local res = {}
+    s[object] = res
+    for k, v in pairs(object) do res[_DeepCopy(k, s)] = _DeepCopy(v, s) end
+    return setmetatable(res, getmetatable(object))
+end
+
+function QuestieLib:DeepCopy(tableToCopy)
+    return _DeepCopy(tableToCopy)
+end

--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -32,6 +32,7 @@ local _InitObjectiveTexts
 ---@param key string monster: m_, items: i_, objects: o_ + string name of the objective
 ---@param objective table
 function QuestieTooltips:RegisterObjectiveTooltip(questId, key, objective)
+    Questie:Debug(DEBUG_SPAM, "Registering objective tooltip for", questId, key)
     if QuestieTooltips.lookupByKey[key] == nil then
         QuestieTooltips.lookupByKey[key] = {};
     end


### PR DESCRIPTION
Initial work for using creature objective corrections to populate dummy objectives and register dummy objective tooltips.
* `QuestieLib:PrintTable` was created for initial discovery and I decided others might  find it useful as well.
* `QuestieLib:DeepCopy` was created to avoid contaminating table references.

See discussion beginning here:
https://discord.com/channels/263036731165638656/263040777658171392/827884666085965854

See images from solution beginning here: https://discord.com/channels/263036731165638656/263040777658171392/828000955579498496
