### PR TITLE
Performance Improvements

### DIFF
--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -565,6 +565,7 @@ QuestieDBCompiler.writers = {
     end
 }
 
+-- NOTE: stream:Read*() increment _pointer, so sum Read + _pointer, not _pointer + Read
 QuestieDBCompiler.skippers = {
     ["s8"] = function(stream) stream._pointer = stream._pointer + 1 end,
     ["u8"] = function(stream) stream._pointer = stream._pointer + 1 end,
@@ -605,9 +606,13 @@ QuestieDBCompiler.skippers = {
             stream._pointer = stream:ReadShort() * 3 + stream._pointer
         end
     end,
-    ["trigger"] = function(stream) 
-        stream._pointer = stream:ReadByte() + stream._pointer
-        QuestieDBCompiler.skippers["spawnlist"](stream)
+    ["trigger"] = function(stream)
+        local len = stream:ReadShort()
+        if len > 0 then
+            stream._pointer = stream._pointer - 2
+            stream._pointer = stream:ReadByte() + stream._pointer
+            QuestieDBCompiler.skippers["spawnlist"](stream)
+        end
     end,
     ["questgivers"] = function(stream)
         --local count = stream:ReadByte()
@@ -1151,7 +1156,8 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                     Questie:Error("ERROR: Unhandled db key: " .. key)
                 end
                 for i = lastIndex, targetIndex-1 do
-                    QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
+                    --QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
+                    QuestieDBCompiler.skippers[types[indexToKey[i]]](stream)
                 end
             end
             return QuestieDBCompiler.readers[typ](stream)
@@ -1198,7 +1204,8 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                             Questie:Error("ERROR: Unhandled db key: " .. key)
                         end
                         for i = lastIndex, targetIndex-1 do
-                            QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
+                            --QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
+                            QuestieDBCompiler.skippers[types[indexToKey[i]]](stream)
                         end
                     end
                     local res = QuestieDBCompiler.readers[typ](stream)
@@ -1224,7 +1231,8 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                     Questie:Error("ERROR: Unhandled db key: " .. key)
                 end
                 for i = lastIndex, targetIndex-1 do
-                    QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
+                    --QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
+                    QuestieDBCompiler.skippers[types[indexToKey[i]]](stream)
                 end
             end
             return QuestieDBCompiler.readers[typ](stream)
@@ -1248,7 +1256,8 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                         Questie:Error("ERROR: Unhandled db key: " .. key)
                     end
                     for i = lastIndex, targetIndex-1 do
-                        QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
+                        --QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
+                        QuestieDBCompiler.skippers[types[indexToKey[i]]](stream)
                     end
                 end
                 local res = QuestieDBCompiler.readers[typ](stream)


### PR DESCRIPTION
Enable skippers on varied size data in DB queries

I need to verify still. Now I just copied my old changes from old PR #3336. Other changes are alredy merged to master.