### PR TITLE
Fix quest 123 "The Collector" starters

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -72,7 +72,7 @@ function QuestieQuestFixes:Load()
             [questKeys.startedBy] = {{233,237,240,261,294,963},nil,nil}, --#2158
         },
         [123] = {
-            [questKeys.startedBy] = {{100},nil,{1307}},
+            [questKeys.startedBy] = {nil,nil,{1307}},
         },
         [148] = {
             [questKeys.preQuestSingle] = {}, -- #1173


### PR DESCRIPTION
NPC `100` "Gruff Swiftbite" does not directly starts quest `123` "The Collector", it is obtained from item `1307` "Gold Pickup Schedule" drop solely