### PR TITLE
[fix] fps drop at looting

### DIFF
--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -634,11 +634,10 @@ function _QuestieTracker:CreateTrackedQuestsFrame()
     frm:EnableMouse(true)
     frm:RegisterForDrag("LeftButton")
 
-    frm:RegisterEvent("BAG_NEW_ITEMS_UPDATED")
     frm:RegisterEvent("BANKFRAME_CLOSED")
 
     frm:SetScript("OnEvent", function(_, event, ...)
-        if (event == "BAG_NEW_ITEMS_UPDATED" or event == "BANKFRAME_CLOSED") then
+        if (event == "BANKFRAME_CLOSED") then
             QuestieCombatQueue:Queue(function()
                 QuestieTracker:ResetLinesForChange()
                 QuestieTracker:Update()


### PR DESCRIPTION
Looting a quest objective item triggers already a quest watch event and/or questlog events. Those run tracker update.
BAG_NEW_ITEMS_UPDATED won't fire when an old item stack gets new items into it. So it is useless for most quest objectives.

Helps little for #3120
Helps little for #2801