### PR TITLE
Refactor Game's cached quest log validation

### DIFF
--- a/Modules/QuestieInit.lua
+++ b/Modules/QuestieInit.lua
@@ -133,15 +133,13 @@ QuestieInit.Stages[1] = function() -- run as a coroutine
 
     QuestieCleanup:Run()
 
-    coroutine.yield()
-
     -- continue to next Init Stage
     return QuestieInit.Stages[2]
 end
 
 QuestieInit.Stages[2] = function() -- not a coroutine
     _QuestieInit.WaitForGameCache()
-    -- continues to next Init Stage from above function
+    -- continues to next Init Stage in above function
 end
 
 QuestieInit.Stages[3] = function() -- run as a coroutine
@@ -357,7 +355,7 @@ function _QuestieInit:StartStageCoroutine(stage)
                 initFrame:SetScript("OnUpdate", nil)
                 initFrame:SetParent(nil)
                 initFrame = nil
-                if type(ret) == "function" then -- continue to next stage, which was returned by coroutine
+                if type(ret) == "function" then -- continue to next stage, if it was returned by coroutine
                     ret()
                 end
             end

--- a/Modules/QuestieInit.lua
+++ b/Modules/QuestieInit.lua
@@ -136,7 +136,7 @@ QuestieInit.Stages[2] = function() -- not a coroutine
         -- continue to next Init Stage
         _QuestieInit:StartStageCoroutine(3)
     else
-        -- tell to game cache checker how to continue to next Init Stage
+        -- QuestieValidateGameCache will take care of starting the next init stage
         QuestieValidateGameCache.AddCallback(_QuestieInit.StartStageCoroutine, _QuestieInit, 3)
     end
 end

