### PR TITLE
Fix Gubber Blump can train fishing

### DIFF
--- a/Modules/QuestieMenu.lua
+++ b/Modules/QuestieMenu.lua
@@ -421,6 +421,9 @@ function QuestieMenu:PopulateTownsfolk()
         end
     end
 
+    -- Fix NPC Gubber Blump (10216) can train fishing profession
+    tinsert(professionTrainers[QuestieProfessions.professionKeys.FISHING], 10216)
+
     Questie.db.global.professionTrainers = professionTrainers
 
     if Questie.IsTBC then


### PR DESCRIPTION
Fixes [Gubber Blump (10216)](https://classic.wowhead.com/npc=10216/gubber-blump) can train fishing. He's not a conventional trainer, but one of its gossip is to train fishing when you don't have the profession. He then becomes a vendor after you trained fishing from him.

I am not sure if this is the proper way to fix this, please let me know if you want a different fix.