### PR TITLE
[fix] Don't taint global variable _

### DIFF
--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -1060,7 +1060,9 @@ function QuestieQuest:PopulateQuestLogInfo(quest)
     end
     local logID = GetQuestLogIndexByID(quest.Id);
     if logID ~= 0 then
-        _, _, _, _, _, quest.isComplete, _, _, _, _, _, _, _, _, _, quest.isHidden = GetQuestLogTitle(logID)
+        local _, _, _, _, _, isComplete, _, _, _, _, _, _, _, _, _, isHidden = GetQuestLogTitle(logID)
+        quest.isComplete = isComplete
+        quest.isHidden = isHidden
         if quest.isComplete ~= nil and quest.isComplete == 1 then
             quest.isComplete = true
         end

--- a/Modules/QuestiePlayer.lua
+++ b/Modules/QuestiePlayer.lua
@@ -115,7 +115,8 @@ function QuestiePlayer:GetPartyMembers()
         for _, v in pairs(partyMembers) do
             local member = {}
             member.Name = v;
-            member.Class, _, _ = UnitClass(v);
+            local class, _, _ = UnitClass(v)
+            member.Class = class
             member.Level = UnitLevel(v);
             table.insert(party, member);
         end

--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -326,9 +326,9 @@ function _QuestieTracker:CreateBaseFrame()
             print(l10n("Error: Questie tracker in invalid location, resetting..."))
 
             if QuestWatchFrame then
-                local result, _ = pcall(frm.SetPoint, frm, unpack({QuestWatchFrame:GetPoint()}))
+                local result2, _ = pcall(frm.SetPoint, frm, unpack({QuestWatchFrame:GetPoint()}))
                 Questie.db[Questie.db.global.questieTLoc].trackerSetpoint = "AUTO"
-                if (not result) then
+                if (not result2) then
                     Questie.db[Questie.db.global.questieTLoc].TrackerLocation = nil
                     _QuestieTracker:SetSafePoint(frm)
                 end

--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -326,7 +326,7 @@ function _QuestieTracker:CreateBaseFrame()
             print(l10n("Error: Questie tracker in invalid location, resetting..."))
 
             if QuestWatchFrame then
-                result, _ = pcall(frm.SetPoint, frm, unpack({QuestWatchFrame:GetPoint()}))
+                local result, _ = pcall(frm.SetPoint, frm, unpack({QuestWatchFrame:GetPoint()}))
                 Questie.db[Questie.db.global.questieTLoc].trackerSetpoint = "AUTO"
                 if (not result) then
                     Questie.db[Questie.db.global.questieTLoc].TrackerLocation = nil


### PR DESCRIPTION
Don't try to assign stuff into global `_`. Wow doesn't like it:
`Global variable _ tainted by Questie - Interface\AddOns\Questie\Modules\Quest\QuestieQuest.lua:1056 PopulateQuestLogInfo()`

This was somewhat mind blown to me.

I used `^\s*((?!(local)|(for)|(function)\s).)*?[,\s]+_[,=\s]+` for search.

**The PR is not tested in game. Only done changes in editor.**
