### PR TITLE
Added event handler to update LDB text label when a completed quest is turned in

### DIFF
--- a/Modules/QuestieEventHandler.lua
+++ b/Modules/QuestieEventHandler.lua
@@ -169,6 +169,16 @@ function _EventHandler:QuestAccepted(questLogIndex, questId)
 
 end
 
+--- Fires when a System Message (yellow text) is output to the main chat window
+---@param message string The message value from the CHAT_MSG_SYSTEM event
+function _EventHandler:ChatMsgSystem(message)
+    -- When a completed quest is turned in, update the LibDataBroker text with the "quest completed" message
+    local questComplete = string.find(message, ERR_QUEST_COMPLETE_S)
+    if questComplete == 1 then
+        MinimapIcon:UpdateText(message)
+    end
+end
+
 --- Fires when a UI Info Message (yellow text) appears near the top of the screen
 ---@param errorType number The error type value from the UI_INFO_MESSAGE event
 ---@param message string The message value from the UI_INFO_MESSAGE event


### PR DESCRIPTION
Similar to this PR I did a while back:

https://github.com/Questie/Questie/pull/3033

This builds upon this functionality a bit more. Currently the LDB text only updates when a quest objective is updated. For example 

> Vile Familiars: 8/12

This new PR will also update the LDB quest when a completed quest is handed in to the quest NPC. At this time the system chat message appears in the chat window. Something like:

> Vile Familiars completed.

This PR makes it so that the LDB text also updates with this message. Example:

![image](https://user-images.githubusercontent.com/87356/144694765-c5d0454e-0869-470d-a301-56cf8712ae0e.png)

![image](https://user-images.githubusercontent.com/87356/144694907-c28f2c89-c04a-4b7b-9acd-e56f6e5a25aa.png)

The purpose of this PR is to simply make the LDB text to better reflect that you actually turned in the quest. Otherwise after turning in the quest, the LDB quest still would say `Vile Familiars: 12/12` even though you have turned it in and moved on to the next quest. I thought it would be useful to also indicate that the quest was completed and turned in.

---

Side note, it would be trivial to also add the functionality to show the similar message a new quest is accepted, like `Quest Accepted: Vile Familiars`. But I'm not sure if that is as useful. Not sure. Maybe it is. Maybe for consistency the LDB should include this so for every quest the Questie LDB shows the full lifecycle of a quest:

1. It being accepted
2. It being in progress
3. It being completed/turned in

What do you think?