### PR TITLE
Update LibQuestXP to 1.0.8 and 2.0.3

### DIFF
--- a/LibsOnlyClassic/LibQuestXP/CHANGELOG.md
+++ b/LibsOnlyClassic/LibQuestXP/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## LibQuestXP - Changelog
 
+**1.0.8**
+- Updated for SoM
+
 **1.0.7**
 
 - No longer loads on Retail

--- a/LibsOnlyClassic/LibQuestXP/LibQuestXP.lua
+++ b/LibsOnlyClassic/LibQuestXP/LibQuestXP.lua
@@ -1,4 +1,4 @@
-local MAJOR, MINOR = "LibQuestXP-1.0", 7
+local MAJOR, MINOR = "LibQuestXP-1.0", 8
 local LibQuestXP = LibStub:NewLibrary(MAJOR, MINOR)
 
 if _G.WOW_PROJECT_ID == _G.WOW_PROJECT_MAINLINE then
@@ -48,11 +48,20 @@ function LibQuestXP:GetAdjustedXP(xp, qLevel)
         xp = 50 * floor((xp + 25) / 50);
     end
 
+    if C_Seasons ~= nil and C_Seasons.HasActiveSeason() and (C_Seasons.GetActiveSeason() == Enum.SeasonID.SeasonOfMastery) then
+        local roundFactor = 50;
+        if xp < 1000 then
+            roundFactor = 10;
+        end
+
+        xp = floor(xp / roundFactor + 0.5) * roundFactor * 1.4;
+    end
+
     return xp;
 end
 
 function GetQuestLogRewardXP(questID)
-    local title, qLevel, xp
+    local title, qLevel, xp, _
 
     -- Try getting the quest from the quest log if no questID was provided
     if questID == nil and selectedQuestLogIndex ~= nil then

--- a/LibsOnlyClassic/LibQuestXP/LibQuestXP.toc
+++ b/LibsOnlyClassic/LibQuestXP/LibQuestXP.toc
@@ -1,8 +1,8 @@
-## Interface: 11302
+## Interface: 11401
 ## Title: LibQuestXP
 ## Author: MrFox
 ## Email: gyussz@live.com
-## Version: 1.0.7
+## Version: 1.0.8
 ## Notes: Library that re-implements GetQuestLogRewardXP for Classic WoW and provides XP reward information for all quests
 ## DefaultState: Enabled
 ## LoadOnDemand: 0

--- a/LibsOnlyClassic/LibQuestXP/libs/LibStub/LibStub.toc
+++ b/LibsOnlyClassic/LibQuestXP/libs/LibStub/LibStub.toc
@@ -1,4 +1,4 @@
-## Interface: 80000
+## Interface: 90005
 ## Title: Lib: LibStub
 ## Notes: Universal Library Stub
 ## Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel

--- a/LibsOnlyTBC/LibQuestXP/CHANGELOG.md
+++ b/LibsOnlyTBC/LibQuestXP/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## LibQuestXP - Changelog
 
+**2.0.3**
+
+- Global _ taint fix
+
 **2.0.2**
 
 - Fixed level limit

--- a/LibsOnlyTBC/LibQuestXP/LibQuestXP.lua
+++ b/LibsOnlyTBC/LibQuestXP/LibQuestXP.lua
@@ -1,4 +1,4 @@
-local MAJOR, MINOR = "LibQuestXP-2.0", 2
+local MAJOR, MINOR = "LibQuestXP-2.0", 3
 local LibQuestXP = LibStub:NewLibrary(MAJOR, MINOR)
 
 if _G.WOW_PROJECT_ID == _G.WOW_PROJECT_MAINLINE then
@@ -26,15 +26,6 @@ end
 
 function LibQuestXP:GetAdjustedXP(xp, qLevel)
     local charLevel = UnitLevel("player");
-
-    --Questie change.
-    if(QuestiePlayer) then
-        charLevel = QuestiePlayer:GetPlayerLevel();
-    else
-        QuestiePlayer = QuestieLoader:ImportModule("QuestiePlayer");
-        charLevel = QuestiePlayer:GetPlayerLevel();
-    end
-
     if (charLevel == 70) then
         return 0;
     end
