### PR TITLE
Improve login, database and questlog performance

### DIFF
--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -280,20 +280,18 @@ function QuestieDB:GetItem(itemId)
     local sources = {}
     if rawdata[QuestieDB.itemKeys.npcDrops] then
         for _, v in pairs(rawdata[QuestieDB.itemKeys.npcDrops]) do -- droppedBy = 3, relatedQuests=2, containedIn=4
-            local source = {
+            sources[#sources+1] = {
                 Type = "monster",
                 Id = v,
             }
-            sources[#sources+1] = source
         end
     end
     if rawdata[QuestieDB.itemKeys.objectDrops] then
         for _, v in pairs(rawdata[QuestieDB.itemKeys.objectDrops]) do -- droppedBy = 3, relatedQuests=2, containedIn=4
-            local source = {
+            sources[#sources+1] = {
                 Type = "object",
                 Id = v,
             }
-            sources[#sources+1] = source
         end
     end
 

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -277,31 +277,36 @@ function QuestieDB:GetItem(itemId)
         return nil
     end
 
-    local item = {};
+    local sources = {}
+    if rawdata[QuestieDB.itemKeys.npcDrops] then
+        for _, v in pairs(rawdata[QuestieDB.itemKeys.npcDrops]) do -- droppedBy = 3, relatedQuests=2, containedIn=4
+            local source = {
+                Type = "monster",
+                Id = v,
+            }
+            sources[#sources+1] = source
+        end
+    end
+    if rawdata[QuestieDB.itemKeys.objectDrops] then
+        for _, v in pairs(rawdata[QuestieDB.itemKeys.objectDrops]) do -- droppedBy = 3, relatedQuests=2, containedIn=4
+            local source = {
+                Type = "object",
+                Id = v,
+            }
+            sources[#sources+1] = source
+        end
+    end
+
+    local item = {
+        Id = itemId,
+        Sources = sources,
+        Hidden = QuestieCorrections.questItemBlacklist[itemId],
+    }
 
     for stringKey, intKey in pairs(QuestieDB.itemKeys) do
         item[stringKey] = rawdata[intKey]
     end
 
-    item.Id = itemId;
-    item.Sources = {};
-    item.Hidden = QuestieCorrections.questItemBlacklist[itemId]
-    if rawdata[QuestieDB.itemKeys.npcDrops] then
-        for _, v in pairs(rawdata[QuestieDB.itemKeys.npcDrops]) do -- droppedBy = 3, relatedQuests=2, containedIn=4
-            local source = {};
-            source.Type = "monster";
-            source.Id = v;
-            tinsert(item.Sources, source);
-        end
-    end
-    if rawdata[QuestieDB.itemKeys.objectDrops] then
-        for _, v in pairs(rawdata[QuestieDB.itemKeys.objectDrops]) do -- droppedBy = 3, relatedQuests=2, containedIn=4
-            local source = {};
-            source.Type = "object";
-            source.Id = v;
-            tinsert(item.Sources, source);
-        end
-    end
     return item
 end
 

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -1504,7 +1504,7 @@ function QuestieQuest:CalculateAndDrawAvailableQuestsIterative(callback)
                             ---@type Quest
                             local quest = QuestieDB:GetQuest(questId)
                             if (not quest.tagInfoWasCached) then
-                                Questie:Debug(Questie.DEBUG_INFO, "Caching for quest", quest.Id)
+                                Questie:Debug(Questie.DEBUG_DEVELOP, "Caching for quest", quest.Id)
                                 quest:GetQuestTagInfo() -- cache to load in the tooltip
                                 quest.tagInfoWasCached = true
                             end

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -296,16 +296,22 @@ end
 
 function QuestieStreamLib:_ReadTinyString_raw()
     local p = self._pointer
+
+    -- inline _ReadByte_raw
     local length = stringbyte(self._bin, p)
     p = p + 1
+
     self._pointer = p + length
     return stringsub(self._bin, p, p+length-1)
 end
 
 function QuestieStreamLib:_ReadTinyStringNil_raw()
     local p = self._pointer
+
+    -- inline _ReadByte_raw
     local length = stringbyte(self._bin, p)
     p = p + 1
+
     if length == 0 then
         self._pointer = p
         return nil
@@ -342,9 +348,12 @@ end
 
 function QuestieStreamLib:_ReadShortString_raw()
     local p = self._pointer
+
+    -- inline _ReadShort_raw
     local a,b = stringbyte(self._bin, p, p+1)
     local length = a*256 + b
     p = p + 2
+
     self._pointer = p + length
     return stringsub(self._bin, p, p+length-1)
 end

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -337,9 +337,9 @@ end
 
 function QuestieStreamLib:_ReadShortStringBySubstring()
     local length = self:ReadShort()
-    local ret = stringsub(self._bin, self._pointer, self._pointer+length-1)
-    self._pointer = self._pointer + length
-    return ret
+    local p = self._pointer
+    self._pointer = p + length
+    return stringsub(self._bin, p, p+length-1)
 end
 
 function QuestieStreamLib:WriteBytes(...)

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -70,6 +70,7 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
         if mode == "raw" then
             stream.ReadByte = QuestieStreamLib._ReadByte_raw
             stream.ReadShort = QuestieStreamLib._ReadShort_raw
+            stream.ReadInt24 = QuestieStreamLib._ReadInt24_raw
             stream.ReadTinyString = QuestieStreamLib._ReadTinyStringBySubstring
             stream.ReadShortString = QuestieStreamLib._ReadShortStringBySubstring
             stream.ReadTinyStringNil = QuestieStreamLib._ReadTinyStringNilBySubstring
@@ -250,6 +251,13 @@ end
 
 function QuestieStreamLib:ReadInt24()
     return lshift(self:ReadByte(), 16) + lshift(self:ReadByte(), 8) + self:ReadByte();
+end
+
+function QuestieStreamLib:_ReadInt24_raw()
+    local p = self._pointer
+    self._pointer = p + 3
+    local a,b,c = stringbyte(self._bin, p, p+2)
+    return a*65536 + b*256 + c
 end
 
 function QuestieStreamLib:ReadInt()

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -71,6 +71,7 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
             stream.ReadByte = QuestieStreamLib._ReadByte_raw
             stream.ReadShort = QuestieStreamLib._ReadShort_raw
             stream.ReadInt24 = QuestieStreamLib._ReadInt24_raw
+            stream.ReadInt = QuestieStreamLib._ReadInt_raw
             stream.ReadTinyString = QuestieStreamLib._ReadTinyStringBySubstring
             stream.ReadShortString = QuestieStreamLib._ReadShortStringBySubstring
             stream.ReadTinyStringNil = QuestieStreamLib._ReadTinyStringNilBySubstring
@@ -262,6 +263,13 @@ end
 
 function QuestieStreamLib:ReadInt()
     return lshift(self:ReadByte(), 24) + lshift(self:ReadByte(), 16) + lshift(self:ReadByte(), 8) + self:ReadByte();
+end
+
+function QuestieStreamLib:_ReadInt_raw()
+    local p = self._pointer
+    self._pointer = p + 4
+    local a,b,c,d = stringbyte(self._bin, p, p+3)
+    return a*16777216 + b*65536 + c*256 + d
 end
 
 function QuestieStreamLib:ReadLong()

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -50,7 +50,7 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
             _rawptr = 1,
             _level = 0,
         }
-        end
+    end
     for k,v in pairs(QuestieStreamLib) do -- copy functions to new object
         stream[k] = v
     end

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -196,11 +196,9 @@ function QuestieStreamLib:_WriteByte_raw(e)
 end
 
 function QuestieStreamLib:_ReadByte_raw()
-    local val = stringbyte(self._bin, self._pointer)
-    --print("Read data at " .. self._pointer .. " = " .. val)
-    self._pointer = self._pointer + 1
-    return val
-    --return self:_readByte()
+    local p = self._pointer
+    self._pointer = p + 1
+    return stringbyte(self._bin, p)
 end
 
 -- this is now set in GetStream based on type

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -296,10 +296,9 @@ end
 
 function QuestieStreamLib:_ReadTinyStringBySubstring()
     local length = self:ReadByte()
-    if length == 0 then return "" end
-    local ret = stringsub(self._bin, self._pointer, self._pointer+length-1)
-    self._pointer = self._pointer + length
-    return ret
+    local p = self._pointer
+    self._pointer = p + length
+    return stringsub(self._bin, p, p+length-1)
 end
 
 function QuestieStreamLib:_ReadTinyStringNilBySubstring()

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -72,6 +72,7 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
             stream.ReadShort = QuestieStreamLib._ReadShort_raw
             stream.ReadInt24 = QuestieStreamLib._ReadInt24_raw
             stream.ReadInt = QuestieStreamLib._ReadInt_raw
+            stream.ReadInt12Pair = QuestieStreamLib._ReadInt12Pair_raw
             stream.ReadTinyString = QuestieStreamLib._ReadTinyStringBySubstring
             stream.ReadShortString = QuestieStreamLib._ReadShortStringBySubstring
             stream.ReadTinyStringNil = QuestieStreamLib._ReadTinyStringNilBySubstring
@@ -248,6 +249,14 @@ end
 function QuestieStreamLib:ReadInt12Pair()
     local a = self:ReadByte()
     return self:ReadByte() + lshift(band(a, 15), 8), self:ReadByte() + lshift(band(a, 240), 4)
+end
+
+function QuestieStreamLib:_ReadInt12Pair_raw()
+    local p = self._pointer
+    self._pointer = p + 3
+    local a,b,c = stringbyte(self._bin, p, p+2)
+    local low4bit = a % 16
+    return low4bit * 256 + b, (a - low4bit) * 16 + c
 end
 
 function QuestieStreamLib:ReadInt24()

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -43,16 +43,17 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
     if stream then
         return stream
     else
-        stream = {}
-    end
+        stream = {
+            _pointer = 1,
+            _bin = {},
+            _raw_bin = {},
+            _rawptr = 1,
+            _level = 0,
+        }
+        end
     for k,v in pairs(QuestieStreamLib) do -- copy functions to new object
         stream[k] = v
     end
-    stream._pointer = 1
-    stream._bin = {}
-    stream._raw_bin = {}
-    stream._rawptr = 1
-    stream._level = 0
     stream.reset = function(self)
         self._pointer = 1
         self._bin = {}

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -69,6 +69,7 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
         stream._mode = mode
         if mode == "raw" then
             stream.ReadByte = QuestieStreamLib._ReadByte_raw
+            stream.ReadShort = QuestieStreamLib._ReadShort_raw
             stream.ReadTinyString = QuestieStreamLib._ReadTinyStringBySubstring
             stream.ReadShortString = QuestieStreamLib._ReadShortStringBySubstring
             stream.ReadTinyStringNil = QuestieStreamLib._ReadTinyStringNilBySubstring
@@ -233,6 +234,13 @@ end
 
 function QuestieStreamLib:ReadShort()
     return lshift(self:ReadByte(), 8) + self:ReadByte();
+end
+
+function QuestieStreamLib:_ReadShort_raw()
+    local p = self._pointer
+    self._pointer = p + 2
+    local a,b = stringbyte(self._bin, p, p+1)
+    return a*256 + b
 end
 
 function QuestieStreamLib:ReadInt12Pair()

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -73,9 +73,9 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
             stream.ReadInt24 = QuestieStreamLib._ReadInt24_raw
             stream.ReadInt = QuestieStreamLib._ReadInt_raw
             stream.ReadInt12Pair = QuestieStreamLib._ReadInt12Pair_raw
-            stream.ReadTinyString = QuestieStreamLib._ReadTinyStringBySubstring
-            stream.ReadShortString = QuestieStreamLib._ReadShortStringBySubstring
-            stream.ReadTinyStringNil = QuestieStreamLib._ReadTinyStringNilBySubstring
+            stream.ReadTinyString = QuestieStreamLib._ReadTinyString_raw
+            stream.ReadShortString = QuestieStreamLib._ReadShortString_raw
+            stream.ReadTinyStringNil = QuestieStreamLib._ReadTinyStringNil_raw
             stream._WriteByte = QuestieStreamLib._writeByte
         elseif mode == "1short" then
             stream.ReadByte = QuestieStreamLib._ReadByte_1short
@@ -294,17 +294,22 @@ function QuestieStreamLib:ReadTinyString()
     return stringchar(unpack(ret))
 end
 
-function QuestieStreamLib:_ReadTinyStringBySubstring()
-    local length = self:ReadByte()
+function QuestieStreamLib:_ReadTinyString_raw()
     local p = self._pointer
+    local length = stringbyte(self._bin, p)
+    p = p + 1
     self._pointer = p + length
     return stringsub(self._bin, p, p+length-1)
 end
 
-function QuestieStreamLib:_ReadTinyStringNilBySubstring()
-    local length = self:ReadByte()
-    if length == 0 then return nil end
+function QuestieStreamLib:_ReadTinyStringNil_raw()
     local p = self._pointer
+    local length = stringbyte(self._bin, p)
+    p = p + 1
+    if length == 0 then
+        self._pointer = p
+        return nil
+    end
     self._pointer = p + length
     return stringsub(self._bin, p, p+length-1)
 end
@@ -335,9 +340,11 @@ function QuestieStreamLib:ReadShortString()
     end
 end
 
-function QuestieStreamLib:_ReadShortStringBySubstring()
-    local length = self:ReadShort()
+function QuestieStreamLib:_ReadShortString_raw()
     local p = self._pointer
+    local a,b = stringbyte(self._bin, p, p+1)
+    local length = a*256 + b
+    p = p + 2
     self._pointer = p + length
     return stringsub(self._bin, p, p+length-1)
 end

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -304,9 +304,9 @@ end
 function QuestieStreamLib:_ReadTinyStringNilBySubstring()
     local length = self:ReadByte()
     if length == 0 then return nil end
-    local ret = stringsub(self._bin, self._pointer, self._pointer+length-1)
-    self._pointer = self._pointer + length
-    return ret
+    local p = self._pointer
+    self._pointer = p + length
+    return stringsub(self._bin, p, p+length-1)
 end
 
 function QuestieStreamLib:ReadTinyStringNil()


### PR DESCRIPTION
Reduces lag spikes at login and at accepting, turning in and progressing a quest.
Improves overall performance everywhere database is used.

~~Backports a fix from quest-event-refactor to SmoothReset(). Really an edge case, I doubt it has been visible to player often.~~

~~This PR includes PR #3337 and PR #3338~~