### PR TITLE
Performance improvements to map icons generation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2708,15 +2708,8 @@
         "Database/TEMP_questie4items.lua",
         "Database/TEMP_repprof.lua",
         "Database/zoneDB.lua",
-        "Locale/deDE/**",
-        "Locale/enUS/**",
-        "Locale/esES/**",
-        "Locale/frFR/**",
-        "Locale/koKR/**",
-        "Locale/ptBR/**",
-        "Locale/ruRU/**",
-        "Locale/zhCN/**",
-        "Locale/zhTW/**"
+        "Localization/lookups/**",
+        "Localization/Translations/**"
     ],
     "files.exclude": {
         "ExternalScripts(DONOTINCLUDEINRELEASE)": true,

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -46,84 +46,74 @@ function QuestieMap.utils:SetDrawOrder(frame)
     end
 end
 
----@param points table<number, Point> @Pointlist {x=0, y=0}
----@return Point @{x=?, y=?}
-function QuestieMap.utils:CenterPoint(points)
-    local center = {}
-    local count = 0
-    center.x = 0
-    center.y = 0
-    for _, point in pairs(points) do
-        center.x = center.x + point.x
-        center.y = center.y + point.y
-        count = count + 1
+---@param points table<number, Point> @{{x=0, y=0}, ...}
+---@return number x, number y @Center coordinates
+function QuestieMap.utils.CenterPoint(points)
+    local x, y = 0, 0
+    local count = #points
+    for i=1, count do
+        local point = points[i]
+        x = x + point.x
+        y = y + point.y
     end
-    center.x = center.x / count
-    center.y = center.y / count
-    return center
+    x = x / count
+    y = y / count
+    return x, y
 end
 
----@param points table<number, Point> @A simple pointlist with {x=0, y=0, zone=0}
+---@param points table<number, Point> @A pointlist with {worldX=0, worldY=0, UiMapID=0, distance=0}
 ---@param rangeR number @Range of the hotzones.
 ---@param count number @Optional, used to allow more notes if far away from the quest giver.
 ---@return table<number, table<number, Point>> @A table of hotzones
 function QuestieMap.utils:CalcHotzones(points, rangeR, count)
-    if(points == nil) then return nil; end
+--    if(points == nil) then return nil; end
+
+    local hotzones = {}
+    local pointsCount = #points
+
+    if pointsCount == 1 then
+        -- This is execution shortcut to skip loop in case table size == 1
+
+        hotzones = { { points[1] } }
+        return hotzones
+    end
 
     --If count isn't set we want to distance clustering to still work,
     --to simplify the logic we just use a big number.
     if not count then
-      count = 99999;
+        count = 99999;
     end
 
+    local useMovingRange = (count > 100)
+
     local range = rangeR or 100;
-    local hotzones = {};
-    local pointsCount = #points
-    if pointsCount == 1 then
-        -- This is execution shortcut to skip loop in case table size == 1
-        points[1].touched = true
-        hotzones = { { points[1] } }
-    else
-        for j=1, pointsCount do
-            local point = points[j]
-            if(point.touched == nil) then
-                local notes = {};
-                point.touched = true;
-                tinsert(notes, point);
 
-                local times = 1;
+    for j=1, pointsCount do
+        local point = points[j]
+        if(point.touched == nil) then
+            point.touched = true
+            local notes = { point }
 
-                --We want things further away to be clustered more
-                local movingRange = range;
-                if(point.distance and point.distance > 1000 and count > 100) then
-                    movingRange = movingRange * (point.distance/1000);
-                end
+            --We want things further away to be clustered more
+            local movingRange = range
+            if useMovingRange and (point.distance > 1000) then
+                movingRange = movingRange * (point.distance/1000);
+            end
 
-                if (point.x > 1 and point.y > 1) then
-                    times = 100
-                end
-                local aX, aY = HBD:GetWorldCoordinatesFromZone(
-                                    point.x / times, point.y / times,
-                                    point.UiMapID)
-                aX = aX or 0
-                aY = aY or 0
+            local aX, aY = point.worldX, point.worldY
 
-                for i=j+1, pointsCount do
-                    local point2 = points[i]
-                    --We only want to cluster icons that are on the same map.
-                    if (point2.touched == nil) and (point.UiMapID == point2.UiMapID) then
-                        local bX, bY = HBD:GetWorldCoordinatesFromZone(
-                                            point2.x / times, point2.y / times,
-                                            point2.UiMapID)
-                        local distance = QuestieLib:Euclid(aX, aY, bX or 0, bY or 0)
-                        if (distance < movingRange) then
-                            point2.touched = true
-                            tinsert(notes, point2)
-                        end
+            for i=j+1, pointsCount do
+                local point2 = points[i]
+                --We only want to cluster icons that are on the same map.
+                if (point2.touched == nil) and (point.UiMapID == point2.UiMapID) then
+                    local distance = QuestieLib:Euclid(aX, aY, point2.worldX, point2.worldY)
+                    if (distance < movingRange) then
+                        point2.touched = true
+                        notes[#notes+1] = point2
                     end
                 end
-                tinsert(hotzones, notes)
             end
+            hotzones[#hotzones+1] = notes
         end
     end
     return hotzones

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -87,7 +87,7 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
             for i=j, #points do
                 local point2 = points[i]
                 --We only want to cluster icons that are on the same map.
-                if(point.UiMapID == point2.UiMapID) then
+                if (point2.touched == nil) and (point.UiMapID == point2.UiMapID) then
                     local times = 1;
 
                     --We want things further away to be clustered more
@@ -109,7 +109,7 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
                     -- local dY = (point.y*times) - (point2.y*times);
                     local distance =
                         QuestieLib:Euclid(aX or 0, aY or 0, bX or 0, bY or 0)
-                    if (distance < movingRange and point2.touched == nil) then
+                    if (distance < movingRange) then
                         point2.touched = true
                         tinsert(notes, point2)
                     end

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -79,45 +79,50 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
     local range = rangeR or 100;
     local hotzones = {};
     local pointsCount = #points
-    for j=1, pointsCount do
-        local point = points[j]
-        if(point.touched == nil) then
-            local notes = {};
-            point.touched = true;
-            tinsert(notes, point);
+    if pointsCount == 1 then
+        points[1].touched = true
+        hotzones = { { points[1] } }
+    else
+        for j=1, pointsCount do
+            local point = points[j]
+            if(point.touched == nil) then
+                local notes = {};
+                point.touched = true;
+                tinsert(notes, point);
 
-            local times = 1;
+                local times = 1;
 
-            --We want things further away to be clustered more
-            local movingRange = range;
-            if(point.distance and point.distance > 1000 and count > 100) then
-                movingRange = movingRange * (point.distance/1000);
-            end
+                --We want things further away to be clustered more
+                local movingRange = range;
+                if(point.distance and point.distance > 1000 and count > 100) then
+                    movingRange = movingRange * (point.distance/1000);
+                end
 
-            if (point.x > 1 and point.y > 1) then
-                times = 100
-            end
-            local aX, aY = HBD:GetWorldCoordinatesFromZone(
-                                point.x / times, point.y / times,
-                                point.UiMapID)
-            aX = aX or 0
-            aY = aY or 0
+                if (point.x > 1 and point.y > 1) then
+                    times = 100
+                end
+                local aX, aY = HBD:GetWorldCoordinatesFromZone(
+                                    point.x / times, point.y / times,
+                                    point.UiMapID)
+                aX = aX or 0
+                aY = aY or 0
 
-            for i=j, pointsCount do
-                local point2 = points[i]
-                --We only want to cluster icons that are on the same map.
-                if (point2.touched == nil) and (point.UiMapID == point2.UiMapID) then
-                    local bX, bY = HBD:GetWorldCoordinatesFromZone(
-                                        point2.x / times, point2.y / times,
-                                        point2.UiMapID)
-                    local distance = QuestieLib:Euclid(aX, aY, bX or 0, bY or 0)
-                    if (distance < movingRange) then
-                        point2.touched = true
-                        tinsert(notes, point2)
+                for i=j, pointsCount do
+                    local point2 = points[i]
+                    --We only want to cluster icons that are on the same map.
+                    if (point2.touched == nil) and (point.UiMapID == point2.UiMapID) then
+                        local bX, bY = HBD:GetWorldCoordinatesFromZone(
+                                            point2.x / times, point2.y / times,
+                                            point2.UiMapID)
+                        local distance = QuestieLib:Euclid(aX, aY, bX or 0, bY or 0)
+                        if (distance < movingRange) then
+                            point2.touched = true
+                            tinsert(notes, point2)
+                        end
                     end
                 end
+                tinsert(hotzones, notes)
             end
-            tinsert(hotzones, notes)
         end
     end
     return hotzones

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -84,24 +84,26 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
             local notes = {};
             point.touched = true;
             tinsert(notes, point);
+
+            local times = 1;
+
+            --We want things further away to be clustered more
+            local movingRange = range;
+            if(point.distance and point.distance > 1000 and count > 100) then
+                movingRange = movingRange * (point.distance/1000);
+            end
+
+            if (point.x > 1 and point.y > 1) then
+                times = 100
+            end
+            local aX, aY = HBD:GetWorldCoordinatesFromZone(
+                                point.x / times, point.y / times,
+                                point.UiMapID)
+
             for i=j, #points do
                 local point2 = points[i]
                 --We only want to cluster icons that are on the same map.
                 if (point2.touched == nil) and (point.UiMapID == point2.UiMapID) then
-                    local times = 1;
-
-                    --We want things further away to be clustered more
-                    local movingRange = range;
-                    if(point.distance and point.distance > 1000 and count > 100) then
-                        movingRange = movingRange * (point.distance/1000);
-                    end
-
-                    if (point.x > 1 and point.y > 1) then
-                        times = 100
-                    end
-                    local aX, aY = HBD:GetWorldCoordinatesFromZone(
-                                        point.x / times, point.y / times,
-                                        point.UiMapID)
                     local bX, bY = HBD:GetWorldCoordinatesFromZone(
                                         point2.x / times, point2.y / times,
                                         point2.UiMapID)

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -80,6 +80,7 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
     local hotzones = {};
     local pointsCount = #points
     if pointsCount == 1 then
+        -- This is execution shortcut to skip loop in case table size == 1
         points[1].touched = true
         hotzones = { { points[1] } }
     else
@@ -107,7 +108,7 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
                 aX = aX or 0
                 aY = aY or 0
 
-                for i=j, pointsCount do
+                for i=j+1, pointsCount do
                     local point2 = points[i]
                     --We only want to cluster icons that are on the same map.
                     if (point2.touched == nil) and (point.UiMapID == point2.UiMapID) then

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -78,7 +78,6 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
 
     local range = rangeR or 100;
     local hotzones = {};
-    local itt = 0;
     while(true) do
         local FoundUntouched
         for _, point in pairs(points) do
@@ -121,7 +120,6 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
             end
         end
         if (FoundUntouched == nil) then break end
-        itt = itt + 1
     end
     return hotzones
 end

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -78,7 +78,8 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
 
     local range = rangeR or 100;
     local hotzones = {};
-    for j=1, #points do
+    local pointsCount = #points
+    for j=1, pointsCount do
         local point = points[j]
         if(point.touched == nil) then
             local notes = {};
@@ -99,18 +100,17 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
             local aX, aY = HBD:GetWorldCoordinatesFromZone(
                                 point.x / times, point.y / times,
                                 point.UiMapID)
+            aX = aX or 0
+            aY = aY or 0
 
-            for i=j, #points do
+            for i=j, pointsCount do
                 local point2 = points[i]
                 --We only want to cluster icons that are on the same map.
                 if (point2.touched == nil) and (point.UiMapID == point2.UiMapID) then
                     local bX, bY = HBD:GetWorldCoordinatesFromZone(
                                         point2.x / times, point2.y / times,
                                         point2.UiMapID)
-                    -- local dX = (point.x*times) - (point2.x*times)
-                    -- local dY = (point.y*times) - (point2.y*times);
-                    local distance =
-                        QuestieLib:Euclid(aX or 0, aY or 0, bX or 0, bY or 0)
+                    local distance = QuestieLib:Euclid(aX, aY, bX or 0, bY or 0)
                     if (distance < movingRange) then
                         point2.touched = true
                         tinsert(notes, point2)

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -78,48 +78,43 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
 
     local range = rangeR or 100;
     local hotzones = {};
-    while(true) do
-        local FoundUntouched
-        for _, point in pairs(points) do
-            if(point.touched == nil) then
-                local notes = {};
-                FoundUntouched = true;
-                point.touched = true;
-                tinsert(notes, point);
-                for _, point2 in pairs(points) do
-                    --We only want to cluster icons that are on the same map.
-                    if(point.UiMapID == point2.UiMapID) then
-                        local times = 1;
+    for _, point in pairs(points) do
+        if(point.touched == nil) then
+            local notes = {};
+            point.touched = true;
+            tinsert(notes, point);
+            for _, point2 in pairs(points) do
+                --We only want to cluster icons that are on the same map.
+                if(point.UiMapID == point2.UiMapID) then
+                    local times = 1;
 
-                        --We want things further away to be clustered more
-                        local movingRange = range;
-                        if(point.distance and point.distance > 1000 and count > 100) then
-                            movingRange = movingRange * (point.distance/1000);
-                        end
+                    --We want things further away to be clustered more
+                    local movingRange = range;
+                    if(point.distance and point.distance > 1000 and count > 100) then
+                        movingRange = movingRange * (point.distance/1000);
+                    end
 
-                        if (point.x > 1 and point.y > 1) then
-                            times = 100
-                        end
-                        local aX, aY = HBD:GetWorldCoordinatesFromZone(
-                                            point.x / times, point.y / times,
-                                            point.UiMapID)
-                        local bX, bY = HBD:GetWorldCoordinatesFromZone(
-                                            point2.x / times, point2.y / times,
-                                            point2.UiMapID)
-                        -- local dX = (point.x*times) - (point2.x*times)
-                        -- local dY = (point.y*times) - (point2.y*times);
-                        local distance =
-                            QuestieLib:Euclid(aX or 0, aY or 0, bX or 0, bY or 0)
-                        if (distance < movingRange and point2.touched == nil) then
-                            point2.touched = true
-                            tinsert(notes, point2)
-                        end
+                    if (point.x > 1 and point.y > 1) then
+                        times = 100
+                    end
+                    local aX, aY = HBD:GetWorldCoordinatesFromZone(
+                                        point.x / times, point.y / times,
+                                        point.UiMapID)
+                    local bX, bY = HBD:GetWorldCoordinatesFromZone(
+                                        point2.x / times, point2.y / times,
+                                        point2.UiMapID)
+                    -- local dX = (point.x*times) - (point2.x*times)
+                    -- local dY = (point.y*times) - (point2.y*times);
+                    local distance =
+                        QuestieLib:Euclid(aX or 0, aY or 0, bX or 0, bY or 0)
+                    if (distance < movingRange and point2.touched == nil) then
+                        point2.touched = true
+                        tinsert(notes, point2)
                     end
                 end
-                tinsert(hotzones, notes)
             end
+            tinsert(hotzones, notes)
         end
-        if (FoundUntouched == nil) then break end
     end
     return hotzones
 end

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -78,12 +78,14 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
 
     local range = rangeR or 100;
     local hotzones = {};
-    for _, point in pairs(points) do
+    for j=1, #points do
+        local point = points[j]
         if(point.touched == nil) then
             local notes = {};
             point.touched = true;
             tinsert(notes, point);
-            for _, point2 in pairs(points) do
+            for i=j, #points do
+                local point2 = points[i]
                 --We only want to cluster icons that are on the same map.
                 if(point.UiMapID == point2.UiMapID) then
                     local times = 1;

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -857,7 +857,15 @@ _DetermineIconsToDraw = function(quest, oObjective, objectiveIndex, objectiveCen
                         -- This will create a distance of 0 but it doesn't matter.
                         local distance = QuestieLib:Euclid(objectiveCenter.x or 0, objectiveCenter.y or 0, x or 0, y or 0);
                         drawIcon.distance = distance or 0;
-                        iconsToDraw[floor(distance)] = drawIcon;
+--                        iconsToDraw[floor(distance)] = drawIcon;
+                        -- there can be multiple icons at same distance at different directions
+                        --local distance = floor(distance) --floored is slower overall
+                        local iconList = iconsToDraw[distance]
+                        if iconList then
+                            iconList[#iconList+1] = drawIcon
+                        else
+                            iconsToDraw[distance] = { drawIcon }
+                        end
                     end
                 end
             end
@@ -941,12 +949,14 @@ _GetIconsSortedByDistance = function(questId, icons, spawnedIconCount, maxPerTyp
 
     -- use the keys to retrieve the values in the sorted order
     for _, distance in ipairs(tableKeys) do
-        if(spawnedIconCount > maxPerType) then
-            Questie:Debug(Questie.DEBUG_DEVELOP, "[QuestieQuest]", "Too many icons for quest:", questId)
-            break;
+        for _, icon in ipairs(icons[distance]) do
+            if(spawnedIconCount > maxPerType) then
+                Questie:Debug(Questie.DEBUG_DEVELOP, "[QuestieQuest]", "Too many icons for quest:", questId)
+                break;
+            end
+            iconCount = iconCount + 1;
+            tinsert(orderedList, icon);
         end
-        iconCount = iconCount + 1;
-        tinsert(orderedList, icons[distance]);
     end
     return iconCount, orderedList
 end

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -861,7 +861,7 @@ _DetermineIconsToDraw = function(quest, objective, objectiveIndex, objectiveCent
                             worldX = 0,
                             worldY = 0,
                             distance = 0,
-                            touched = nil,
+                            touched = nil, -- TODO change. This is ment to let lua reserve memory for all keys needed for sure.
                         }
                         local x, y, _ = HBD:GetWorldCoordinatesFromZone(drawIcon.x/100, drawIcon.y/100, uiMapId)
                         x = x or 0

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -804,37 +804,40 @@ _UnloadAlreadySpawnedIcons = function(objective)
 end
 QuestieQuest._UnloadAlreadySpawnedIcons = _UnloadAlreadySpawnedIcons -- for profiling
 
-_DetermineIconsToDraw = function(quest, oObjective, objectiveIndex, objectiveCenter)
+---@param quest Quest
+---@param objectiveIndex number
+---@param objectiveCenter Point
+_DetermineIconsToDraw = function(quest, objective, objectiveIndex, objectiveCenter)
     local iconsToDraw = {}
     local spawnItemId
 
-    for id, spawnData in pairs(oObjective.spawnList) do
+    for id, spawnData in pairs(objective.spawnList) do
         if spawnData.ItemId then
             spawnItemId = spawnData.ItemId
         end
 
-        if (not oObjective.Icon) and spawnData.Icon then
-            oObjective.Icon = spawnData.Icon
+        if (not objective.Icon) and spawnData.Icon then
+            objective.Icon = spawnData.Icon
         end
-        if (not oObjective.AlreadySpawned[id]) and (not oObjective.Completed) and Questie.db.global.enableObjectives then
+        if (not objective.AlreadySpawned[id]) and (not objective.Completed) and Questie.db.global.enableObjectives then
             local data = {
                 Id = quest.Id,
                 ObjectiveIndex = objectiveIndex,
                 QuestData = quest,
-                ObjectiveData = oObjective,
+                ObjectiveData = objective,
                 Icon = spawnData.Icon,
                 IconColor = quest.Color,
                 GetIconScale = function() return spawnData:GetIconScale() or 1 end,
                 Name = spawnData.Name,
-                Type = oObjective.Type,
+                Type = objective.Type,
                 ObjectiveTargetId = spawnData.Id
             }
             data.IconScale = data:GetIconScale()
 
-            oObjective.AlreadySpawned[id] = {};
-            oObjective.AlreadySpawned[id].data = data;
-            oObjective.AlreadySpawned[id].minimapRefs = {};
-            oObjective.AlreadySpawned[id].mapRefs = {};
+            objective.AlreadySpawned[id] = {};
+            objective.AlreadySpawned[id].data = data;
+            objective.AlreadySpawned[id].minimapRefs = {};
+            objective.AlreadySpawned[id].mapRefs = {};
 
             for zone, spawns in pairs(spawnData.Spawns) do
                 local uiMapId = ZoneDB:GetUiMapIdByAreaId(zone)

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -881,7 +881,7 @@ _DrawObjectiveIcons = function(questId, iconsToDraw, objective, maxPerType)
     local icon
     local iconPerZone = {}
 
-    local iconCount, orderedList = _GetIconsSortedByDistance(questId, iconsToDraw, spawnedIconCount, maxPerType)
+    local iconCount, orderedList = _GetIconsSortedByDistance(iconsToDraw)
 
     local range = Questie.db.global.clusterLevelHotzone
     if orderedList and orderedList[1] and orderedList[1].Icon == ICON_TYPE_OBJECT then -- new clustering / limit code should prevent problems, always show all object notes
@@ -937,25 +937,25 @@ _DrawObjectiveIcons = function(questId, iconsToDraw, objective, maxPerType)
 end
 QuestieQuest._DrawObjectiveIcons = _DrawObjectiveIcons
 
-_GetIconsSortedByDistance = function(questId, icons, spawnedIconCount, maxPerType)
+_GetIconsSortedByDistance = function(icons)
     local iconCount = 0;
     local orderedList = {}
     local tableKeys = {}
 
+    local i = 0
     for k in pairs(icons) do
-        tinsert(tableKeys, k)
+        i = i + 1
+        tableKeys[i] = k
+--        tinsert(tableKeys, k)
     end
     table.sort(tableKeys)
 
     -- use the keys to retrieve the values in the sorted order
     for _, distance in ipairs(tableKeys) do
         for _, icon in ipairs(icons[distance]) do
-            if(spawnedIconCount > maxPerType) then
-                Questie:Debug(Questie.DEBUG_DEVELOP, "[QuestieQuest]", "Too many icons for quest:", questId)
-                break;
-            end
-            iconCount = iconCount + 1;
-            tinsert(orderedList, icon);
+            iconCount = iconCount + 1
+            orderedList[iconCount] = icon
+            --tinsert(orderedList, icon);
         end
     end
     return iconCount, orderedList

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -891,7 +891,6 @@ _DrawObjectiveIcons = function(questId, iconsToDraw, objective, maxPerType)
 
     local hotzones = QuestieMap.utils:CalcHotzones(orderedList, range, iconCount);
 
---    for _, hotzone in pairs(hotzones or {}) do
     for i=1, #hotzones do
         local hotzone = hotzones[i]
         if(spawnedIconCount > maxPerType) then
@@ -905,49 +904,35 @@ _DrawObjectiveIcons = function(questId, iconsToDraw, objective, maxPerType)
         local spawnsMapRefs = objective.AlreadySpawned[icon.AlreadySpawnedId].mapRefs
         local spawnsMinimapRefs = objective.AlreadySpawned[icon.AlreadySpawnedId].minimapRefs
 
---        local midPoint = QuestieMap.utils:CenterPoint2(hotzone);
         local centerX, centerY = QuestieMap.utils.CenterPoint(hotzone)
 
         local dungeonLocation = ZoneDB:GetDungeonLocation(icon.zone)
 
---        if dungeonLocation and midPoint.x == -1 and midPoint.y == -1 then
         if dungeonLocation and centerX == -1 and centerY == -1 then
             if dungeonLocation[2] then -- We have more than 1 instance entrance (e.g. Blackrock dungeons)
                 local secondDungeonLocation = dungeonLocation[2]
                 icon.zone = secondDungeonLocation[1]
-                --midPoint.x = secondDungeonLocation[2]
-                --midPoint.y = secondDungeonLocation[3]
                 centerX = secondDungeonLocation[2]
                 centerY = secondDungeonLocation[3]
 
---                local iconMap, iconMini = QuestieMap:DrawWorldIcon(icon.data, icon.zone, midPoint.x, midPoint.y) -- clustering code takes care of duplicates as long as mindist is more than 0
                 local iconMap, iconMini = QuestieMap:DrawWorldIcon(icon.data, icon.zone, centerX, centerY) -- clustering code takes care of duplicates as long as mindist is more than 0
                 if iconMap and iconMini then
---                    iconPerZone[icon.zone] = {iconMap, midPoint.x, midPoint.y}
                     iconPerZone[icon.zone] = {iconMap, centerX, centerY}
---                    tinsert(spawnsMapRefs, iconMap);
                     spawnsMapRefs[#spawnsMapRefs+1] = iconMap
---                    tinsert(spawnsMinimapRefs, iconMini);
                     spawnsMinimapRefs[#spawnsMinimapRefs+1] = iconMini
                 end
                 spawnedIconCount = spawnedIconCount + 1;
             end
             local firstDungeonLocation = dungeonLocation[1]
             icon.zone = firstDungeonLocation[1]
---            midPoint.x = firstDungeonLocation[2]
---            midPoint.y = firstDungeonLocation[3]
             centerX = firstDungeonLocation[2]
             centerY = firstDungeonLocation[3]
         end
 
---        local iconMap, iconMini = QuestieMap:DrawWorldIcon(icon.data, icon.zone, midPoint.x, midPoint.y) -- clustering code takes care of duplicates as long as mindist is more than 0
         local iconMap, iconMini = QuestieMap:DrawWorldIcon(icon.data, icon.zone, centerX, centerY) -- clustering code takes care of duplicates as long as mindist is more than 0
         if iconMap and iconMini then
---            iconPerZone[icon.zone] = {iconMap, midPoint.x, midPoint.y}
             iconPerZone[icon.zone] = {iconMap, centerX, centerY}
---            tinsert(spawnsMapRefs, iconMap);
             spawnsMapRefs[#spawnsMapRefs+1] = iconMap
---            tinsert(spawnsMinimapRefs, iconMini);
             spawnsMinimapRefs[#spawnsMinimapRefs+1] = iconMini
         end
         spawnedIconCount = spawnedIconCount + 1;

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -940,22 +940,22 @@ QuestieQuest._DrawObjectiveIcons = _DrawObjectiveIcons
 _GetIconsSortedByDistance = function(icons)
     local iconCount = 0;
     local orderedList = {}
-    local tableKeys = {}
+    local distances = {}
 
     local i = 0
-    for k in pairs(icons) do
+    for distance in pairs(icons) do
         i = i + 1
-        tableKeys[i] = k
---        tinsert(tableKeys, k)
+        distances[i] = distance
     end
-    table.sort(tableKeys)
+    table.sort(distances)
 
     -- use the keys to retrieve the values in the sorted order
-    for _, distance in ipairs(tableKeys) do
-        for _, icon in ipairs(icons[distance]) do
+    for distIndex = 1, #distances do
+        local iconsAtDisntace = icons[distances[distIndex]]
+        for iconIndex = 1, #iconsAtDisntace do
+            local icon = iconsAtDisntace[iconIndex]
             iconCount = iconCount + 1
             orderedList[iconCount] = icon
-            --tinsert(orderedList, icon);
         end
     end
     return iconCount, orderedList

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -789,7 +789,6 @@ _RegisterObjectiveTooltips = function(objective, questId)
     end
     objective.hasRegisteredTooltips = true
 end
-QuestieQuest._RegisterObjectiveTooltips = _RegisterObjectiveTooltips -- for profiling
 
 _UnloadAlreadySpawnedIcons = function(objective)
     if next(objective.spawnList) then
@@ -810,7 +809,6 @@ _UnloadAlreadySpawnedIcons = function(objective)
         objective.spawnList = {} -- Remove the spawns for this objective, since we don't need to show them
     end
 end
-QuestieQuest._UnloadAlreadySpawnedIcons = _UnloadAlreadySpawnedIcons -- for profiling
 
 ---@param quest Quest
 ---@param objectiveIndex number
@@ -891,7 +889,6 @@ _DetermineIconsToDraw = function(quest, objective, objectiveIndex, objectiveCent
 
     return iconsToDraw, spawnItemId
 end
-QuestieQuest._DetermineIconsToDraw = _DetermineIconsToDraw -- for profiling
 
 _DrawObjectiveIcons = function(questId, iconsToDraw, objective, maxPerType)
     local spawnedIconCount = 0
@@ -957,7 +954,6 @@ _DrawObjectiveIcons = function(questId, iconsToDraw, objective, maxPerType)
 
     return icon, iconPerZone
 end
-QuestieQuest._DrawObjectiveIcons = _DrawObjectiveIcons -- for profiling
 
 _GetIconsSortedByDistance = function(icons)
     local iconCount = 0;
@@ -982,7 +978,6 @@ _GetIconsSortedByDistance = function(icons)
     end
     return iconCount, orderedList
 end
-QuestieQuest._GetIconsSortedByDistance = _GetIconsSortedByDistance -- for profiling
 
 _DrawObjectiveWaypoints = function(objective, icon, iconPerZone)
     for _, spawnData in pairs(objective.spawnList) do -- spawnData.Name, spawnData.Spawns
@@ -1005,7 +1000,6 @@ _DrawObjectiveWaypoints = function(objective, icon, iconPerZone)
         end
     end
 end
-QuestieQuest._DrawObjectiveWaypoints = _DrawObjectiveWaypoints -- for profiling
 
 local function _CallPopulateObjective(quest)
     for k, v in pairs(quest.Objectives) do


### PR DESCRIPTION
This changes a lot more than I inteded originally. Focuses into QuestieQuest:PopulateObjective( ) and functions it uses, but includes also performance practices elsewhere in modified files.

Includes also a bug fix to use all spawn locations of quest object. Previously only one at same floor(distance) from center was included regardless of direction.

Functionality should be otherwise same. Except now it uses non-floored distances in sorting. Should check with larger data set if floored would be faster, but on my test case non-floored is faster.