### PR TITLE
[fix] Don't open Quest Log in combat from tracker.

### DIFF
--- a/Modules/Tracker/QuestieTrackerUtils.lua
+++ b/Modules/Tracker/QuestieTrackerUtils.lua
@@ -17,7 +17,7 @@ local tinsert = table.insert
 function QuestieTracker.utils:ShowQuestLog(quest)
     -- Priority order first check if addon exist otherwise default to original
     local questFrame = QuestLogExFrame or ClassicQuestLog or QuestLogFrame;
-    HideUIPanel(questFrame);
+    --HideUIPanel(questFrame); -- don't use as I don't see why to use and protected function taints in combat
     local questLogIndex = GetQuestLogIndexByID(quest.Id);
     SelectQuestLogEntry(questLogIndex)
 
@@ -25,11 +25,17 @@ function QuestieTracker.utils:ShowQuestLog(quest)
     local scrollSteps = QuestLogListScrollFrame.ScrollBar:GetValueStep()
     QuestLogListScrollFrame.ScrollBar:SetValue(questLogIndex * scrollSteps - scrollSteps * 3);
 
-    ShowUIPanel(questFrame);
+    if not questFrame:IsShown() then
+        if not InCombatLockdown() then
+            ShowUIPanel(questFrame)
 
-    --Addon specific behaviors
-    if(QuestLogEx) then
-        QuestLogEx:Maximize();
+            --Addon specific behaviors
+            if(QuestLogEx) then
+                QuestLogEx:Maximize();
+            end
+        else
+            Questie:Print("Can't open Quest Log while in combat. Open it manually.")
+        end
     end
 
     QuestLog_UpdateQuestDetails()


### PR DESCRIPTION
ShowUIPanel(  ) is protected, so it can't be used while in combat.
Calling QuestLogFrame:Show() directly would mess up UI.
Select the quest in questlog anyway and try scroll to it.
Scrolling has old bug if the quest is inside collapsed, but I didn't find good way to fix it now.
If we couldn't open quest log, tell user open it themself.

Fixes #2854

Changes aren't tested  with other quest log addons mentioned in code