### PR TITLE
Fix quest The Missing Diplomat (1267)

### DIFF
--- a/Database/Corrections/Classic/classicNPCFixes.lua
+++ b/Database/Corrections/Classic/classicNPCFixes.lua
@@ -602,6 +602,9 @@ function QuestieNPCFixes:Load()
         [4967] = {
             [npcKeys.spawns] = {[zoneIDs.DUSTWALLOW_MARSH]={{45.2,24.4},{59.6,41.2},{66.4,49.2}}},
         },
+        [4968] = {
+            [npcKeys.spawns] = {[zoneIDs.DUSTWALLOW_MARSH]={{66.27,49.04},{45.22,24.22}}},
+        },
         [4969] = {
             [npcKeys.zoneID] = zoneIDs.STORMWIND_CITY,
             [npcKeys.spawns] = {[zoneIDs.STORMWIND_CITY] = {{69.89,44.9}}},

--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -640,6 +640,9 @@ function QuestieQuestFixes:Load()
         [1265] = {
             [questKeys.triggerEnd] = {"Sentry Point explored",{[zoneIDs.DUSTWALLOW_MARSH]={{59.92,40.9}}}},
         },
+        [1267] = {
+            [questKeys.startedBy] = {{4968},nil,nil},
+        },
         [1268] = {
             [questKeys.startedBy] = {nil,{21015,21016},nil}, -- #1574
         },


### PR DESCRIPTION
Fix quest [The Missing Diplomat (1267)](https://classic.wowhead.com/quest=1267/the-missing-diplomat) that was incorrectly set to start from Archmage Tervosh, but is in fact started and finished by [Lady Jaina Proudmoore (4968)](https://classic.wowhead.com/npc=4968/lady-jaina-proudmoore).

Also added Jaina's spawn nearby Tervosh after you turn-in quest [The Missing Diplomat (1324)](https://classic.wowhead.com/quest=1324/the-missing-diplomat).