### PR TITLE
[bcc][quests] Midsummer Striking Back quest fixes

### DIFF
--- a/Database/Corrections/QuestieEvent.lua
+++ b/Database/Corrections/QuestieEvent.lua
@@ -650,6 +650,7 @@ tinsert(QuestieEvent.eventQuests, {"Midsummer", 11833}) -- Honor the Flame
 tinsert(QuestieEvent.eventQuests, {"Midsummer", 11933}) -- Stealing the Exodar's Flame
 tinsert(QuestieEvent.eventQuests, {"Midsummer", 11935}) -- Stealing Silvermoon's Flame
 tinsert(QuestieEvent.eventQuests, {"Midsummer", 11915}) -- Playing with Fire
+tinsert(QuestieEvent.eventQuests, {"Midsummer", 11954}) -- Striking Back (level 67)
 tinsert(QuestieEvent.eventQuests, {"Midsummer", 11971}) -- The Spinner of Summer Tales
 
 tinsert(QuestieEvent.eventQuests, {"Winter Veil", 11528}) -- A Winter Veil Gift

--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -427,6 +427,7 @@ function QuestieQuestBlacklist:Load()
         [11915] = true,
         [11933] = true,
         [11935] = true,
+        [11954] = true,
         [11955] = true,
         [11964] = true,
         [11966] = true,

