### PR TITLE
[fix] Improve performance of Database

### DIFF
--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -69,6 +69,7 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
         if mode == "raw" then
             stream.ReadByte = QuestieStreamLib._ReadByte_raw
             stream.ReadShort = QuestieStreamLib._ReadShort_raw
+            stream.ReadInt24 = QuestieStreamLib._ReadInt24_raw
             stream.ReadTinyString = QuestieStreamLib._ReadTinyStringBySubstring
             stream.ReadShortString = QuestieStreamLib._ReadShortStringBySubstring
             stream.ReadTinyStringNil = QuestieStreamLib._ReadTinyStringNilBySubstring
@@ -249,6 +250,13 @@ end
 
 function QuestieStreamLib:ReadInt24()
     return lshift(self:ReadByte(), 16) + lshift(self:ReadByte(), 8) + self:ReadByte();
+end
+
+function QuestieStreamLib:_ReadInt24_raw()
+    local p = self._pointer
+    self._pointer = p + 3
+    local a,b,c = stringbyte(self._bin, p, p+2)
+    return a*65536 + b*256 + c
 end
 
 function QuestieStreamLib:ReadInt()

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -195,11 +195,9 @@ function QuestieStreamLib:_WriteByte_raw(e)
 end
 
 function QuestieStreamLib:_ReadByte_raw()
-    local val = stringbyte(self._bin, self._pointer)
-    --print("Read data at " .. self._pointer .. " = " .. val)
-    self._pointer = self._pointer + 1
-    return val
-    --return self:_readByte()
+    local p = self._pointer
+    self._pointer = p + 1
+    return stringbyte(self._bin, p)
 end
 
 -- this is now set in GetStream based on type

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -68,6 +68,7 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
         stream._mode = mode
         if mode == "raw" then
             stream.ReadByte = QuestieStreamLib._ReadByte_raw
+            stream.ReadShort = QuestieStreamLib._ReadShort_raw
             stream.ReadTinyString = QuestieStreamLib._ReadTinyStringBySubstring
             stream.ReadShortString = QuestieStreamLib._ReadShortStringBySubstring
             stream.ReadTinyStringNil = QuestieStreamLib._ReadTinyStringNilBySubstring
@@ -232,6 +233,13 @@ end
 
 function QuestieStreamLib:ReadShort()
     return lshift(self:ReadByte(), 8) + self:ReadByte();
+end
+
+function QuestieStreamLib:_ReadShort_raw()
+    local p = self._pointer
+    self._pointer = p + 2
+    local a,b = stringbyte(self._bin, p, p+1)
+    return a*256 + b
 end
 
 function QuestieStreamLib:ReadInt12Pair()

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -71,6 +71,7 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
             stream.ReadShort = QuestieStreamLib._ReadShort_raw
             stream.ReadInt24 = QuestieStreamLib._ReadInt24_raw
             stream.ReadInt = QuestieStreamLib._ReadInt_raw
+            stream.ReadInt12Pair = QuestieStreamLib._ReadInt12Pair_raw
             stream.ReadTinyString = QuestieStreamLib._ReadTinyStringBySubstring
             stream.ReadShortString = QuestieStreamLib._ReadShortStringBySubstring
             stream.ReadTinyStringNil = QuestieStreamLib._ReadTinyStringNilBySubstring
@@ -247,6 +248,14 @@ end
 function QuestieStreamLib:ReadInt12Pair()
     local a = self:ReadByte()
     return self:ReadByte() + lshift(band(a, 15), 8), self:ReadByte() + lshift(band(a, 240), 4)
+end
+
+function QuestieStreamLib:_ReadInt12Pair_raw()
+    local p = self._pointer
+    self._pointer = p + 3
+    local a,b,c = stringbyte(self._bin, p, p+2)
+    local low4bit = a % 16
+    return low4bit * 256 + b, (a - low4bit) * 16 + c
 end
 
 function QuestieStreamLib:ReadInt24()

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -70,6 +70,7 @@ function QuestieStreamLib:GetStream(mode) -- returns a new stream
             stream.ReadByte = QuestieStreamLib._ReadByte_raw
             stream.ReadShort = QuestieStreamLib._ReadShort_raw
             stream.ReadInt24 = QuestieStreamLib._ReadInt24_raw
+            stream.ReadInt = QuestieStreamLib._ReadInt_raw
             stream.ReadTinyString = QuestieStreamLib._ReadTinyStringBySubstring
             stream.ReadShortString = QuestieStreamLib._ReadShortStringBySubstring
             stream.ReadTinyStringNil = QuestieStreamLib._ReadTinyStringNilBySubstring
@@ -261,6 +262,13 @@ end
 
 function QuestieStreamLib:ReadInt()
     return lshift(self:ReadByte(), 24) + lshift(self:ReadByte(), 16) + lshift(self:ReadByte(), 8) + self:ReadByte();
+end
+
+function QuestieStreamLib:_ReadInt_raw()
+    local p = self._pointer
+    self._pointer = p + 4
+    local a,b,c,d = stringbyte(self._bin, p, p+3)
+    return a*16777216 + b*65536 + c*256 + d
 end
 
 function QuestieStreamLib:ReadLong()


### PR DESCRIPTION
For stream type "raw", which Questie's database uses:
Don't use expensive `lshift(x, bits)` but `x * 2^bits`
Don't call `:ReadByte()` to extract one byte at time from the string, but use directly `stringbyte(string, start, stop)` to get all bytes by a single string access.
Use a local variable to access `stream._pointer` less times.
Use `return someFunction()` if return value is got from a single function. Lua can optimize this.
