### PR TITLE
[fix] Special objectives vanish at loading screen

### DIFF
--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -186,7 +186,6 @@ function QuestieQuest:ClearAllNotes()
                 s.AlreadySpawned = {}
             end
         end
-        quest.SpecialObjectives = {}
     end
 
     for _, frameList in pairs(QuestieMap.questIdFrames) do


### PR DESCRIPTION
Fixes #3464

`quest.SpecialObjectives` is first initialized in `QuestieDB:GetQuest( )` with static data.
Rest of data is more or less created in `QuestieQuest:PopulateQuestLogInfo( )`
`QuestieQuest:ClearAllNotes()` deletes whole SpecialObjectives table so static data gets never filled back.

Quest completed and abandoned won't delete whole table, only clear AlreadySpawned field of it, which is also done in `QuestieQuest:ClearAllNotes()`. So I would *assume* not-deleting the table won't have side effects.