--- a/Database/Corrections/TBC/tbcNPCFixes.lua
+++ b/Database/Corrections/TBC/tbcNPCFixes.lua
@@ -492,19 +492,19 @@ function QuestieTBCNpcFixes:Load()
             [npcKeys.spawns] = {[zoneIDs.TIRISFAL_GLADES] = {{57.2,51.8},},},
         },
         [26116] = {
-            [npcKeys.spawns] = {[zoneIDs.ASHENVALE] = {{10.1,12.8},},},
+            [npcKeys.spawns] = {[zoneIDs.ASHENVALE] = {{9.62,12.20},{9.25,11.50},{9.66,11.17},},},
         },
         [26178] = {
-            [npcKeys.spawns] = {[zoneIDs.DESOLACE] = {{40.2,28.9},},},
+            [npcKeys.spawns] = {[zoneIDs.DESOLACE] = {{40.35,30.27},{40.26,31.35},{39.28,30.35},},},
         },
         [26204] = {
-            [npcKeys.spawns] = {[zoneIDs.STRANGLETHORN_VALE] = {{20.75,22.81},},},
+            [npcKeys.spawns] = {[zoneIDs.STRANGLETHORN_VALE] = {{21.17,22.74},{21.30,23.36},{21.26,24.30},},},
         },
         [26214] = {
-            [npcKeys.spawns] = {[zoneIDs.BURNING_STEPPES] = {{15.0,35.1},},},
+            [npcKeys.spawns] = {[zoneIDs.SEARING_GORGE] = {{16.02,36.87},{14.66,34.22},{13.55,37.20},},},
         },
         [26215] = {
-            [npcKeys.spawns] = {[zoneIDs.SILITHUS] = {{64.5,15.2},},},
+            [npcKeys.spawns] = {[zoneIDs.SILITHUS] = {{66.60,20.62},{67.03,18.72},{67.45,20.14},},},
         },
         [26216] = {
             [npcKeys.spawns] = {[zoneIDs.HELLFIRE_PENINSULA] = {{84.2,47.0},{84.2,53.4},{85.4,47.0},{85.6,53.2},{85.8,47.2},{85.8,47.6},},},

--- a/Database/Corrections/TBC/tbcQuestFixes.lua
+++ b/Database/Corrections/TBC/tbcQuestFixes.lua
@@ -2482,7 +2482,7 @@ function QuestieTBCQuestFixes:Load()
             [questKeys.startedBy] = {{26221,},nil,nil,},
             [questKeys.finishedBy] = {{26221,},nil,},
             [questKeys.preQuestSingle] = {12012},
-            [questKeys.requiredLevel] = 65,
+            [questKeys.requiredLevel] = 64,
         },
         [11955] = {
             [questKeys.startedBy] = {{26221,},nil,nil,},

--- a/Database/Corrections/TBC/tbcQuestFixes.lua
+++ b/Database/Corrections/TBC/tbcQuestFixes.lua
@@ -2377,6 +2377,10 @@ function QuestieTBCQuestFixes:Load()
         [11915] = {
             [questKeys.startedBy] = {{25994,},nil,nil,},
         },
+        [11917] = {
+            [questKeys.finishedBy] = {{26221,},nil,},
+            [questKeys.preQuestSingle] = {12012},
+        },
         [11922] = {
             [questKeys.startedBy] = {{26113,},nil,nil,},
             [questKeys.finishedBy] = {{26113},nil,nil},
@@ -2457,6 +2461,28 @@ function QuestieTBCQuestFixes:Load()
         },
         [11935] = {
             [questKeys.startedBy] = {nil,{188129},{35568,},},
+        },
+        [11947] = {
+            [questKeys.finishedBy] = {{26221,},nil,},
+            [questKeys.preQuestSingle] = {12012},
+        },
+        [11948] = {
+            [questKeys.finishedBy] = {{26221,},nil,},
+            [questKeys.preQuestSingle] = {12012},
+        },
+        [11952] = {
+            [questKeys.finishedBy] = {{26221,},nil,},
+            [questKeys.preQuestSingle] = {12012},
+        },
+        [11953] = {
+            [questKeys.finishedBy] = {{26221,},nil,},
+            [questKeys.preQuestSingle] = {12012},
+        },
+        [11954] = {
+            [questKeys.startedBy] = {{26221,},nil,nil,},
+            [questKeys.finishedBy] = {{26221,},nil,},
+            [questKeys.preQuestSingle] = {12012},
+            [questKeys.requiredLevel] = 65,
         },
         [11955] = {
             [questKeys.startedBy] = {{26221,},nil,nil,},

--- a/Database/Corrections/TBC/tbcQuestFixes.lua
+++ b/Database/Corrections/TBC/tbcQuestFixes.lua
@@ -2380,6 +2380,7 @@ function QuestieTBCQuestFixes:Load()
         [11917] = {
             [questKeys.finishedBy] = {{26221,},nil,},
             [questKeys.preQuestSingle] = {12012},
+            [questKeys.specialFlags] = 0,
         },
         [11922] = {
             [questKeys.startedBy] = {{26113,},nil,nil,},
@@ -2465,24 +2466,29 @@ function QuestieTBCQuestFixes:Load()
         [11947] = {
             [questKeys.finishedBy] = {{26221,},nil,},
             [questKeys.preQuestSingle] = {12012},
+            [questKeys.specialFlags] = 0,
         },
         [11948] = {
             [questKeys.finishedBy] = {{26221,},nil,},
             [questKeys.preQuestSingle] = {12012},
+            [questKeys.specialFlags] = 0,
         },
         [11952] = {
             [questKeys.finishedBy] = {{26221,},nil,},
             [questKeys.preQuestSingle] = {12012},
+            [questKeys.specialFlags] = 0,
         },
         [11953] = {
             [questKeys.finishedBy] = {{26221,},nil,},
             [questKeys.preQuestSingle] = {12012},
+            [questKeys.specialFlags] = 0,
         },
         [11954] = {
             [questKeys.startedBy] = {{26221,},nil,nil,},
             [questKeys.finishedBy] = {{26221,},nil,},
             [questKeys.preQuestSingle] = {12012},
             [questKeys.requiredLevel] = 64,
+            [questKeys.specialFlags] = 0,
         },
         [11955] = {
             [questKeys.startedBy] = {{26221,},nil,nil,},


### PR DESCRIPTION
Adds ice stone locations to summon and kill quest objective mob.
Adds npcs for finishing quests (turn-in)
Adds required prequest.
Adds quest giver and minimum level for highest level version of the quest. Minimum level is 65 as a safe guess for now.