### PR TITLE
[fix] Fix tooltips not registering for completed quests on mobs and items

### DIFF
--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -656,7 +656,7 @@ function QuestieQuest:PopulateObjective(quest, objectiveIndex, objective, blockI
 
     local objectiveData = quest.ObjectiveData[objective.Index] or objective -- the reason for "or objective" is to handle "SpecialObjectives" aka non-listed objectives (demonic runestones for closing the portal)
 
-    if (not completed) and (not next(objective.spawnList)) and _QuestieQuest.objectiveSpawnListCallTable[objectiveData.Type] then
+    if (not next(objective.spawnList)) and _QuestieQuest.objectiveSpawnListCallTable[objectiveData.Type] then
         objective.spawnList = _QuestieQuest.objectiveSpawnListCallTable[objectiveData.Type](objective.Id, objective, objectiveData);
     end
 
@@ -717,8 +717,20 @@ end
 
 _RegisterObjectiveTooltips = function(objective, questId, blockItemTooltips)
     Questie:Debug(Questie.DEBUG_INFO, "Registering objective tooltips for", objective.Description)
+
+    if questId == 572 then
+        print("AAA")
+        print(objective.spawnList)
+    end
+    --local objectiveData = quest.ObjectiveData[objective.Index] or objective
+    --objective.spawnList = _QuestieQuest.objectiveSpawnListCallTable[objectiveData.Type](objective.Id, objective, objectiveData);
+
     if objective.spawnList then
         for id, spawnData in pairs(objective.spawnList) do
+            print(id)
+            print(spawnData.TooltipKey)
+            print(objective.AlreadySpawned[id])
+            print(objective.hasRegisteredTooltips)
             if spawnData.TooltipKey and (not objective.AlreadySpawned[id]) and (not objective.hasRegisteredTooltips) then
                 QuestieTooltips:RegisterObjectiveTooltip(questId, spawnData.TooltipKey, objective)
             end
@@ -992,7 +1004,8 @@ function QuestieQuest:PopulateObjectiveNotes(quest) -- this should be renamed to
 
     if quest:IsComplete() == 1 then
         _AddSourceItemObjective(quest)
-        _RegisterAllObjectiveTooltips(quest)
+        --_RegisterAllObjectiveTooltips(quest)
+        _CallPopulateObjective(quest)
 
         QuestieQuest:AddFinisher(quest)
         return

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -718,19 +718,8 @@ end
 _RegisterObjectiveTooltips = function(objective, questId, blockItemTooltips)
     Questie:Debug(Questie.DEBUG_INFO, "Registering objective tooltips for", objective.Description)
 
-    if questId == 572 then
-        print("AAA")
-        print(objective.spawnList)
-    end
-    --local objectiveData = quest.ObjectiveData[objective.Index] or objective
-    --objective.spawnList = _QuestieQuest.objectiveSpawnListCallTable[objectiveData.Type](objective.Id, objective, objectiveData);
-
     if objective.spawnList then
         for id, spawnData in pairs(objective.spawnList) do
-            print(id)
-            print(spawnData.TooltipKey)
-            print(objective.AlreadySpawned[id])
-            print(objective.hasRegisteredTooltips)
             if spawnData.TooltipKey and (not objective.AlreadySpawned[id]) and (not objective.hasRegisteredTooltips) then
                 QuestieTooltips:RegisterObjectiveTooltip(questId, spawnData.TooltipKey, objective)
             end


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

After a reload/login no tooltips on items/mobs are added for complete quests (still in quest log but ready to turn in).
Not sure if there is an open issue for this.

## Proposed changes

- Complete quests will now also register tooltips on mobs and items
- This is the same behaviour for when you complete a quest and don't do a reload

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->
Taken after a /reload

![grafik](https://user-images.githubusercontent.com/33514570/171900176-320ab8d3-b47a-4897-b431-74907f03f145.png)
