### PR TITLE
Fix quest Investigate the Camp (201)

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -103,6 +103,9 @@ function QuestieQuestFixes:Load()
         [172] = {
             [questKeys.zoneOrSort] = sortKeys.SEASONAL,
         },
+        [201] = {
+            [questKeys.triggerEnd] = {"Locate the hunters' camp", {[zoneIDs.STRANGLETHORN_VALE]={{35.65,10.59}}}}
+        },
         [219] = {
             [questKeys.triggerEnd] = {"Escort Corporal Keeshan back to Redridge", {[zoneIDs.REDRIDGE_MOUNTAINS]={{33.36,48.7}}}},
         },


### PR DESCRIPTION
The location of quest [Investigate the Camp (201)](https://classic.wowhead.com/quest=201/investigate-the-camp) contained a wrong location in Westfall, but also the proper location in Stranglethorn Vale was slightly off; it was just a tad outside the camp, making the waypoint arrow points slightly on the side.