### PR TITLE
Fix quest turn in for instant quests which don't fire QUEST_REMOVED

### DIFF
--- a/Modules/QuestieEventHandler.lua
+++ b/Modules/QuestieEventHandler.lua
@@ -306,9 +306,10 @@ function _EventHandler:QuestFinished()
         Questie:Debug(DEBUG_DEVELOP, "shouldRunQLU still active")
         if next(latestTurnedInQuestIds) then
             Questie:Debug(DEBUG_DEVELOP, "finishedEventReceived is questId")
-            local quest = QuestieDB:GetQuest(latestTurnedInQuestIds[1])
+            -- these quests won't fire QUEST_REMOVED event
+            local questId = table.remove(latestTurnedInQuestIds, 1)
             Questie:Debug(DEBUG_DEVELOP, "Completing automatic completion quest")
-            QuestieQuest:CompleteQuest(quest)
+            _EventHandler:CompleteQuest(questId)
         else
             Questie:Debug(DEBUG_DEVELOP, "latestTurnedInQuestIds is empty. Something is off?")
         end


### PR DESCRIPTION
"Instant" quests (I don't know correct term) won't fire QUEST_REMOVED and so they pollute latestTurnedInQuestIds[]. This breaks next quest turn ins / completions. Visible to users mostly so that quest markers won't disappear from the map / the minimap.

There was also missing a call to add these "instant" quest completions to Questie Journey. I choosed to go via ready helper function for hopefully easy future  code maintenance. Downside for this is use of timer in helper function until server returns the quest to be completed status.