### PR TITLE
[fix] Detect event spanning across year cange

### DIFF
--- a/Database/Corrections/QuestieEvent.lua
+++ b/Database/Corrections/QuestieEvent.lua
@@ -199,10 +199,11 @@ _WithinDates = function(startDay, startMonth, endDay, endMonth)
     local date = (C_DateAndTime.GetTodaysDate or C_DateAndTime.GetCurrentCalendarTime)()
     local day = date.day or date.monthDay
     local month = date.month
-    if (month < startMonth) or -- Too early in the year
-        (month > endMonth) or -- Too late in the year
-        (month == startMonth and day < startDay) or -- Too early in the correct month
-        (month == endMonth and day > endDay) then -- Too late in the correct month
+    if (startMonth <= endMonth) -- Event start and end during same year
+        and ((month < startMonth) or (month > endMonth)) -- Too early or late in the year
+        or ((month < startMonth) and (month > endMonth)) -- Event span across year change
+        or (month == startMonth and day < startDay) -- Too early in the correct month
+        or (month == endMonth and day > endDay) then -- Too late in the correct month
         return false
     else
         return true

--- a/Database/Corrections/QuestieEvent.lua
+++ b/Database/Corrections/QuestieEvent.lua
@@ -784,4 +784,4 @@ tinsert(QuestieEvent.eventQuests, {"Midsummer", 11966}) -- Incense for the Festi
 tinsert(QuestieEvent.eventQuests, {"Midsummer", 11970}) -- The Master of Summer Lore
 tinsert(QuestieEvent.eventQuests, {"Midsummer", 11971}) -- The Spinner of Summer Tales
 
-tinsert(QuestieEvent.eventQuests, {"Winter Veil", 11528}) -- A Winter Veil Gift
+tinsert(QuestieEvent.eventQuests, {"Winter Veil", 11528, "25/12", "2/1"}) -- A Winter Veil Gift


### PR DESCRIPTION
Current code never detects event be active if the event starts and ends at different years - i.e. start month is larger than end month.
```lua
if (month < startMonth) or -- Too early in the year
    (month > endMonth) or -- Too late in the year
```
example:
```lua
startMonth = 12
endMonth = 1
(12 < 12) or (12 > 1) -- evaluates always to true -> event not active
```

This PR fixes logic to work also in this case.

Also fix to show the Winter Veil Gift new in TBC only starting from christmas day.