### PR TITLE
[fix] First Tracker update if starting combat middle of it

### DIFF
--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -1813,8 +1813,8 @@ function QuestieTracker:Update()
             end
         end
         _QuestieTracker.IsFirstRun = nil
-        QuestieCombatQueue:Queue(function()
-            C_Timer.After(2.0, function()
+        C_Timer.After(2.0, function()
+            QuestieCombatQueue:Queue(function()
                 QuestieTracker:Update()
             end)
         end)


### PR DESCRIPTION
If player gets into combat during the 2s timer, then QuestieCombatQueue was useless. So start timer first and add into QuestieCombatQueue at end of timer.