### PR TITLE
Fix quest Beginnings (1599)

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -805,7 +805,6 @@ function QuestieQuestFixes:Load()
         },
         [1599] = {
             [questKeys.exclusiveTo] = {1598}, -- #999
-            [questKeys.preQuestSingle] = {705}, -- #1164
         },
         [1638] = {
             [questKeys.exclusiveTo] = {1666,1678,1680,1683,1686},


### PR DESCRIPTION
Fix quest [Beginnings (1599)](https://classic.wowhead.com/quest=1599/beginnings) missing on the map. It was mistaken for quest 1559.