### PR TITLE
NPC Blackmoss the Fetid (3535) does not start quest The Moss-twined Heart (927) directly

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -448,7 +448,7 @@ function QuestieQuestFixes:Load()
             [questKeys.exclusiveTo] = {924}, -- #2195
         },
         [927] = {
-            [questKeys.startedBy] = {{3535},nil,{5179}},
+            [questKeys.startedBy] = {nil,nil,{5179}},
         },
         [930] = {
             [questKeys.preQuestSingle] = {918}, -- #971


### PR DESCRIPTION
The NPC [Blackmoss the Fetid (3535)](https://classic.wowhead.com/npc=3535/blackmoss-the-fetid) does not start the quest [The Moss-twined Heart (927)](https://classic.wowhead.com/quest=927/the-moss-twined-heart) directly, it is only obtainable from the item [Moss-twined Heart (5179)](https://classic.wowhead.com/item=5179/moss-twined-heart) dropped by that same NPC.

I fixed something similar some time ago in Elwynn Forest for the quest [The Collector (123)](https://classic.wowhead.com/quest=123/the-collector) here: https://github.com/Questie/Questie/pull/3237. I realize now that this is a hack that was done in order to get quests obtained from item drops to show on the map.

There are probably a bunch more like this, and honestly those hacks should all be removed from the database, because when we write an addon that uses Questie's database, we get these invalid results. What needs to be done in Questie, if that ain't the case already, is to add or fix some code that will find those quests from item drops, and somehow show them on the map without relying on hacking the database. It would actually be quite useful if it was possible to somehow ask the database if a quest is from a drop rather than an NPC, I could use that information in my addon to determine if a quest is somewhat optional.