### PR TITLE
Fix quest Thunderbrew (117) and related items

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -25,7 +25,6 @@ function QuestieItemFixes:Load()
         [1262] = {
             [itemKeys.relatedQuests] = {116,117},
             [itemKeys.npcDrops] = {239},
-            [itemKeys.objectDrops] = {},
         },
         [1524] = {
             [itemKeys.npcDrops] = {667,669,670,672,696,780,781,782,783,784,1059,1061,1062},
@@ -35,18 +34,15 @@ function QuestieItemFixes:Load()
         },
         [1939] = {
             [itemKeys.relatedQuests] = {116},
-            [itemKeys.npcDrops] = {465},
-            [itemKeys.objectDrops] = {},
+            [itemKeys.vendors] = {465},
         },
         [1941] = {
             [itemKeys.relatedQuests] = {116},
-            [itemKeys.npcDrops] = {277},
-            [itemKeys.objectDrops] = {},
+            [itemKeys.vendors] = {277},
         },
         [1942] = {
             [itemKeys.relatedQuests] = {116},
-            [itemKeys.npcDrops] = {274},
-            [itemKeys.objectDrops] = {},
+            [itemKeys.vendors] = {274},
         },
         [2318] = {
             [itemKeys.npcDrops] = {},

--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -82,6 +82,9 @@ function QuestieQuestFixes:Load()
         [109] = {
             [questKeys.startedBy] = {{233,237,240,261,294,963},nil,nil}, --#2158
         },
+        [117] = {
+            [questKeys.name] = "Thunderbrew",
+        },
         [148] = {
             [questKeys.preQuestSingle] = {}, -- #1173
         },


### PR DESCRIPTION
Fix quest [Thunderbrew (117)](https://classic.wowhead.com/quest=117/thunderbrew) which name was incorrect. Also fixed related items to be from vendors rather than npcDrops.

One thing remains thought, the item [Keg of Thunderbrew (1262)](https://classic.wowhead.com/item=1262/keg-of-thunderbrew) is not an npcDrop from [Grimbooze Thunderbrew (239)](https://classic.wowhead.com/npc=239/grimbooze-thunderbrew), but instead a reward from the quest [Thunderbrew (117)](https://classic.wowhead.com/quest=117/thunderbrew). The question is, should that questId be added to the item `questRewards` field (if I understood the purpose), and do we still need the `npcDrops` hack then?