### PR TITLE
Major performance improvements to compiler readers

### DIFF
--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -124,24 +124,24 @@ QuestieDBCompiler.readers = {
 
         local list = {}
 
-        for _ = 1, count do
-            tinsert(list, stream:ReadShort())
+        for i = 1, count do
+            list[i] = stream:ReadShort()
         end
         return list
     end,
     ["u8s16pairs"] = function(stream)
         local list = {}
         local count = stream:ReadByte()
-        for _ = 1, count do
-            tinsert(list, {stream:ReadShort() - 32767, stream:ReadShort() - 32767})
+        for i = 1, count do
+            list[i] = {stream:ReadShort() - 32767, stream:ReadShort() - 32767}
         end
         return list
     end,
     ["u16u16array"] = function(stream)
         local list = {}
         local count = stream:ReadShort()
-        for _ = 1, count do
-            tinsert(list, stream:ReadShort())
+        for i = 1, count do
+            list[i] = stream:ReadShort()
         end
         return list
     end,
@@ -151,16 +151,16 @@ QuestieDBCompiler.readers = {
         if count == 0 then return nil end
 
         local list = {}
-        for _ = 1, count do
-            tinsert(list, stream:ReadInt24())
+        for i = 1, count do
+            list[i] = stream:ReadInt24()
         end
         return list
     end,
     ["u8u16stringarray"] = function(stream)
         local list = {}
         local count = stream:ReadByte()
-        for _ = 1, count do
-            tinsert(list, stream:ReadShortString())
+        for i = 1, count do
+            list[i] = stream:ReadShortString()
         end
         return list
     end,
@@ -183,12 +183,12 @@ QuestieDBCompiler.readers = {
             local zone = stream:ReadShort()
             local spawnCount = stream:ReadShort()
             local list = {}
-            for _ = 1, spawnCount do
+            for i = 1, spawnCount do
                 local x, y = stream:ReadInt12Pair()
                 if x == 0 and y == 0 then
-                    tinsert(list, {-1, -1})
+                    list[i] = {-1, -1}
                 else
-                    tinsert(list, {x / 40.90, y / 40.90}) 
+                    list[i] = {x / 40.90, y / 40.90}
                 end
             end
             spawnlist[zone] = list
@@ -201,18 +201,16 @@ QuestieDBCompiler.readers = {
         else
             stream._pointer = stream._pointer - 2
         end
-        local ret = {}
-        tinsert(ret, stream:ReadTinyStringNil())
-        tinsert(ret, QuestieDBCompiler.readers["spawnlist"](stream))
-        return ret
+        return {stream:ReadTinyStringNil(), QuestieDBCompiler.readers["spawnlist"](stream)}
     end,
     ["questgivers"] = function(stream)
         --local count = stream:ReadByte()
         --if count == 0 then return nil end
-        local ret = {}
-        ret[1] = QuestieDBCompiler.readers["u8u24array"](stream)
-        ret[2] = QuestieDBCompiler.readers["u8u24array"](stream)
-        ret[3] = QuestieDBCompiler.readers["u8u24array"](stream)
+        local ret = {
+            QuestieDBCompiler.readers["u8u24array"](stream),
+            QuestieDBCompiler.readers["u8u24array"](stream),
+            QuestieDBCompiler.readers["u8u24array"](stream)
+        }
 
         --for i = 1, count do
         --    tinsert(ret, QuestieDBCompiler.readers["u8u16array"](stream))
@@ -228,24 +226,24 @@ QuestieDBCompiler.readers = {
 
         local ret = {}
 
-        for _ = 1, count do
-            tinsert(ret, {stream:ReadInt24(), stream:ReadTinyStringNil()})
+        for i = 1, count do
+            ret[i] = {stream:ReadInt24(), stream:ReadTinyStringNil()}
         end
         return ret
     end,
     ["objectives"] = function(stream)
-        local ret = {}
-
-        ret[1] = QuestieDBCompiler.readers["objective"](stream)
-        ret[2] = QuestieDBCompiler.readers["objective"](stream)
-        ret[3] = QuestieDBCompiler.readers["objective"](stream)
-        ret[4] = QuestieDBCompiler.readers["u24pair"](stream)
+        local ret = {
+            QuestieDBCompiler.readers["objective"](stream),
+            QuestieDBCompiler.readers["objective"](stream),
+            QuestieDBCompiler.readers["objective"](stream),
+            QuestieDBCompiler.readers["u24pair"](stream),
+        }
 
         local creditCount = stream:ReadByte()
         if creditCount > 0 then
             local creditList = {}
-            for _=1,creditCount do
-                tinsert(creditList, stream:ReadInt24())
+            for i=1,creditCount do
+                creditList[i] = stream:ReadInt24()
             end
             local rootNPCId = stream:ReadInt24()
             local rootNPCName = stream:ReadTinyStringNil()
@@ -258,10 +256,10 @@ QuestieDBCompiler.readers = {
         local count = stream:ReadByte()
         if count > 0 then
             local ret = {}
-            for _=1,count do
+            for i=1,count do
                 local type = QuestieDBCompiler.refTypes[stream:ReadByte()]
                 local id = stream:ReadInt24()
-                tinsert(ret, {type, id})
+                ret[i] = {type, id}
             end
             return ret
         end
@@ -270,14 +268,14 @@ QuestieDBCompiler.readers = {
         local count = stream:ReadByte()
         if count > 0 then
             local ret = {}
-            for _=1,count do
-                tinsert(ret, {
+            for i=1,count do
+                ret[i] = {
                     QuestieDBCompiler.readers["spawnlist"](stream),
                     stream:ReadTinyString(),
                     stream:ReadShortString(),
                     stream:ReadInt24(),
                     QuestieDBCompiler.readers["reflist"](stream)
-                })
+                }
             end
             return ret
         end
@@ -290,18 +288,18 @@ QuestieDBCompiler.readers = {
             local lists = {}
             local zone = stream:ReadShort()
             local listCount = stream:ReadByte()
-            for _ = 1, listCount do
+            for j = 1, listCount do
                 local spawnCount = stream:ReadShort()
                 local list = {}
-                for _ = 1, spawnCount do
+                for i = 1, spawnCount do
                     local x, y = stream:ReadInt12Pair()
                     if x == 0 and y == 0 then
-                        tinsert(list, {-1, -1})
+                        list[i] = {-1, -1}
                     else
-                        tinsert(list, {x / 40.90, y / 40.90}) 
+                        list[i] = {x / 40.90, y / 40.90}
                     end
                 end
-                tinsert(lists, list)
+                lists[j] = list
             end
             waypointlist[zone] = lists
         end


### PR DESCRIPTION
Replace table.insert with a lot faster table[i] = foo
Use known table size in few places