--- a/Modules/QuestieValidateGameCache.lua
+++ b/Modules/QuestieValidateGameCache.lua
@@ -1,0 +1,145 @@
+--[[
+Flow:
+-> QuestieValidateGameCache.StartCheck()
+--> Wait for PLAYER_ENTERING_WORLD
+---> Wait For QUEST_LOG_UPDATE (2x at login, 1x at reload)
+----> Game cache should have all quests in it, data of each quest may be invalid.
+      If data is invalid, Wait for next QUEST_LOG_UPDATE and check again.
+-----> Game Cache ok. Call possible callback functions.
+]]--
+
+---@class QuestieValidateGameCache
+local QuestieValidateGameCache = QuestieLoader:CreateModule("QuestieValidateGameCache")
+
+local stringSub = string.sub
+local GetNumQuestLogEntries, GetQuestLogTitle, GetQuestObjectives = GetNumQuestLogEntries, GetQuestLogTitle, C_QuestLog.GetQuestObjectives
+
+local tpack = table.pack or function(...) return { n = select("#", ...), ... } end
+local tunpack = table.unpack or unpack
+
+-- 3 * (Max possible number of quests in game quest log)
+-- This is a safe value, even smaller would be enough. Too large won't effect performance
+local MAX_QUEST_LOG_INDEX = 75
+
+local eventFrame
+local numberOfQuestLogUpdatesToSkip
+
+local cacheGood = false
+local callbacks = {} -- example: { [1] = {func, {arg1, arg2, arg3}}, [2] = {func, {arg1, arg2}}, }
+
+function QuestieValidateGameCache.IsCacheGood()
+    return cacheGood
+end
+
+---@param func function @A function to call once cache is good.
+---@param ... any @Possible arguments for function.
+function QuestieValidateGameCache.AddCallback(func, ...)
+    callbacks[#callbacks+1] = {func, tpack(...)}
+end
+
+
+local function DestroyEventFrame()
+    if eventFrame then
+        eventFrame:UnregisterAllEvents()
+        eventFrame:SetScript("OnEvent", nil)
+        eventFrame:SetParent(nil)
+        eventFrame = nil
+    end
+end
+
+-- Called directly and OnEvent.
+local function OnQuestLogUpdate()
+    local numEntries, numQuests = GetNumQuestLogEntries()
+    print("--> QuestieValidateGameCache.OnQuestLogUpdate() numEntries:", numEntries, "numQuests:", numQuests)
+
+    if numberOfQuestLogUpdatesToSkip > 0 then
+        numberOfQuestLogUpdatesToSkip = numberOfQuestLogUpdatesToSkip - 1
+        print("--> QuestieValidateGameCache.OnQuestLogUpdate() Skipping event.")
+        return
+    end
+
+    --[[
+    -- Player can have 0 quests in questlog OR game's cache can have empty questlog while cache is invalid
+    -- This is a workaround to wait and see if player really has 0 quests.
+    -- Without cached information the first QLU does not have any quest log entries.
+    -- After MAX_INIT_QUEST_LOG_TRIES tries we stop trying
+    if numEntries == 0 then
+        initQuestLogTries = initQuestLogTries + 1
+        if initQuestLogTries < MAX_INIT_QUEST_LOG_TRIES then
+            print("--> QuestieValidateGameCache.OnQuestLogUpdate()", GetTime(), "Game's quest log is empty. Tries:", initQuestLogTries.."/"..MAX_INIT_QUEST_LOG_TRIES)
+            _WaitForGameCache_TryAgainAtEvent()
+            return
+        else
+            print("--> QuestieValidateGameCache.OnQuestLogUpdate()", GetTime(), "Decide player has no quests for real.")
+        end
+    end
+    ]]--
+
+    local isGameCacheGood = true
+    local goodQuestsCount = 0 -- for debug stats
+
+    for i = 1, MAX_QUEST_LOG_INDEX do
+        local title, _, _, isHeader, _, _, _, questId = GetQuestLogTitle(i)
+        if (not title) then
+            break -- We exceeded the valid quest log entries
+        end
+        if (not isHeader) then
+            local hasInvalidObjective -- for debug stats
+            local objectiveList = GetQuestObjectives(questId)
+            for _, objective in pairs(objectiveList) do -- objectiveList may be {} and that is validly cached quest in game log
+                if (not objective.text) or stringSub(objective.text, 1, 1) == " " then
+                    -- Game hasn't cached the quest fully yet
+                    isGameCacheGood = false
+                    hasInvalidObjective = true
+
+                    -- No early "return false" here to force iterate whole quest log and speed up caching
+                end
+            end
+            if not hasInvalidObjective then
+                goodQuestsCount = goodQuestsCount + 1
+            end
+        end
+    end
+
+    if not isGameCacheGood then
+        print("--> QuestieValidateGameCache.OnQuestLogUpdate()", GetTime(), "Game's quest log is not yet okey. Good quest: "..goodQuestsCount.."/"..numQuests)
+        return
+    end
+
+    if goodQuestsCount ~= numQuests then
+        -- This shouldn't be possible
+        Questie:Error("Report this error! Game QuestLog cache is broken. Good quest: "..goodQuestsCount.."/"..numQuests) -- TODO fix message and add translations? translations might not be available?
+        -- TODO should we stop whole addon loading progress?
+    end
+
+    print("--> QuestieValidateGameCache.OnQuestLogUpdate()", GetTime(), "Game's quest log is |cff00bc32".."OK".."|r. Good quest: "..goodQuestsCount.."/"..numQuests)
+
+    DestroyEventFrame()
+
+    cacheGood = true
+
+    -- Call all callbacks
+    while (#callbacks > 0) do
+        local callback = table.remove(callbacks, 1)
+        local func, args = tunpack(callback)
+        print("--> QuestieValidateGameCache.OnQuestLogUpdate()", "Calling a callback.")
+        func(tunpack(args))
+    end
+end
+
+local function OnPlayerEnteringWorld(_, _, isInitialLogin, isReloadingUi)
+    assert(isInitialLogin or isReloadingUi)
+
+    numberOfQuestLogUpdatesToSkip = isReloadingUi and 0 or 1
+
+    eventFrame:UnregisterAllEvents()
+    eventFrame:SetScript("OnEvent", OnQuestLogUpdate)
+    eventFrame:RegisterEvent("QUEST_LOG_UPDATE")
+end
+
+-- MUST be started very early to count number of events firing.
+function QuestieValidateGameCache.StartCheck()
+    eventFrame = CreateFrame("Frame")
+    eventFrame:SetScript("OnEvent", OnPlayerEnteringWorld)
+    eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+end

--- a/Questie-BCC.toc
+++ b/Questie-BCC.toc
@@ -88,6 +88,7 @@ Modules\Libs\QuestieCombatQueue.lua
 Modules\Libs\QuestieHash.lua
 
 # Modules
+Modules\QuestieValidateGameCache.lua
 Modules\QuestieInit.lua
 Modules\MinimapIcon.lua
 Modules\QuestieProfessions.lua

--- a/Questie-Classic.toc
+++ b/Questie-Classic.toc
@@ -82,6 +82,7 @@ Modules\Libs\QuestieCombatQueue.lua
 Modules\Libs\QuestieHash.lua
 
 # Modules
+Modules\QuestieValidateGameCache.lua
 Modules\QuestieInit.lua
 Modules\MinimapIcon.lua
 Modules\QuestieProfessions.lua

--- a/Questie.lua
+++ b/Questie.lua
@@ -32,6 +32,8 @@ local QuestieQuestTimers = QuestieLoader:ImportModule("QuestieQuestTimers")
 local QuestieCombatQueue = QuestieLoader:ImportModule("QuestieCombatQueue")
 ---@type QuestieSlash
 local QuestieSlash = QuestieLoader:ImportModule("QuestieSlash")
+---@class QuestieValidateGameCache
+local QuestieValidateGameCache = QuestieLoader:ImportModule("QuestieValidateGameCache")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
 
@@ -199,3 +201,6 @@ function Questie:Debug(...)
         end
     end
 end
+
+-- Start checking the game's cache.
+QuestieValidateGameCache.StartCheck()


### PR DESCRIPTION
- Validate game's cached quest log asyncronously
- Make Questie's init flow to pause and wait valid quest log for parts needing it.
- Has QuestieInit.lua modified to support easier refactor of whole init flow, which is a bit mess now (even without PR-3111).

Note: Required test for future in PTR when blizzard is going to release a new phase - as those usually may have bigger changes to how things work.

1. Delete game cache. For example the directory: `...\_classic_era_\Cache\`.
2. Login a character having many quests in quest log.
3. /reload
4. Logout and login the character again.
5. Login another character having 0 quests in quest log. (Or if you use same character, then delete game cache again after emptying the quest log).
6. /reload
7. Logout and login the character again.
