### PR TITLE
[fix] Check collapsedQuests[] exists before using it

### DIFF
--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -386,7 +386,7 @@ function QuestieQuest:AcceptQuest(questId)
             function() QuestieMap:UnloadQuestFrames(questId) end,
             function() QuestieTooltips:RemoveQuest(questId) end,
             function() QuestieHash:AddNewQuestHash(questId) end,
-            function() Questie.db.char.collapsedQuests[questId] = nil end,  -- re-accepted quest can be collapsed. expand it. specially dailies.
+            function() if Questie.db.char.collapsedQuests then Questie.db.char.collapsedQuests[questId] = nil end end,  -- re-accepted quest can be collapsed. expand it. specially dailies.
             function() QuestieQuest:PopulateQuestLogInfo(quest) end,
             function() QuestieQuest:PopulateObjectiveNotes(quest) end,
             QuestieQuest.CalculateAndDrawAvailableQuestsIterative

--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -2210,7 +2210,9 @@ end
 
 function QuestieTracker:RemoveQuest(questId)
     Questie:Debug(Questie.DEBUG_DEVELOP, "QuestieTracker: RemoveQuest")
-    Questie.db.char.collapsedQuests[questId] = nil  -- forget the collapsed/expanded state
+    if Questie.db.char.collapsedQuests then -- if because this function is called even Tracker isn't initialized
+        Questie.db.char.collapsedQuests[questId] = nil  -- forget the collapsed/expanded state
+    end
     if Questie.db.char.TrackerFocus then
         if (type(Questie.db.char.TrackerFocus) == "number" and Questie.db.char.TrackerFocus == questId)
         or (type(Questie.db.char.TrackerFocus) == "string" and Questie.db.char.TrackerFocus:sub(1, #tostring(questId)) == tostring(questId)) then


### PR DESCRIPTION
Check that Questie.db.char.collapsedQuests[] exists before using it.
It exists only if tracker has been initialised at least once on character