@@ -61,7 +52,7 @@ function LibQuestXP:GetAdjustedXP(xp, qLevel)
 end
 
 function GetQuestLogRewardXP(questID)
-    local title, qLevel, xp
+    local title, qLevel, xp, _
 
     -- Try getting the quest from the quest log if no questID was provided
     if questID == nil and selectedQuestLogIndex ~= nil then

--- a/LibsOnlyTBC/LibQuestXP/LibQuestXP.toc
+++ b/LibsOnlyTBC/LibQuestXP/LibQuestXP.toc
@@ -1,8 +1,8 @@
-## Interface: 20501
+## Interface: 20502
 ## Title: LibQuestXP
 ## Author: MrFox
 ## Email: gyussz@live.com
-## Version: 2.0.2
+## Version: 2.0.3
 ## Notes: Library that re-implements GetQuestLogRewardXP for Classic WoW and provides XP reward information for all quests
 ## DefaultState: Enabled
 ## LoadOnDemand: 0

--- a/LibsOnlyTBC/LibQuestXP/libs/LibStub/LibStub.toc
+++ b/LibsOnlyTBC/LibQuestXP/libs/LibStub/LibStub.toc
@@ -1,4 +1,4 @@
-## Interface: 80000
+## Interface: 90005
 ## Title: Lib: LibStub
 ## Notes: Universal Library Stub
 ## Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel

--- a/Modules/Tooltips/MapIconTooltip.lua
+++ b/Modules/Tooltips/MapIconTooltip.lua
@@ -33,7 +33,6 @@ local WRAP_TEXT = 1;
 local DEFAULT_WAYPOINT_HOVER_COLOR = { 0.93, 0.46, 0.13, 0.8}
 
 local lastTooltipShowTimestamp = GetTime()
-local isSoM = Questie.IsSoM
 
 function MapIconTooltip:Show()
     local _, _, _, alpha = self.texture:GetVertexColor();
@@ -216,10 +215,6 @@ function MapIconTooltip:Show()
                     if (quest and shift) then
                         local xpReward = GetQuestLogRewardXP(questData.questId)
                         if xpReward > 0 then
-                            if isSoM then
-                                xpReward = xpReward * 1.4 -- 40% increased quest XP
-                                --xpReward = xpReward * 1.4 * ((quest:IsDungeonQuest() or quest:IsEliteQuest()) and 1.15 or 1) -- 40% increased quest XP ; extra 15% bonus for Elite & Dungeon quests
-                            end
                             rewardString = QuestieLib:PrintDifficultyColor(quest.level, "(".. FormatLargeNumber(xpReward) .. xpString .. ") ")
                         end
 
@@ -311,10 +306,6 @@ function MapIconTooltip:Show()
                 local xpReward = GetQuestLogRewardXP(questId)
                 if (quest and shift and xpReward > 0) then
                     r, g, b = QuestieLib:GetDifficultyColorPercent(quest.level);
-                    if isSoM then
-                        xpReward = xpReward * 1.4 -- 40% increased quest XP
-                        --xpReward = xpReward * 1.4 * ((quest:IsDungeonQuest() or quest:IsEliteQuest()) and 1.15 or 1) -- 40% increased quest XP ; extra 15% bonus for Elite & Dungeon quests
-                    end
                     self:AddDoubleLine(questTitle, "("..FormatLargeNumber(xpReward)..xpString..")", 0.2, 1, 0.2, r, g, b);
                     firstLine = false;
                 elseif (firstLine and not shift) then


### PR DESCRIPTION
The lib has build in support for SoM quest xp bonus,
so Questie's code for +40% is removed now.
Extra bonus xp for elite and dungeon quests is still missing.

Questie modifications of library's TBC version removed.
It was modified to use `QuestiePlayer:GetPlayerLevel()` while Questie was in debug mode.