### PR TITLE
Refactor DailyQuest.lua

### DIFF
--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -507,7 +507,7 @@ function QuestieDB:IsDoable(questId)
         return false
     end
 
-    if (not DailyQuests:IsActiveDailyQuest(questId)) then
+    if (DailyQuests.IsHiddenDailyQuest(questId)) then
         Questie:Debug(Questie.DEBUG_SPAM, "[QuestieDB:IsDoable] quest is a daily quest not active today!")
         return false
     end

--- a/Modules/FramePool/QuestieFrame.lua
+++ b/Modules/FramePool/QuestieFrame.lua
@@ -417,7 +417,7 @@ function _Qframe:ShouldBeHidden()
         -- Hide only available quest icons of following quests. I.e. show objectives and complete icons always (when they are in questlog).
         -- i.e. (iconType == "available")  ==  (iconType ~= "monster" and iconType ~= "object" and iconType ~= "event" and iconType ~= "item" and iconType ~= "complete"):
         or (iconType == "available"
-            and ((not DailyQuests:IsActiveDailyQuest(questId)) -- hide not-today-dailies
+            and ((DailyQuests.IsHiddenDailyQuest(questId)) -- hide not-today-dailies
                 or ((not questieCharDB.showRepeatableQuests) and QuestieDB:IsRepeatable(questId))
                 or ((not questieCharDB.showEventQuests) and QuestieDB:IsActiveEventQuest(questId))
                 or ((not questieCharDB.showDungeonQuests) and QuestieDB:IsDungeonQuest(questId))

--- a/Modules/Network/QuestieComms.lua
+++ b/Modules/Network/QuestieComms.lua
@@ -158,7 +158,9 @@ function QuestieComms:Initialize()
     -- Lets us send any length of message. Also implements ChatThrottleLib to not get disconnected.
     Questie:RegisterComm(_QuestieComms.prefix, _QuestieComms.OnCommReceived);
 
-    Questie:RegisterComm("REPUTABLE", DailyQuests.FilterDailies);
+    if Questie.IsTBC then
+        Questie:RegisterComm("REPUTABLE", DailyQuests.FilterDailies)
+    end
 
     -- Events to be used to broadcast updates to other people
     Questie:RegisterMessage("QC_ID_BROADCAST_QUEST_UPDATE", _QuestieComms.BroadcastQuestUpdate);

--- a/Modules/Quest/DailyQuests.lua
+++ b/Modules/Quest/DailyQuests.lua
@@ -1,43 +1,39 @@
 ---@class DailyQuests
-local DailyQuests = QuestieLoader:CreateModule("DailyQuests");
+local DailyQuests = QuestieLoader:CreateModule("DailyQuests")
 local Questie = _G.Questie
 
 local IsQuestFlaggedCompleted = IsQuestFlaggedCompleted or C_QuestLog.IsQuestFlaggedCompleted
 
 ---@type QuestieMap
-local QuestieMap = QuestieLoader:ImportModule("QuestieMap");
+local QuestieMap = QuestieLoader:ImportModule("QuestieMap")
 ---@type QuestieQuest
-local QuestieQuest = QuestieLoader:ImportModule("QuestieQuest");
+local QuestieQuest = QuestieLoader:ImportModule("QuestieQuest")
 ---@type QuestieTooltips
-local QuestieTooltips = QuestieLoader:ImportModule("QuestieTooltips");
+local QuestieTooltips = QuestieLoader:ImportModule("QuestieTooltips")
 ---@type QuestiePlayer
-local QuestiePlayer = QuestieLoader:ImportModule("QuestiePlayer");
----@type QuestieDB
-local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
+local QuestiePlayer = QuestieLoader:ImportModule("QuestiePlayer")
 
 -- Forward declarations
 local nhcDailyIds, hcDailyIds, cookingDailyIds, fishingDailyIds, pvpDailyIds, everydayDailyIds
 
 
-local nextCheck = -1
+local nextCheck = -1 -- -1 is always smaller than GetTime()
 local dailyResetTimer
 
 
 ---@param questId number
 ---@return nil
 local function _HideDailyQuest(questId)
-    Questie:Debug(Questie.DEBUG_DEVELOP, "[DailyQuests]: _HideDailyQuest", questId) -- TEMPORARY
-    QuestieMap:UnloadQuestFrames(questId);
-    QuestieTooltips:RemoveQuest(questId);
+    QuestieMap:UnloadQuestFrames(questId)
+    QuestieTooltips:RemoveQuest(questId)
 end
 
 
 ---@param questId number
 ---@return nil
 local function _ShowDailyQuest(questId)
-    Questie:Debug(Questie.DEBUG_DEVELOP, "[DailyQuests]: _ShowDailyQuest", questId, "no frames, isDoable:", (not QuestieMap.questIdFrames[questId]), QuestieDB:IsDoable(questId)) -- TEMPORARY
     if (not QuestieMap.questIdFrames[questId]) then
-        QuestieQuest:DrawDailyQuest(questId);
+        QuestieQuest:DrawDailyQuest(questId)
     end
 end
 
@@ -48,7 +44,7 @@ end
 --- Start Timer to reset again
 ---@return nil
 local function _ResetEverydayDailyQuests()
-    Questie:Debug(Questie.DEBUG_INFO, "[DailyQuests]: ResetEverydayDailyQuests() - This okey to get run also at non-reset times")
+    Questie:Debug(Questie.DEBUG_INFO, "[DailyQuests]: ResetEverydayDailyQuests() - Okey to get run also at non-reset times")
 
     local dbCharCompletedQuests = Questie.db.char.complete
 
@@ -120,13 +116,11 @@ end
 ---@param possibleQuestIds table<number, boolean>
 ---@param currentQuestId number @today's daily quest
 ---@param type string
----@return boolean @true = reset required and done
+---@return nil
 local function _ResetHiddenIfRequired(possibleQuestIds, currentQuestId, type)
     if currentQuestId > 0 and (Questie.db.char.hiddenDailies[type][currentQuestId] or (not next(Questie.db.char.hiddenDailies[type]))) and (not IsQuestFlaggedCompleted(currentQuestId)) then
         Questie.db.char.hiddenDailies[type] = _ResetHiddenDailyQuests(possibleQuestIds, currentQuestId)
-        return true
     end
-    return false
 end
 
 
@@ -177,15 +171,11 @@ function DailyQuests:FilterDailies(message, _, _)
 
         local nhcQuestId, hcQuestId, cookingQuestId, fishingQuestId, pvpQuestId = _GetTodaysDailyIdsFromMessage(message);
 
-        local somethingReset = false
-        somethingReset = _ResetHiddenIfRequired(nhcDailyIds, nhcQuestId, "nhc") or somethingReset
-        somethingReset = _ResetHiddenIfRequired(hcDailyIds, hcQuestId, "hc") or somethingReset
-        somethingReset = _ResetHiddenIfRequired(cookingDailyIds, cookingQuestId, "cooking") or somethingReset
-        somethingReset = _ResetHiddenIfRequired(fishingDailyIds, fishingQuestId, "fishing") or somethingReset
-        somethingReset = _ResetHiddenIfRequired(pvpDailyIds, pvpQuestId, "pvp") or somethingReset
-
-        --TODO remove this debug
-        print("'"..message.."'", nhcQuestId, hcQuestId, cookingQuestId, fishingQuestId, pvpQuestId, somethingReset)
+        _ResetHiddenIfRequired(nhcDailyIds, nhcQuestId, "nhc")
+        _ResetHiddenIfRequired(hcDailyIds, hcQuestId, "hc")
+        _ResetHiddenIfRequired(cookingDailyIds, cookingQuestId, "cooking")
+        _ResetHiddenIfRequired(fishingDailyIds, fishingQuestId, "fishing")
+        _ResetHiddenIfRequired(pvpDailyIds, pvpQuestId, "pvp")
     end
 end
 

--- a/Modules/Quest/DailyQuests.lua
+++ b/Modules/Quest/DailyQuests.lua
@@ -1,6 +1,6 @@
 ---@class DailyQuests
 local DailyQuests = QuestieLoader:CreateModule("DailyQuests");
-local _DailyQuests = {}
+local Questie = _G.Questie
 
 local IsQuestFlaggedCompleted = IsQuestFlaggedCompleted or C_QuestLog.IsQuestFlaggedCompleted
 
@@ -13,44 +13,116 @@ local QuestieTooltips = QuestieLoader:ImportModule("QuestieTooltips");
 ---@type QuestiePlayer
 local QuestiePlayer = QuestieLoader:ImportModule("QuestiePlayer");
 
-local nhcDailyIds, hcDailyIds, cookingDailyIds, fishingDailyIds, pvpDailyIds
+-- Forward declarations
+local nhcDailyIds, hcDailyIds, cookingDailyIds, fishingDailyIds, pvpDailyIds, everydayDailyIds
 
-local lastCheck
 
----@param message string
+local nextCheck = -1
+local dailyResetTimer
+
+
+---@param questId number
 ---@return nil
-function DailyQuests:FilterDailies(message, _, _)
-    if message and Questie.db.char.showRepeatableQuests and QuestiePlayer:GetPlayerLevel() == 70 then
-        -- If the REPUTABLE message is empty, i.e contains "::::::::::" we don't count it as a check.
-        if (not lastCheck) and not string.find(message, "::::::::::") then
-            lastCheck = GetTime();
-        elseif lastCheck and GetTime() - lastCheck < 10 and not string.find(message, "::::::::::") then
-            lastCheck = GetTime();
-            return;
-        end
+local function _HideDailyQuest(questId)
+    QuestieMap:UnloadQuestFrames(questId);
+    QuestieTooltips:RemoveQuest(questId);
+end
 
-        local nhcQuestId, hcQuestId, cookingQuestId, fishingQuestId, pvpQuestId = _DailyQuests:GetDailyIds(message);
 
-        local somethingChanged = _DailyQuests:ResetIfRequired(nhcQuestId, hcQuestId, cookingQuestId, fishingQuestId, pvpQuestId);
-        if (not somethingChanged) then
-            -- We are already showing the correct quests
-            return;
-        end
-
-        _DailyQuests:HandleDailyQuests(nhcDailyIds, nhcQuestId, "nhc");
-        _DailyQuests:HandleDailyQuests(hcDailyIds, hcQuestId, "hc");
-        _DailyQuests:HandleDailyQuests(cookingDailyIds, cookingQuestId, "cooking");
-        _DailyQuests:HandleDailyQuests(fishingDailyIds, fishingQuestId, "fishing");
-        _DailyQuests:HandleDailyQuests(pvpDailyIds, pvpQuestId, "pvp");
+---@param questId number
+---@return nil
+local function _ShowDailyQuest(questId)
+    if (not QuestieMap.questIdFrames[questId]) then
+        QuestieQuest:DrawDailyQuest(questId);
     end
 end
 
--- /run DailyQuests:FilterDailies("0:0:11364:0:11354:0:11377:0:11667:0:11340:0")
--- /run Questie.db.char.hiddenDailies = {nhc={},hc={},cooking={},fishing={},pvp={}}
+
+--- Reset which quests are completed
+--- And Show quests as necessary
+--- Start Timer to reset again
+---@return nil
+local function _ResetEverydayDailyQuests()
+    local dbCharCompletedQuests = Questie.db.char.complete
+
+    for questId, _ in pairs(everydayDailyIds) do
+        if not IsQuestFlaggedCompleted(questId) then
+            -- Mark the quest uncompleted so it can be available again
+            dbCharCompletedQuests[questId] = nil
+            _ShowDailyQuest(questId)
+        end
+    end
+
+    if dailyResetTimer then
+        DailyQuests.StopDailyResetTimer()
+    else
+        dailyResetTimer = C_Timer.NewTimer(C_DateAndTime.GetSecondsUntilDailyReset() + 10, _ResetEverydayDailyQuests)
+    end
+end
+
+
+--- Generate list of hidden dailies of type for today from possibleQuestIds
+--- And update if quest is completed or not
+--- And Show/Hide quest as necessary
+---@param possibleQuestIds table<number, boolean>
+---@param currentQuestId number @today's daily quest
+---@return table<number, boolean> @list of hidden dailies of type
+local function _ResetHiddenDailyQuests(possibleQuestIds, currentQuestId)
+    assert(currentQuestId and (currentQuestId > 0), "ResetHiddenDailyQuests(): Invalid currentQuestId")
+
+    local hiddenDailies = {}
+    local dbCharCompletedQuests = Questie.db.char.complete
+
+    local someIsCompleted = false
+    for questId, _ in pairs(possibleQuestIds) do
+        if IsQuestFlaggedCompleted(currentQuestId) then
+            someIsCompleted = true
+        else
+            -- Mark the quest uncompleted so it can be available again
+            dbCharCompletedQuests[questId] = nil
+        end
+    end
+
+    if someIsCompleted then
+        -- Hide all dailies of this daily type as we have already completed one today
+        for questId, _ in pairs(possibleQuestIds) do
+            -- No need to call HideDailyQuest() as one quest is completed already, so none can be visible
+            hiddenDailies[questId] = true
+        end
+    else
+        -- Hide quests dailies of this type which aren't available today
+        for questId, _ in pairs(possibleQuestIds) do
+            if questId == currentQuestId then
+                _ShowDailyQuest(questId)
+                hiddenDailies[questId] = nil
+            else
+                -- If the quest is not in the questlog remove all frames
+                if (GetQuestLogIndexByID(questId) == 0) then
+                    _HideDailyQuest(questId)
+                end
+                hiddenDailies[questId] = true
+            end
+        end
+    end
+
+    return hiddenDailies
+end
+
+
+---@param possibleQuestIds table<number, boolean>
+---@param currentQuestId number @today's daily quest
+---@param type string
+---@return nil
+local function _ResetHiddenIfRequired(possibleQuestIds, currentQuestId, type)
+    if currentQuestId > 0 and (Questie.db.char.hiddenDailies[type][currentQuestId] or (not next(Questie.db.char.hiddenDailies[type]))) and (not IsQuestFlaggedCompleted(currentQuestId)) then
+        Questie.db.char.hiddenDailies[type] = _ResetHiddenDailyQuests(possibleQuestIds, currentQuestId)
+    end
+end
+
 
 ---@param message string
 ---@return number, number, number, number, number
-function _DailyQuests:GetDailyIds(message)
+local function _GetTodaysDailyIdsFromMessage(message)
     -- Each questId is followed by the timestamp from GetQuestResetTime(). We don't use that timestamp (yet)
     local _, _, nhcQuestId, _, hcQuestId, _, cookingQuestId, _, fishingQuestId, _, pvpQuestId, _ = strsplit(":", message);
 
@@ -61,96 +133,71 @@ function _DailyQuests:GetDailyIds(message)
         tonumber(pvpQuestId) or 0;
 end
 
----@param nhcQuestId number
----@param hcQuestId number
----@param cookingQuestId number
----@param fishingQuestId number
----@param pvpQuestId number
----@return boolean
-function _DailyQuests:ResetIfRequired(nhcQuestId, hcQuestId, cookingQuestId, fishingQuestId, pvpQuestId)
-    local somethingChanged = false
-    if nhcQuestId > 0 and (Questie.db.char.hiddenDailies.nhc[nhcQuestId] or (not next(Questie.db.char.hiddenDailies.nhc))) and (not IsQuestFlaggedCompleted(nhcQuestId)) then
-        Questie.db.char.hiddenDailies.nhc = {};
-        somethingChanged = true;
-    end
-    if hcQuestId > 0 and (Questie.db.char.hiddenDailies.hc[hcQuestId] or (not next(Questie.db.char.hiddenDailies.hc))) and (not IsQuestFlaggedCompleted(hcQuestId)) then
-        Questie.db.char.hiddenDailies.hc = {};
-        somethingChanged = true;
-    end
-    if cookingQuestId > 0 and (Questie.db.char.hiddenDailies.cooking[cookingQuestId] or (not next(Questie.db.char.hiddenDailies.cooking))) and (not IsQuestFlaggedCompleted(cookingQuestId)) then
-        Questie.db.char.hiddenDailies.cooking = {};
-        somethingChanged = true;
-    end
-    if fishingQuestId > 0 and (Questie.db.char.hiddenDailies.fishing[fishingQuestId] or (not next(Questie.db.char.hiddenDailies.fishing))) and (not IsQuestFlaggedCompleted(fishingQuestId)) then
-        Questie.db.char.hiddenDailies.fishing = {};
-        somethingChanged = true;
-    end
-    if pvpQuestId > 0 and (Questie.db.char.hiddenDailies.pvp[pvpQuestId] or (not next(Questie.db.char.hiddenDailies.pvp))) and (not IsQuestFlaggedCompleted(pvpQuestId)) then
-        Questie.db.char.hiddenDailies.pvp = {};
-        somethingChanged = true;
-    end
 
-    return somethingChanged;
+---@return nil
+function DailyQuests.StartDailyResetTimer()
+    if Questie.IsTBC then
+        _ResetEverydayDailyQuests()
+    end
 end
 
----@param possibleQuestIds table<number, number>
----@param currentQuestId number
----@param type string
----@return nil
-function _DailyQuests:HandleDailyQuests(possibleQuestIds, currentQuestId, type)
-    if currentQuestId == 0 then
-        return;
-    end
 
-    for questId, _ in pairs(possibleQuestIds) do
-        if questId == currentQuestId then
-            _DailyQuests:ShowDailyQuest(questId);
-            Questie.db.char.hiddenDailies[type][questId] = nil;
-        else
-            -- If the quest is not in the questlog remove all frames
-            if (GetQuestLogIndexByID(questId) == 0) then
-                _DailyQuests:HideDailyQuest(questId);
-            end
-            Questie.db.char.hiddenDailies[type][questId] = true;
+---@return nil
+function DailyQuests.StopDailyResetTimer()
+    if dailyResetTimer then
+        dailyResetTimer:Cancel()
+        dailyResetTimer = nil
+    end
+end
+
+
+---@param message string
+---@return nil
+function DailyQuests.FilterDailies(_, message, _, _)
+    if message and Questie.db.char.showRepeatableQuests and QuestiePlayer:GetPlayerLevel() == 70 then
+        -- If the REPUTABLE message is empty, i.e contains "::::::::::" we don't count it as a check.
+        if GetTime() < nextCheck or string.find(message, "::::::::::") then
+            return
         end
+        nextCheck = GetTime() + 10 -- seconds
+
+        local nhcQuestId, hcQuestId, cookingQuestId, fishingQuestId, pvpQuestId = _GetTodaysDailyIdsFromMessage(message);
+
+        _ResetHiddenIfRequired(nhcDailyIds, nhcQuestId, "nhc")
+        _ResetHiddenIfRequired(hcDailyIds, hcQuestId, "nhc")
+        _ResetHiddenIfRequired(cookingDailyIds, cookingQuestId, "nhc")
+        _ResetHiddenIfRequired(fishingDailyIds, fishingQuestId, "nhc")
+        _ResetHiddenIfRequired(pvpDailyIds, pvpQuestId, "nhc")
     end
 end
 
----@param questId number
----@return nil
-function _DailyQuests:HideDailyQuest(questId)
-    QuestieMap:UnloadQuestFrames(questId);
-    QuestieTooltips:RemoveQuest(questId);
-end
+-- /run DailyQuests:FilterDailies("0:0:11364:0:11354:0:11377:0:11667:0:11340:0")
+-- /run Questie.db.char.hiddenDailies = {nhc={},hc={},cooking={},fishing={},pvp={}}
 
----@param questId number
----@return nil
-function _DailyQuests:ShowDailyQuest(questId)
-    if (not QuestieMap.questIdFrames[questId]) then
-        QuestieQuest:DrawDailyQuest(questId);
-    end
-end
 
 ---@param questId number
 ---@return boolean
-function DailyQuests:IsActiveDailyQuest(questId)
+function DailyQuests.IsHiddenDailyQuest(questId)
     local hiddenQuests = Questie.db.char.hiddenDailies
-    return not (hiddenQuests.nhc[questId] or
+    return hiddenQuests.nhc[questId] or
         hiddenQuests.hc[questId] or
         hiddenQuests.cooking[questId] or
         hiddenQuests.fishing[questId] or
-        hiddenQuests.pvp[questId]);
+        hiddenQuests.pvp[questId]
 end
+
 
 ---@param questId number
 ---@return boolean
-function DailyQuests:IsDailyQuest(questId)
+function DailyQuests.IsDailyQuest(questId)
     return nhcDailyIds[questId] ~= nil or
             hcDailyIds[questId] ~= nil or
             cookingDailyIds[questId] ~= nil or
             fishingDailyIds[questId] ~= nil or
-            pvpDailyIds[questId] ~= nil;
+            pvpDailyIds[questId] ~= nil or
+            everydayDailyIds[questId] ~= nil
 end
+
 
 nhcDailyIds = {
     [11364] = true,
@@ -161,7 +208,7 @@ nhcDailyIds = {
     [11387] = true,
     [11389] = true,
     [11500] = true,
-};
+}
 
 hcDailyIds = {
     [11354] = true,
@@ -179,22 +226,23 @@ hcDailyIds = {
     [11384] = true,
     [11386] = true,
     [11388] = true,
-};
+    [11499] = true,
+}
 
 cookingDailyIds = {
     [11377] = true,
     [11379] = true,
     [11380] = true,
     [11381] = true,
-};
+}
 
 fishingDailyIds = {
-    [11667] = true,
     [11665] = true,
     [11666] = true,
+    [11667] = true,
     [11668] = true,
     [11669] = true,
-};
+}
 
 pvpDailyIds = {
     [11335] = true,
@@ -205,4 +253,85 @@ pvpDailyIds = {
     [11340] = true,
     [11341] = true,
     [11342] = true,
+}
+
+everydayDailyIds = {
+    -- P = pvp, O = P2 Oggrila/Skettis, N = Netherwing
+    -- EB = Event Brewfest, EH = Event Halloween, ES = Event mid Summer
+    -- NOTE: Checked to be correct: P, O
+    [10106] = true, --P: Hellfire Fortifications
+    [10110] = true, --P: Hellfire Fortifications
+    [11008] = true, --O: Fires Over Skettis
+--    [11015] = true, --N: Netherwing Crystals
+--    [11016] = true, --N: Nethermine Flayer Hide
+--    [11017] = true, --N: Netherdust Pollen
+--    [11018] = true, --N: Nethercite Ore
+--    [11020] = true, --N: A Slow Death
+    [11023] = true, --O: Bomb Them Again!
+--    [11035] = true, --N: The Not-So-Friendly Skies...
+    [11051] = true, --O: Banish More Demons
+--    [11055] = true, --N: The Booterang: A Cure For The Common Worthless Peon
+    [11066] = true, --O: Wrangle More Aether Rays!
+--    [11076] = true, --N: Picking Up The Pieces...
+--    [11077] = true, --N: Dragons are the Least of Our Problems
+    [11080] = true, --O: The Relic's Emanation
+    [11085] = true, --O: Escape from Skettis
+--    [11086] = true, --N: Disrupting the Twilight Portal
+--    [11097] = true, --N: The Deadliest Trap Ever Laid
+--    [11101] = true, --N: The Deadliest Trap Ever Laid
+--    [11131] = true, --EH: Stop the Fires!
+--    [11219] = true, --EH: Stop the Fires!
+--    [11293] = true, --EB: Bark for the Barleybrews!
+--    [11294] = true, --EB: Bark for the Thunderbrews!
+--    [11401] = true, --EH: Call the Headless Horseman
+--    [11404] = true, --EH: Call the Headless Horseman
+--    [11405] = true, --EH: Call the Headless Horseman
+--    [11407] = true, --EB: Bark for Drohn's Distillery!
+--    [11408] = true, --EB: Bark for T'chali's Voodoo Brewery!
+--    [11496] = true, --S: The Sanctum Wards
+    [11502] = true, --P: In Defense of Halaa
+    [11503] = true, --P: Enemies, Old and New
+    [11505] = true, --P: Spirits of Auchindoun
+    [11506] = true, --P: Spirits of Auchindoun
+--    [11513] = true, --S: Intercepting the Mana Cells
+--    [11514] = true, --S: Maintaining the Sunwell Portal
+--    [11515] = true, --S: Blood for Blood
+--    [11516] = true, --S: Blast the Gateway
+--    [11520] = true, --S: Discovering Your Roots
+--    [11521] = true, --S: Rediscovering Your Roots
+--    [11523] = true, --S: Arm the Wards!
+--    [11524] = true, --S: Erratic Behavior
+--    [11525] = true, --S: Further Conversions
+--    [11532] = true, --S: Distraction at the Dead Scar
+--    [11533] = true, --S: The Air Strikes Must Continue
+--    [11535] = true, --S: Making Ready
+--    [11536] = true, --S: Don't Stop Now....
+--    [11537] = true, --S: The Battle Must Go On
+--    [11538] = true, --S: The Battle for the Sun's Reach Armory
+--    [11539] = true, --S: Taking the Harbor
+--    [11540] = true, --S: Crush the Dawnblade
+--    [11541] = true, --S: Disrupt the Greengill Coast
+--    [11542] = true, --S: Intercept the Reinforcements
+--    [11543] = true, --S: Keeping the Enemy at Bay
+--    [11544] = true, --S: Ata'mal Armaments
+--    [11545] = true, --S: A Charitable Donation
+--    [11546] = true, --S: Open for Business
+--    [11547] = true, --S: Know Your Ley Lines
+--    [11548] = true, --S: Your Continued Support
+--    [11691] = true, --ES: Summon Ahune
+--    [11875] = true, --S: Gaining the Advantage
+--    [11877] = true, --S: Sunfury Attack Plans
+--    [11880] = true, --S: The Multiphase Survey
+--    [11917] = true, --ES: Striking Back
+--    [11921] = true, --ES: More Torch Tossing
+--    [11924] = true, --ES: More Torch Catching
+--    [11925] = true, --ES: More Torch Catching
+--    [11926] = true, --ES: More Torch Tossing
+--    [11947] = true, --ES: Striking Back
+--    [11948] = true, --ES: Striking Back
+--    [11952] = true, --ES: Striking Back
+--    [11953] = true, --ES: Striking Back
+--    [11954] = true, --ES: Striking Back
+--    [12020] = true, --EB: This One Time, When I Was Drunk...
+--    [12062] = true, --EB: Insult Coren Direbrew
 }

--- a/Modules/Quest/DailyQuests.lua
+++ b/Modules/Quest/DailyQuests.lua
@@ -77,35 +77,23 @@ local function _ResetHiddenDailyQuests(possibleQuestIds, currentQuestId)
     local hiddenDailies = {}
     local dbCharCompletedQuests = Questie.db.char.complete
 
-    local someIsCompleted = false
     for questId, _ in pairs(possibleQuestIds) do
-        if IsQuestFlaggedCompleted(currentQuestId) then
-            someIsCompleted = true
-        else
-            -- Mark the quest uncompleted so it can be available again
+        if not IsQuestFlaggedCompleted(questId) then
+            -- If daily reset happens while online, mark old dailies uncompleted so those can be shown again
             dbCharCompletedQuests[questId] = nil
         end
-    end
 
-    if someIsCompleted then
-        -- Hide all dailies of this daily type as we have already completed one today
-        for questId, _ in pairs(possibleQuestIds) do
-            -- No need to call HideDailyQuest() as one quest is completed already, so none can be visible
-            hiddenDailies[questId] = true
-        end
-    else
-        -- Hide quests dailies of this type which aren't available today
-        for questId, _ in pairs(possibleQuestIds) do
-            if questId == currentQuestId then
-                _ShowDailyQuest(questId)
-                hiddenDailies[questId] = nil
-            else
+        if questId == currentQuestId then
+            -- Show today's daily quest
+            _ShowDailyQuest(questId)
+            hiddenDailies[questId] = nil
+        else
+            if (GetQuestLogIndexByID(questId) == 0) then
                 -- If the quest is not in the questlog remove all frames
-                if (GetQuestLogIndexByID(questId) == 0) then
-                    _HideDailyQuest(questId)
-                end
-                hiddenDailies[questId] = true
+                _HideDailyQuest(questId)
             end
+            -- Objectives & Turn-in are shown for all quests in the questlog -> safe to mark hidden
+            hiddenDailies[questId] = true
         end
     end
 

--- a/Modules/Quest/DailyQuests.lua
+++ b/Modules/Quest/DailyQuests.lua
@@ -144,6 +144,7 @@ end
 
 
 --- This handles only non-random everyday dailies.
+--- Does reset check ALSO when called.
 ---@return nil
 function DailyQuests.StartDailyResetTimer()
     if Questie.IsTBC and Questie.db.char.showRepeatableQuests and QuestiePlayer:GetPlayerLevel() == 70 then

--- a/Modules/Quest/DailyQuests.lua
+++ b/Modules/Quest/DailyQuests.lua
@@ -35,19 +35,20 @@ end
 ---@param questId number
 ---@return nil
 local function _ShowDailyQuest(questId)
-    Questie:Debug(Questie.DEBUG_DEVELOP, "[DailyQuests]: _ShowDailyQuest", questId, (not QuestieMap.questIdFrames[questId]), QuestieDB:IsDoable(questId)) -- TEMPORARY
+    Questie:Debug(Questie.DEBUG_DEVELOP, "[DailyQuests]: _ShowDailyQuest", questId, "no frames, isDoable:", (not QuestieMap.questIdFrames[questId]), QuestieDB:IsDoable(questId)) -- TEMPORARY
     if (not QuestieMap.questIdFrames[questId]) then
         QuestieQuest:DrawDailyQuest(questId);
     end
 end
 
 
---- Reset which quests are completed
+--- Reset which daily quests are completed,
+---  can freely be run also at not-daily-reset-time
 --- And Show quests as necessary
 --- Start Timer to reset again
 ---@return nil
 local function _ResetEverydayDailyQuests()
-    Questie:Debug(Questie.DEBUG_INFO, "[DailyQuests]: ResetEverydayDailyQuests")
+    Questie:Debug(Questie.DEBUG_INFO, "[DailyQuests]: ResetEverydayDailyQuests() - This okey to get run also at non-reset times")
 
     local dbCharCompletedQuests = Questie.db.char.complete
 
@@ -178,10 +179,10 @@ function DailyQuests:FilterDailies(message, _, _)
 
         local somethingReset = false
         somethingReset = _ResetHiddenIfRequired(nhcDailyIds, nhcQuestId, "nhc") or somethingReset
-        somethingReset = _ResetHiddenIfRequired(hcDailyIds, hcQuestId, "nhc") or somethingReset
-        somethingReset = _ResetHiddenIfRequired(cookingDailyIds, cookingQuestId, "nhc") or somethingReset
-        somethingReset = _ResetHiddenIfRequired(fishingDailyIds, fishingQuestId, "nhc") or somethingReset
-        somethingReset = _ResetHiddenIfRequired(pvpDailyIds, pvpQuestId, "nhc") or somethingReset
+        somethingReset = _ResetHiddenIfRequired(hcDailyIds, hcQuestId, "hc") or somethingReset
+        somethingReset = _ResetHiddenIfRequired(cookingDailyIds, cookingQuestId, "cooking") or somethingReset
+        somethingReset = _ResetHiddenIfRequired(fishingDailyIds, fishingQuestId, "fishing") or somethingReset
+        somethingReset = _ResetHiddenIfRequired(pvpDailyIds, pvpQuestId, "pvp") or somethingReset
 
         --TODO remove this debug
         print("'"..message.."'", nhcQuestId, hcQuestId, cookingQuestId, fishingQuestId, pvpQuestId, somethingReset)
@@ -196,7 +197,7 @@ end
 ---@return boolean
 function DailyQuests.IsHiddenDailyQuest(questId)
     local hiddenQuests = Questie.db.char.hiddenDailies
-    return not not (hiddenQuests.nhc[questId] -- "not not" to covert to boolean
+    return not not (hiddenQuests.nhc[questId] -- "not not" to convert to boolean
                 or hiddenQuests.hc[questId]
                 or hiddenQuests.cooking[questId]
                 or hiddenQuests.fishing[questId]
@@ -207,7 +208,7 @@ end
 ---@param questId number
 ---@return boolean
 function DailyQuests.IsDailyQuest(questId)
-    return not not (nhcDailyIds[questId] -- "not not" to covert to boolean
+    return not not (nhcDailyIds[questId] -- "not not" to convert to boolean
                 or hcDailyIds[questId]
                 or cookingDailyIds[questId]
                 or fishingDailyIds[questId]

--- a/Modules/Quest/DailyQuests.lua
+++ b/Modules/Quest/DailyQuests.lua
@@ -44,7 +44,7 @@ end
 --- Start Timer to reset again
 ---@return nil
 local function _ResetEverydayDailyQuests()
-    Questie:Debug(Questie.DEBUG_INFO, "[DailyQuests]: ResetEverydayDailyQuests() - Okey to get run also at non-reset times")
+    Questie:Debug(Questie.DEBUG_INFO, "[DailyQuests]: _ResetEverydayDailyQuests() - Okey to get run also at non-reset times")
 
     local dbCharCompletedQuests = Questie.db.char.complete
 
@@ -69,10 +69,11 @@ end
 --- And update if quest is completed or not
 --- And Show/Hide quest as necessary
 ---@param possibleQuestIds table<number, boolean>
----@param currentQuestId number @today's daily quest
----@return table<number, boolean> @list of hidden dailies of type
-local function _ResetHiddenDailyQuests(possibleQuestIds, currentQuestId)
-    assert(currentQuestId and (currentQuestId > 0), "ResetHiddenDailyQuests(): Invalid currentQuestId")
+---@param currentQuestId number|nil @today's daily quest. nil -> we don't know and show all
+---@param type string @Which type of dailies we are checking. examples: "nhc" "hc" "cooking" "fishing"
+---@return nil
+local function _ResetHiddenDailyQuests(possibleQuestIds, currentQuestId, type)
+    Questie:Debug(Questie.DEBUG_DEVELOP, "[DailyQuests]: _ResetHiddenDailyQuests(  ) currentQuestId, type:", currentQuestId, type)
 
     local hiddenDailies = {}
     local dbCharCompletedQuests = Questie.db.char.complete
@@ -96,8 +97,7 @@ local function _ResetHiddenDailyQuests(possibleQuestIds, currentQuestId)
             hiddenDailies[questId] = true
         end
     end
-
-    return hiddenDailies
+    Questie.db.char.hiddenDailies[type] = hiddenDailies
 end
 
 
@@ -107,7 +107,7 @@ end
 ---@return nil
 local function _ResetHiddenIfRequired(possibleQuestIds, currentQuestId, type)
     if currentQuestId > 0 and (Questie.db.char.hiddenDailies[type][currentQuestId] or (not next(Questie.db.char.hiddenDailies[type]))) and (not IsQuestFlaggedCompleted(currentQuestId)) then
-        Questie.db.char.hiddenDailies[type] = _ResetHiddenDailyQuests(possibleQuestIds, currentQuestId)
+        _ResetHiddenDailyQuests(possibleQuestIds, currentQuestId, type)
     end
 end
 

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -319,6 +319,7 @@ function QuestieQuest:SmoothReset()
         end,
         function()
             DailyQuests.StartDailyResetTimer()
+            return true
         end,
         function()
             QuestieQuest._isResetting = nil

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -318,6 +318,9 @@ function QuestieQuest:SmoothReset()
             return (not QuestieQuest._resetNeedsAvailables) and #QuestieMap._mapDrawQueue == 0 and #QuestieMap._minimapDrawQueue == 0
         end,
         function()
+            DailyQuests.StartDailyResetTimer()
+        end,
+        function()
             QuestieQuest._isResetting = nil
             if QuestieQuest._resetAgain then
                 QuestieQuest._resetAgain = nil

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -403,9 +403,8 @@ end
 function QuestieQuest:CompleteQuest(quest)
     local questId = quest.Id
     QuestiePlayer.currentQuestlog[questId] = nil;
-    -- Only quests that aren't repeatable and not a daily quest should be marked complete,
-    -- otherwise objectives for repeatable quests won't track correctly - #1433
-    Questie.db.char.complete[questId] = DailyQuests:IsDailyQuest(questId) or (not quest.IsRepeatable);
+    -- Don't mark repeatable non-daily quests as complete or those won't work correctly - #1433
+    Questie.db.char.complete[questId] = DailyQuests.IsDailyQuest(questId) or (not quest.IsRepeatable);
 
     QuestieHash:RemoveQuestHash(questId)
 
@@ -1500,8 +1499,8 @@ function QuestieQuest:CalculateAndDrawAvailableQuestsIterative(callback)
 end
 
 function QuestieQuest:DrawDailyQuest(questId)
-    local quest = QuestieDB:GetQuest(questId)
     if QuestieDB:IsDoable(questId) then
+        local quest = QuestieDB:GetQuest(questId)
         _QuestieQuest:DrawAvailableQuest(quest)
     end
 end

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -263,6 +263,7 @@ function QuestieQuest:SmoothReset()
     
     -- bit of a hack (there has to be a better way to do logic like this
     QuestieDBMIntegration:ClearAll()
+    DailyQuests.StopDailyResetTimer()
     local stepTable = {
         function()
             return #QuestieMap._mapDrawQueue == 0 and #QuestieMap._minimapDrawQueue == 0 -- wait until draw queue is finished

--- a/Modules/QuestieInit.lua
+++ b/Modules/QuestieInit.lua
@@ -44,6 +44,8 @@ local HBDHooks = QuestieLoader:ImportModule("HBDHooks")
 local ChatFilter = QuestieLoader:ImportModule("ChatFilter")
 ---@type Hooks
 local Hooks = QuestieLoader:ImportModule("Hooks")
+---@type DailyQuests
+local DailyQuests = QuestieLoader:ImportModule("DailyQuests")
 
 -- initialize all questie modules
 -- this function runs inside a coroutine
@@ -181,6 +183,8 @@ function QuestieInit:InitAllModules()
     Questie.started = true
 
     if Questie.IsTBC and QuestiePlayer:GetPlayerLevel() == 70 then
+        DailyQuests.StartDailyResetTimer()
+
         local lastRequestWasYesterday = Questie.db.char.lastDailyRequestDate ~= date("%d-%m-%y"); -- Yesterday or some day before
         local isPastDailyReset = Questie.db.char.lastDailyRequestResetTime < GetQuestResetTime();
 


### PR DESCRIPTION
 - Refactor whole `DailyQuest.lua`
 - Fix non-random everyday dailies showing always available - even right after turn in
 - "Old" random dailies should work as before.
 - Reset non-radom everyday dailies to be available again at server's daily reset