### PR TITLE
[quest] Some fixes to Midsummer quests in TBCC 2021

### DIFF
--- a/Database/Corrections/TBC/tbcNPCFixes.lua
+++ b/Database/Corrections/TBC/tbcNPCFixes.lua
@@ -435,7 +435,7 @@ function QuestieTBCNpcFixes:Load()
             [npcKeys.spawns] = {[zoneIDs.ASHENVALE] = {{14.2,16.8},{14.4,18.2},{14.4,19.2},{14.4,19.8},{14.4,22.4},{15.0,18.2},{15.2,18.6},{15.4,17.4},{15.4,20.0},{15.4,20.8},{15.6,17.4},{15.6,20.2},{16.0,18.4},{16.0,19.2},{16.0,20.8},{16.6,19.2},{16.6,19.6},{16.8,18.4},{16.8,20.6},},},
         },
         [25888] = {
-            [npcKeys.spawns] = {[zoneIDs.AZUREMYST_ISLE] = {{44.5,52.4},},},
+            [npcKeys.spawns] = {[zoneIDs.AZUREMYST_ISLE] = {{44.5,52.5},},},
         },
         [25889] = {
             [npcKeys.spawns] = {[zoneIDs.BLADES_EDGE_MOUNTAINS] = {{41.4,65.9},},},

--- a/Database/Corrections/TBC/tbcNPCFixes.lua
+++ b/Database/Corrections/TBC/tbcNPCFixes.lua
@@ -441,7 +441,7 @@ function QuestieTBCNpcFixes:Load()
             [npcKeys.spawns] = {[zoneIDs.BLADES_EDGE_MOUNTAINS] = {{41.4,65.9},},},
         },
         [25891] = {
-            [npcKeys.spawns] = {[zoneIDs.BLOODMYST_ISLE] = {{55.6,68.1},},},
+            [npcKeys.spawns] = {[zoneIDs.BLOODMYST_ISLE] = {{55.8,67.9},},},
         },
         [25892] = {
             [npcKeys.spawns] = {[zoneIDs.BURNING_STEPPES] = {{80.3,62.9},},},

--- a/Database/Corrections/TBC/tbcNPCFixes.lua
+++ b/Database/Corrections/TBC/tbcNPCFixes.lua
@@ -444,7 +444,7 @@ function QuestieTBCNpcFixes:Load()
             [npcKeys.spawns] = {[zoneIDs.BLOODMYST_ISLE] = {{55.6,68.1},},},
         },
         [25892] = {
-            [npcKeys.spawns] = {[zoneIDs.BURNING_STEPPES] = {{80.5,62.7},},},
+            [npcKeys.spawns] = {[zoneIDs.BURNING_STEPPES] = {{80.3,62.9},},},
         },
         [25899] = {
             [npcKeys.spawns] = {[zoneIDs.FERALAS] = {{28.4,44.0},},},

--- a/Database/Corrections/TBC/tbcNPCFixes.lua
+++ b/Database/Corrections/TBC/tbcNPCFixes.lua
@@ -447,7 +447,7 @@ function QuestieTBCNpcFixes:Load()
             [npcKeys.spawns] = {[zoneIDs.BURNING_STEPPES] = {{80.3,62.9},},},
         },
         [25899] = {
-            [npcKeys.spawns] = {[zoneIDs.FERALAS] = {{28.4,44.0},},},
+            [npcKeys.spawns] = {[zoneIDs.FERALAS] = {{28.3,43.9},},},
         },
         [25903] = {
             [npcKeys.spawns] = {[zoneIDs.NAGRAND] = {{49.7,69.4},},},


### PR DESCRIPTION
@drejjmit Here are those fixes to alliance bonfire quests in Azeroth (not Outland) as I promised on Discord. Only some minor location changes to few of the Honor the Flame -quests. Desecrate this Fire! were okey.

I also checked quests for alliance in horde capitals.

XP and Gold gains are wrong, but I have no idea how to fix those. (Is it worth to create an issue?)