### PR TITLE
Fix warrior quest Elanaria

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -819,6 +819,7 @@ function QuestieQuestFixes:Load()
             [questKeys.exclusiveTo] = {1681}, -- #1724
         },
         [1684] = {
+            [questKeys.startedBy] = {{2151,3598,3657},nil,nil},
             [questKeys.exclusiveTo] = {1639,1666,1678,1686,1680},
         },
         [1686] = {


### PR DESCRIPTION
Fix warrior quest [Elanaria (1684)](https://classic.wowhead.com/quest=1684/elanaria)
- startedBy [Moon Priestess Amara (2151)](https://classic.wowhead.com/npc=2151/moon-priestess-amara), [Kyra Windblade (3598)](https://classic.wowhead.com/npc=3598/kyra-windblade) and [Sentinel Elissa Starbreeze (3657)](https://classic.wowhead.com/npc=3657/sentinel-elissa-starbreeze)