### PR TITLE
iterate backpack containers more correctly in tracker

### DIFF
--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -675,8 +675,8 @@ function _QuestieTracker:CreateTrackedQuestItemButtons()
             local validTexture
             local isFound = false
 
-            for bag = 0 , 5 do
-                for slot = 0 , 24 do
+            for bag = 0 , 4 do
+                for slot = 1, GetContainerNumSlots(bag) do
                     local texture, _, _, _, _, _, _, _, _, itemID = GetContainerItemInfo(bag, slot)
                     if quest.sourceItemId == itemID then
                         validTexture = texture


### PR DESCRIPTION
There are only BagIDs 0-4 where items can be used: 0 backpack and 1-4 for equipped bags on character. BagID 5 is a bag in a bank.

Slots in a container start from 1 instead of 0 and we can use `GetContainerNumSlots()` to get how many slots a container has.