### PR TITLE
[quest] Fix ally and Add missing horde "Brew of the Month Club"

### DIFF
--- a/Database/Corrections/QuestieEvent.lua
+++ b/Database/Corrections/QuestieEvent.lua
@@ -560,7 +560,8 @@ tinsert(QuestieEvent.eventQuests, {"Brewfest", 12192}) -- This One Time, When I 
 tinsert(QuestieEvent.eventQuests, {"Brewfest", 11437}) -- [PH] Beer Garden A
 --tinsert(QuestieEvent.eventQuests, {"Brewfest", 11454}) -- Seek the Saboteurs
 tinsert(QuestieEvent.eventQuests, {"Brewfest", 12420}) -- Brew of the Month Club
-tinsert(QuestieEvent.eventQuests, {"Brewfest", 12306}) -- Brew of the Month Club
+tinsert(QuestieEvent.eventQuests, {"Brewfest", 12421}) -- Brew of the Month Club
+--tinsert(QuestieEvent.eventQuests, {"Brewfest", 12306}) -- Brew of the Month Club
 tinsert(QuestieEvent.eventQuests, {"Brewfest", 11120}) -- Pink Elekks On Parade
 tinsert(QuestieEvent.eventQuests, {"Brewfest", 11400}) -- Brewfest Riding Rams
 tinsert(QuestieEvent.eventQuests, {"Brewfest", 11442}) -- Welcome to Brewfest!

--- a/Database/Corrections/TBC/tbcItemFixes.lua
+++ b/Database/Corrections/TBC/tbcItemFixes.lua
@@ -203,6 +203,27 @@ function QuestieTBCItemFixes:Load()
         [35277] = {
             [itemKeys.npcDrops] = {25866,25863,25924},
         },
+        [37736] = { -- 2021 Brewfest item (Alliance)
+            [itemKeys.name] = '"Brew of the Month" Club Membership Form',
+            [itemKeys.startQuest] = 12420,
+            [itemKeys.itemLevel] = 1,
+            [itemKeys.requiredLevel] = 1,
+            [itemKeys.ammoType] = 0,
+            [itemKeys.class] = 12,
+            [itemKeys.subClass] = 0,
+            [itemKeys.vendors] = {23710,27478},
+        },
+        [37737] = { -- 2021 Brewfest item (Horde)
+            [itemKeys.name] = '"Brew of the Month" Club Membership Form',
+            [itemKeys.startQuest] = 12421,
+            [itemKeys.itemLevel] = 1,
+            [itemKeys.requiredLevel] = 1,
+            [itemKeys.ammoType] = 0,
+            [itemKeys.class] = 12,
+            [itemKeys.subClass] = 0,
+            [itemKeys.vendors] = {24495,27489},
+        },
+
 
         -- Below are fake items which can be used to show special quest "objectives" as requiredSourceItem.
         -- For example this is used for quest 10129 to show the NPC you have to talk with to start the flight

--- a/Database/Corrections/TBC/tbcQuestFixes.lua
+++ b/Database/Corrections/TBC/tbcQuestFixes.lua
@@ -15,6 +15,7 @@ QuestieCorrections.reversedKillCreditQuestIDs = {
 function QuestieTBCQuestFixes:Load()
     QuestieDB.questData[12192] = {}; -- This One Time, When I Was Drunk... (Horde)
     QuestieDB.questData[12420] = {}; -- Brew of the Month Club (Alliance)
+    QuestieDB.questData[12421] = {}; -- Brew of the Month Club (Horde)
     QuestieDB.questData[63866] = {}; -- Claiming the Light
     QuestieDB.questData[64139] = {}; -- A Summons from Lady Liadrin
     QuestieDB.questData[64140] = {}; -- The Master's Path
@@ -2620,13 +2621,24 @@ function QuestieTBCQuestFixes:Load()
         },
         [12420] = {
             [questKeys.name] = "Brew of the Month Club",
-            [questKeys.startedBy] = {nil,{37571,},nil,},
-            [questKeys.finishedBy] = {{27478,},nil,},
+            [questKeys.startedBy] = {nil,nil,{37736}},
+            [questKeys.finishedBy] = {{27478},nil},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = -1,
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Bring the \"Brew of the Month\" club membership form to Larkin Thunderbrew in the Stonefire Tavern in Ironforge.",},
-            [questKeys.sourceItemId] = 37571,
+            [questKeys.objectivesText] = {"Bring the \"Brew of the Month\" club membership form to Larkin Thunderbrew in the Stonefire Tavern in Ironforge."},
+            [questKeys.sourceItemId] = 37736,
+            [questKeys.zoneOrSort] = -370,
+        },
+        [12421] = {
+            [questKeys.name] = "Brew of the Month Club",
+            [questKeys.startedBy] = {nil,nil,{37737}},
+            [questKeys.finishedBy] = {{27489},nil},
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = -1,
+            [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
+            [questKeys.objectivesText] = {"Bring the \"Brew of the Month\" club membership form to Ray'ma in the Darkbriar Lodge in Orgrimmar's Valley of Spirits."},
+            [questKeys.sourceItemId] = 37737,
             [questKeys.zoneOrSort] = -370,
         },
         [12513] = {


### PR DESCRIPTION
Ally version has object instead of item as starter - and id was wrong. Fixes #3179
Horde had a version with wrong quest id.
Not sure if objectivesText are correct as I haven't done quests ingame.