### PR TITLE
Fix item Moss-twined Heart (5179) npc drops

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -298,6 +298,9 @@ function QuestieItemFixes:Load()
             [itemKeys.npcDrops] = {},
             [itemKeys.objectDrops] = {},
         },
+        [5179] = {
+            [itemKeys.npcDrops] = {3535}
+        },
         [5184] = {
             [itemKeys.relatedQuests] = {921},
             [itemKeys.npcDrops] = {},


### PR DESCRIPTION
Item [Moss-twined Heart (5179)](https://classic.wowhead.com/item=5179/moss-twined-heart) is dropped by npc [Blackmoss the Fetid (3535)](https://classic.wowhead.com/npc=3535/blackmoss-the-fetid)