### PR TITLE
[fix] Get next from correct table

### DIFF
--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -257,8 +257,7 @@ function QuestieQuest:SmoothReset()
     end
     QuestieQuest._isResetting = true
     QuestieQuest._resetNeedsAvailables = false
-    QuestieQuest._nextRestQuest = next(QuestiePlayer.currentQuestlog)
-    
+
     -- bit of a hack (there has to be a better way to do logic like this
     QuestieDBMIntegration:ClearAll()
     local stepTable = {
@@ -289,6 +288,7 @@ function QuestieQuest:SmoothReset()
 
             -- draw available quests
             QuestieQuest:GetAllQuestIdsNoObjectives()
+            QuestieQuest._nextRestQuest = next(QuestiePlayer.currentQuestlog)
             return true
         end,
         function()


### PR DESCRIPTION
Backported fix from quest-event-refactor. Really an edge case.