### PR TITLE
for PR #3127: loop less in quest objects. more objective tries

### DIFF
--- a/Modules/Libs/QuestieHash.lua
+++ b/Modules/Libs/QuestieHash.lua
@@ -5,6 +5,8 @@ local QuestieHash = QuestieLoader:CreateModule("QuestieHash")
 local QuestieLib = QuestieLoader:ImportModule("QuestieLib")
 ---@type QuestieDB
 local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
+---@type QuestieQuest
+local QuestieQuest = QuestieLoader:ImportModule("QuestieQuest")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
 ---@type QuestieSerializer
@@ -52,11 +54,13 @@ end
 function QuestieHash:AddNewQuestHash(questId)
     Questie:Debug(DEBUG_DEVELOP, "AddNewQuestHash:", questId)
     questLogHashes[questId] = QuestieHash:GetQuestHash(questId)
+    QuestieQuest:SetObjectivesDirty(questId)
 end
 
 function QuestieHash:RemoveQuestHash(questId)
     Questie:Debug(DEBUG_DEVELOP, "RemoveQuestHash:", questId)
     questLogHashes[questId] = nil
+    QuestieQuest:SetObjectivesDirty(questId)
 end
 
 ---@param questIdList table<number, number> A list of questIds whose hash should to be checked
@@ -78,6 +82,7 @@ function QuestieHash:CompareHashesOfQuestIdList(questIdList)
                     Questie:Debug(DEBUG_DEVELOP, "Hash changed for questId:", questId)
                     questLogHashes[questId] = newHash
                     table.insert(updatedQuestIds, questId)
+                    QuestieQuest:SetObjectivesDirty(questId)
                 end
             end
         end
@@ -104,6 +109,7 @@ function QuestieHash:CompareQuestHash(questId)
                 Questie:Debug(DEBUG_DEVELOP, "Hash changed for questId:", questId)
                 questLogHashes[questId] = newHash
                 hashChanged = true
+                QuestieQuest:SetObjectivesDirty(questId)
             end
         end
     end

--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -161,7 +161,7 @@ function QuestieLib:GetQuestObjectives(questId)
         count = count + 1
         if good then break end
     end
-    Questie:Debug(DEBUG_SPAM, "[QuestieLib:GetQuestObjectives]: Loaded objective(s) for quest:", questId)
+    --Questie:Debug(DEBUG_SPAM, "[QuestieLib:GetQuestObjectives]: Loaded objective(s) for quest:", questId)
     return objectiveList
 end
 

--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -107,7 +107,7 @@ function QuestieLib:IsResponseCorrect(questId)
     local count = 0
     local objectiveList
     local good = true
-    while (true and count < 1) do
+    while (count < 1) do
         good = true
         objectiveList = C_QuestLog.GetQuestObjectives(questId)
         if (not objectiveList) then
@@ -135,12 +135,12 @@ function QuestieLib:IsResponseCorrect(questId)
     return good
 end
 
----@param questId QuestId @The quest ID
+---@param questId number @The quest ID
 ---@return table
 function QuestieLib:GetQuestObjectives(questId)
     local count = 0
     local objectiveList
-    while (true and count < 1) do
+    while (count < 1) do
         local good = true
         objectiveList = C_QuestLog.GetQuestObjectives(questId)
         if not objectiveList then

--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -101,12 +101,13 @@ function QuestieLib:GetRGBForObjective(objective)
     end
 end
 
----@param questId QuestId @The quest ID
+---@param questId number @The quest ID
+---@return boolean
 function QuestieLib:IsResponseCorrect(questId)
     local count = 0
     local objectiveList
     local good = true
-    while (true and count < 50) do
+    while (true and count < 1) do
         good = true
         objectiveList = C_QuestLog.GetQuestObjectives(questId)
         if (not objectiveList) then
@@ -139,7 +140,7 @@ end
 function QuestieLib:GetQuestObjectives(questId)
     local count = 0
     local objectiveList
-    while (true and count < 50) do
+    while (true and count < 1) do
         local good = true
         objectiveList = C_QuestLog.GetQuestObjectives(questId)
         if not objectiveList then

--- a/Modules/Quest/QuestEventHandler.lua
+++ b/Modules/Quest/QuestEventHandler.lua
@@ -24,8 +24,8 @@ local QUEST_LOG_STATES = {
     QUEST_REMOVED = "QUEST_REMOVED",
     QUEST_ABANDONED = "QUEST_ABANDONED"
 }
-local MAX_INIT_QUEST_LOG_TRIES = 3
-local MAX_OBJECTIVE_TEXT_TRIES = 3
+local MAX_INIT_QUEST_LOG_TRIES = 10
+local MAX_OBJECTIVE_TEXT_TRIES = 5
 
 local eventFrame = CreateFrame("Frame", "QuestieQuestEventFrame")
 local questLog = {}


### PR DESCRIPTION
As little changes as possible. A bit speed up before beta testing. Looks almost bugless while playing. Clicking quest log entries to enable / disalbe questie tracker tracking bugs a bit by affecting wrong quest sometimes.

I have not yet reviewed QuestEventHandler.lua latest version for bug & stuff.