### PR TITLE
Fix item 2686 Thunder Ale not showing as quest marker

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -76,6 +76,10 @@ function QuestieItemFixes:Load()
         [2633] = {
             [itemKeys.npcDrops] = {940,941,942}, -- #2433
         },
+        [2686] = {
+            [itemKeys.relatedQuests] = {308},
+            [itemKeys.npcDrops] = {1247,1682,7744},
+        },
         [2837] = {
             [itemKeys.relatedQuests] = {361},
             [itemKeys.npcDrops] = {},

--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -93,7 +93,7 @@ function QuestieItemFixes:Load()
         },
         [2894] = { -- #1285
             [itemKeys.relatedQuests] = {384},
-            [itemKeys.npcDrops] = {1247},
+            [itemKeys.npcDrops] = {1247,1682,7744},
             [itemKeys.objectDrops] = {},
         },
         [2997] = {


### PR DESCRIPTION
Fixes item [Thunder Ale (2686)](https://classic.wowhead.com/item=2686/thunder-ale) not showing as quest marker for quest [Distracting Jarven (308)](https://classic.wowhead.com/quest=308/distracting-jarven).

Also added missing npcDrops for item [Rhapsody Malt (2894)](https://classic.wowhead.com/item=2894/rhapsody-malt) while at it.