### PR TITLE
Fix Tracker stuck on mouse with multiple buttons

### DIFF
--- a/Modules/Tracker/QuestieTrackerPrivates.lua
+++ b/Modules/Tracker/QuestieTrackerPrivates.lua
@@ -14,12 +14,15 @@ local mouselookTicker = {}
 local updateTimer
 local tempTrackerLocation
 
+local dragButton
+
 function _QuestieTracker:OnDragStart(button)
     Questie:Debug(Questie.DEBUG_DEVELOP, "[_QuestieTracker:OnDragStart]", button)
     local baseFrame = QuestieTracker:GetBaseFrame()
     if IsMouseButtonDown(button) then
         if (IsControlKeyDown() and Questie.db.global.trackerLocked and not ChatEdit_GetActiveWindow()) or not Questie.db.global.trackerLocked then
             _QuestieTracker.isMoving = true
+            dragButton = button
             startDragAnchor = {baseFrame:GetPoint()}
             preSetPoint = ({baseFrame:GetPoint()})[1]
             baseFrame:SetClampedToScreen(true)
@@ -44,15 +47,16 @@ function _QuestieTracker:OnDragStart(button)
     end
 end
 
-function _QuestieTracker:OnDragStop(button)
-    Questie:Debug(Questie.DEBUG_DEVELOP, "[_QuestieTracker:OnDragStop]", button)
+function _QuestieTracker:OnDragStop()
+    Questie:Debug(Questie.DEBUG_DEVELOP, "[_QuestieTracker:OnDragStop]")
 
-    if IsMouseButtonDown(button) or not startDragPos or not startDragPos[4] or not startDragPos[5] or not endDragPos or not startDragAnchor then
+    if not dragButton or IsMouseButtonDown(dragButton) or not startDragPos or not startDragPos[4] or not startDragPos[5] or not endDragPos or not startDragAnchor then
         return
     end
 
     local baseFrame = QuestieTracker:GetBaseFrame()
     _QuestieTracker.isMoving = false
+    dragButton = nil
     endDragPos = {baseFrame:GetPoint()}
     baseFrame:StopMovingOrSizing()
 


### PR DESCRIPTION
Fixes #3266
OnDragStop uihandler event won't give button argument.
I would like to remove also IsMouseButtonDown altogether, because drag event is registered only for left button, and also remove \*Drag\* checks, but I'm afraid of possible bugs as I am not sure why those all are there even checking just .isMoving would be enough.
