### PR TITLE
[fix] Remove addon version check. Add addon name check. Enable retail game check

### DIFF
--- a/Modules/VersionCheck.lua
+++ b/Modules/VersionCheck.lua
@@ -1,11 +1,13 @@
+local addonName, _ = ...
+
 if GetBuildInfo() <= '1.13' then
-    StaticPopupDialogs["VERSION_ERROR"] = {
+    StaticPopupDialogs["QUESTIE_VERSION_ERROR"] = {
         text = "|cffff0000ERROR|r\nYou're trying to use Questie on vanilla WoW!\nQuestie is supporting WoW Classic only!\n\nYou should come and join the real WoW",
         button2 = "Okay, maybe I will",
         hasEditBox = false,
         whileDead = true
     }
-    StaticPopup_Show("VERSION_ERROR")
+    StaticPopup_Show("QUESTIE_VERSION_ERROR")
 
     DEFAULT_CHAT_FRAME:AddMessage("---------------------------------")
     DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5adYou're trying to use Questie on vanilla WoW!|r")
@@ -13,8 +15,8 @@ if GetBuildInfo() <= '1.13' then
     return
 end
 
-if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE and false then
-    StaticPopupDialogs["RETAIL_ERROR"] = {
+if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
+    StaticPopupDialogs["QUESTIE_RETAIL_ERROR"] = {
         text = "|cffff0000ERROR|r\nYou're trying to use Questie on retail WoW!\nQuestie is supporting WoW Classic only!\n\nYou should come and join the real WoW",
         button2 = "Okay, maybe I will",
         hasEditBox = false,
@@ -28,18 +30,30 @@ if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE and false then
         DEFAULT_CHAT_FRAME:AddMessage("---------------------------------")
         error("ERROR: You're trying to use Questie on retail WoW. Questie is supporting WoW Classic only!")
     end)
-    StaticPopup_Show("RETAIL_ERROR")
+    StaticPopup_Show("QUESTIE_RETAIL_ERROR")
     return
 end
 
-if GetAddOnMetadata("Questie", "Version") ~= "6.5.1" then
-    StaticPopupDialogs["QUESTIE_NOT_RESTARTED"] = {
-        text = "You just updated Questie but forgot to restart the WoW client. Questie will not work properly if you don't restart!",
-        button2 = "Okay, I will restart",
+-- Check addon is not renamed to avoid conflicts in global name space.
+if addonName ~= "Questie" then
+    local msg = { "You have renamed Questie addon.", "This is restricted to avoid issues.", "Please remove '"..addonName.."'", "and reinstall the original version."}
+    StaticPopupDialogs["QUESTIE_ADDON_NAME_ERROR"] = {
+        text = "|cffff0000ERROR|r\n"..msg[1].."\n"..msg[2].."\n\n"..msg[3].."\n"..msg[4],
+        button2 = "OK",
         hasEditBox = false,
-        whileDead = true
+        whileDead = true,
     }
-    StaticPopup_Show("QUESTIE_NOT_RESTARTED")
+
+    C_Timer.After(4, function()
+        DEFAULT_CHAT_FRAME:AddMessage("---------------------------------")
+        DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[1].."|r")
+        DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[2].."|r")
+        DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[3].."|r")
+        DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[4].."|r")
+        DEFAULT_CHAT_FRAME:AddMessage("---------------------------------")
+        error("ERROR: "..msg[1].." "..msg[2].." "..msg[3])
+    end)
+    StaticPopup_Show("QUESTIE_ADDON_NAME_ERROR")
     return
 end
 
@@ -59,6 +73,7 @@ end
 --Initialized below
 ---@class Questie
 Questie = LibStub("AceAddon-3.0"):NewAddon("Questie", "AceConsole-3.0", "AceEvent-3.0", "AceTimer-3.0", "AceComm-3.0", "AceSerializer-3.0", "AceBucket-3.0")
+local Questie = Questie
 
 -- preinit placeholder to stop tukui crashing from literally force-removing one of our features no matter what users select in the config ui
 Questie.db = {profile={minimap={hide=false}}}

--- a/cli.lua
+++ b/cli.lua
@@ -63,12 +63,20 @@ C_Timer = {
     end
 }
 
+-- WoW addon namespace
+local addonName = "Questie"
+local addonTable = {}
+
 local function loadTOC(file)
     local rfile = io.open(file, "r")
     for line in rfile:lines() do
         if string.len(line) > 1 and string.byte(line, 1) ~= 35 then
             line = line:gsub("\\", "/")
-            local r, _ = pcall(dofile, line)
+            local r = nil
+            local chunck = loadfile(line)
+            if chunck then
+                r = pcall(chunck, addonName, addonTable)
+            end
             if r then
                 --print("Loaded " .. line)
             else

--- a/cli.lua
+++ b/cli.lua
@@ -1,3 +1,7 @@
+WOW_PROJECT_ID = 5
+WOW_PROJECT_CLASSIC = 2
+WOW_PROJECT_BURNING_CRUSADE_CLASSIC = 5
+WOW_PROJECT_MAINLINE = 1
 
 tremove = table.remove
 tinsert = table.insert


### PR DESCRIPTION
Review of VersionCheck.lua
 -  Remove addon version check as it didn't do its job and should be soon unnecessary once WoW supports full addon reloading at `/reload`. Hopefully CurseForge gets their shit together too and release addon manager supporting multiple tocs okey.
 - Added extra check that Questie really is run from `Questie` folder and with that name. So users won't try to run multiple at once. Even double Questie global is already checked.
 - Enable retail game check which was most likely unintentionally left disabled by old development testing while getting retail/tbc zoneIDs.