### PR TITLE
[fix] Reset collapsing of a quest to show item

### DIFF
--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -386,6 +386,7 @@ function QuestieQuest:AcceptQuest(questId)
             function() QuestieMap:UnloadQuestFrames(questId) end,
             function() QuestieTooltips:RemoveQuest(questId) end,
             function() QuestieHash:AddNewQuestHash(questId) end,
+            function() Questie.db.char.collapsedQuests[questId] = nil end,  -- re-accepted quest can be collapsed. expand it. specially dailies.
             function() QuestieQuest:PopulateQuestLogInfo(quest) end,
             function() QuestieQuest:PopulateObjectiveNotes(quest) end,
             QuestieQuest.CalculateAndDrawAvailableQuestsIterative

--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -2208,11 +2208,12 @@ function QuestieTracker:ResetLinesForChange()
     end
 end
 
-function QuestieTracker:RemoveQuest(id)
+function QuestieTracker:RemoveQuest(questId)
     Questie:Debug(Questie.DEBUG_DEVELOP, "QuestieTracker: RemoveQuest")
+    Questie.db.char.collapsedQuests[questId] = nil  -- forget the collapsed/expanded state
     if Questie.db.char.TrackerFocus then
-        if (type(Questie.db.char.TrackerFocus) == "number" and Questie.db.char.TrackerFocus == id)
-        or (type(Questie.db.char.TrackerFocus) == "string" and Questie.db.char.TrackerFocus:sub(1, #tostring(id)) == tostring(id)) then
+        if (type(Questie.db.char.TrackerFocus) == "number" and Questie.db.char.TrackerFocus == questId)
+        or (type(Questie.db.char.TrackerFocus) == "string" and Questie.db.char.TrackerFocus:sub(1, #tostring(questId)) == tostring(questId)) then
             QuestieTracker:UnFocus()
             QuestieQuest:ToggleNotes(true)
         end


### PR DESCRIPTION
Normal setting collapse a quest when complete.
Reset this when the quest is removed or added to questlog.