### PR TITLE
Fix item Flagon of Dwarven Honeymead (2594)

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -71,7 +71,9 @@ function QuestieItemFixes:Load()
             [itemKeys.npcDrops] = {},
         },
         [2594] = {
-            [itemKeys.npcDrops] = {1464},
+            [itemKeys.npcDrops] = {},
+            [itemKeys.vendors] = {12794,2832,12785,5140,5611,277,1301,258,5570,1311,5111,1305,1328,5848,955,1697,465,1464,5112},
+            [itemKeys.relatedQuests] = {288},
         },
         [2633] = {
             [itemKeys.npcDrops] = {940,941,942}, -- #2433


### PR DESCRIPTION
The item [Flagon of Dwarven Honeymead (2594)](https://classic.wowhead.com/item=2594/flagon-of-dwarven-honeymead) had an incorrect npc in its `npcDrops` list: [Mikhail (4963)](https://classic.wowhead.com/npc=4963/mikhail) does not sell that item. Now that `vendors` is used in quest objectives, I am fixing that in this PR. Also, the item was missing the `relatedQuests` [The Third Fleet (288)](https://classic.wowhead.com/quest=288/the-third-fleet).