### PR TITLE
Fix error when tracking quests from quest log while quest tracker is disabled

### DIFF
--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -2251,7 +2251,7 @@ end
 
 function QuestieTracker:AQW_Insert(index, expire)
     Questie:Debug(Questie.DEBUG_DEVELOP, "QuestieTracker: AQW_Insert")
-    if QuestieTracker._disableHooks then
+    if (not Questie.db.global.trackerEnabled) or QuestieTracker._disableHooks then
         return
     end
 


### PR DESCRIPTION
When trying to track a quest from the quest log while the quest tracker is disabled, I got this exception:
```
Message: ...ce\AddOns\Questie\Modules\Tracker\QuestieTracker.lua:2284: attempt to index field 'TrackedQuests' (a nil value)
Time: Mon May 16 09:26:51 2022
Count: 1
Stack: ...ce\AddOns\Questie\Modules\Tracker\QuestieTracker.lua:2284: attempt to index field 'TrackedQuests' (a nil value)
[string "=[C]"]: ?
[string "@Interface\AddOns\Questie\Modules\Tracker\QuestieTracker.lua"]:2284: in function `AQW_Insert'
[string "@Interface\AddOns\Questie\Modules\QuestLinks\Hooks.lua"]:30: in function `QuestLogTitleButton_OnClick'
[string "*:OnClick"]:1: in function <[string "*:OnClick"]:1>

Locals: 
```