### PR TITLE
[quest] Blacklist all event quests

### DIFF
--- a/Database/Corrections/QuestieEvent.lua
+++ b/Database/Corrections/QuestieEvent.lua
@@ -483,9 +483,9 @@ tinsert(QuestieEvent.eventQuests, {"Children's Week", 10942}) -- Children's Week
 tinsert(QuestieEvent.eventQuests, {"Children's Week", 10943}) -- Children's Week
 
 tinsert(QuestieEvent.eventQuests, {"Darkmoon Faire", 9249}) -- 40 Tickets - Schematic: Steam Tonk Controller
+tinsert(QuestieEvent.eventQuests, {"Darkmoon Faire", 10938}) -- Darkmoon Blessings Deck
 tinsert(QuestieEvent.eventQuests, {"Darkmoon Faire", 10939}) -- Darkmoon Storms Deck
 tinsert(QuestieEvent.eventQuests, {"Darkmoon Faire", 10940}) -- Darkmoon Furies Deck
-tinsert(QuestieEvent.eventQuests, {"Darkmoon Faire", 10941}) -- Darkmoon Lunacy Deck
 tinsert(QuestieEvent.eventQuests, {"Darkmoon Faire", 10941}) -- Darkmoon Lunacy Deck
 
 --tinsert(QuestieEvent.eventQuests, {"Hallow's End", 11450}) -- Fire Training

--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -480,6 +480,7 @@ function QuestieQuestBlacklist:Load()
         [11122] = true,
         [12318] = true,
         [12022] = true,
+        [12062] = true,
         [12133] = true,
         [12191] = true,
         [12194] = true,

--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -564,6 +564,7 @@ function QuestieQuestBlacklist:Load()
         [12408] = true,
         [12409] = true,
         [12420] = true,
+        [12421] = true,
         ----------------
 
         --mount replacement

--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -482,6 +482,8 @@ function QuestieQuestBlacklist:Load()
         [12022] = true,
         [12062] = true,
         [12133] = true,
+        [12135] = true,
+        [12139] = true,
         [12191] = true,
         [12194] = true,
         [12278] = true,


### PR DESCRIPTION
Checked all quests in `QuestieEvent.lua` (excluding war effort) exists in `QuestieQuestBlaclist.lua`. 

* Add "Darkmoon Blessings Deck" (10938) to DMF event quests. It's a new quest in TBC p3. It was already blacklisted.
* Remove duplicate entry of "Darkmoon Lunacy Deck" (10941) from event quests.
* Blacklist Horde "Brew of the Month Club" (12421)
* Blacklist "Insult Coren Direbrew" (12062).
Fixes #3240
* Blacklist "Let the Fires Come!" (12135) (12139)
Fixes #3238