### PR TITLE
[quest] More fixes to midsummer quests in BCC

### DIFF
--- a/Database/Corrections/TBC/tbcQuestFixes.lua
+++ b/Database/Corrections/TBC/tbcQuestFixes.lua
@@ -2495,6 +2495,7 @@ function QuestieTBCQuestFixes:Load()
             [questKeys.startedBy] = {{26221,},nil,nil,},
             [questKeys.finishedBy] = {{25710,},nil,nil},
             [questKeys.preQuestSingle] = {12012},
+            [questKeys.requiredLevel] = 65,
         },
         [11964] = {
             [questKeys.startedBy] = {{16817,},nil,nil,},


### PR DESCRIPTION
Add level requirement 65 for quest "Ahune, the Frost Lord" 11955.  Currently it is showing available to lowbies.