### PR TITLE
Fix tooltips to show objectives and quest accept on the same mob

### DIFF
--- a/Modules/QuestieNameplate.lua
+++ b/Modules/QuestieNameplate.lua
@@ -27,7 +27,7 @@ function QuestieNameplate:GetFrame(guid)
 
     local frame = tremove(npUnusedFrames)
 
-    if(not frame) then
+    if (not frame) then
         frame = CreateFrame("Frame")
         npFramesCount = npFramesCount + 1
     end

--- a/Modules/Tooltips/TooltipHandler.lua
+++ b/Modules/Tooltips/TooltipHandler.lua
@@ -29,11 +29,9 @@ function _QuestieTooltips:AddUnitDataToTooltip()
         lastGuid ~= guid
     ) then
         QuestieTooltips.lastGametooltipUnit = name
-        local tooltipData = QuestieTooltips:GetTooltip("m_" .. npcId);
-        if tooltipData then
-            for _, v in pairs (tooltipData) do
-                GameTooltip:AddLine(v)
-            end
+        local tooltipRows = QuestieTooltips:GetTooltip("m_" .. npcId);
+        for i = 0, #tooltipRows do
+            GameTooltip:AddLine(tooltipRows[i])
         end
         QuestieTooltips.lastGametooltipCount = _QuestieTooltips:CountTooltip()
     end


### PR DESCRIPTION
The quests to test this are https://tbc.wowhead.com/quest=443/rot-hide-ichor and https://tbc.wowhead.com/quest=460/resting-in-pieces

Currently only the quest accept line is shown on the mob:

![grafik](https://user-images.githubusercontent.com/33514570/156900507-71792e99-5ab8-4464-bb53-8d19d3fdd22b.png)

but correct is:
![grafik](https://user-images.githubusercontent.com/33514570/156900485-bbbf2fb6-2f3b-4fcb-93d8-80b8ecde7917.png)

Things left todo:

- [ ] Add back comms information to also show the progress of other players