### PR TITLE
Fix quest The Tome of Nobility (4485)

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -1360,6 +1360,7 @@ function QuestieQuestFixes:Load()
             [questKeys.preQuestSingle] = {4341},
         },
         [4485] = {
+            [questKeys.startedBy] = {{6179},nil,nil},
             [questKeys.exclusiveTo] = {1661,4486},
         },
         [4486] = {


### PR DESCRIPTION
Fix quest [The Tome of Nobility (4485)](https://classic.wowhead.com/quest=4485/the-tome-of-nobility) which is started by [Tiza Battleforge (6179)](https://classic.wowhead.com/npc=6179/tiza-battleforge) and not Arthur in SW.

FYI, the quest [The Tome of Nobility (1661)](https://classic.wowhead.com/quest=1661/the-tome-of-nobility) did not show up on the map for me, even thought I got a level 40 dwarf paladin that can pick it up. I looked into the DB and didn't see anything wrong, so perhaps something is odd within the code.