### PR TITLE
Fix item Stormwind Seasoning Herbs (2665)

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -76,6 +76,9 @@ function QuestieItemFixes:Load()
         [2633] = {
             [itemKeys.npcDrops] = {940,941,942}, -- #2433
         },
+        [2665] = {
+            [itemKeys.relatedQuests] = {90},
+        },
         [2686] = {
             [itemKeys.relatedQuests] = {308},
             [itemKeys.npcDrops] = {1247,1682,7744},


### PR DESCRIPTION
Fixes item [Stormwind Seasoning Herbs (2665)](https://classic.wowhead.com/item=2665/stormwind-seasoning-herbs)
- npcDrops [Felicia Gump (1303)](https://classic.wowhead.com/npc=1303/felicia-gump)
- relatedQuests [Seasoned Wolf Kabobs (90)](https://classic.wowhead.com/quest=90/seasoned-wolf-kabobs)