### PR TITLE
Update tbcQuestFixes.lua

### DIFF
--- a/Database/Corrections/TBC/tbcQuestFixes.lua
+++ b/Database/Corrections/TBC/tbcQuestFixes.lua
@@ -91,6 +91,9 @@ function QuestieTBCQuestFixes:Load()
         [1135] = {
             [questKeys.startedBy] = {{4456},nil,nil},
         },
+        [1204] = {--no required pre-quest anymore with tbc
+            [questKeys.preQuestSingle] = {},
+        },        
         [1437] = {
             [questKeys.triggerEnd] = {"Find and search Tyranis and Dalinda Malem's wagon", {[zoneIDs.DESOLACE]={{56.52,17.84}}}},
         },


### PR DESCRIPTION
Removed preQuestSingle for 1204. There's no pre-quest required in tbc.