### PR TITLE
Fix quest Distracting Jarven (308)

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -127,12 +127,14 @@ function QuestieQuestFixes:Load()
         [308] = {
             [questKeys.exclusiveTo] = {311}, -- distracting jarven can't be completed once you get the followup
             [questKeys.specialFlags] = 1,
+            [questKeys.preQuestSingle] = {},
+            [questKeys.parentQuest] = 310
         },
         [309] = {
             [questKeys.triggerEnd] = {"Escort Miran to the excavation site", {[zoneIDs.LOCH_MODAN]={{65.12,65.77}}}},
         },
         [310] = {
-            [questKeys.childQuests] = {403},
+            [questKeys.childQuests] = {308,403},
         },
         [353] = {
             [questKeys.preQuestSingle] = {}, -- #2364


### PR DESCRIPTION
Fix quest [Distracting Jarven (308)](https://classic.wowhead.com/quest=308/distracting-jarven) which actually does not require [Guarded Thunderbrew Barrel (403)](https://classic.wowhead.com/quest=403/guarded-thunderbrew-barrel) to be completed. 

Both these quests are actually child quests of [Bitter Rivals (310)](https://classic.wowhead.com/quest=310/bitter-rivals); they can only be done while you have that quest in your quest log. Once [Bitter Rivals (310)](https://classic.wowhead.com/quest=310/bitter-rivals) has been turned-in (when you pick up the barrel and take the follow-up quest), [Distracting Jarven (308)](https://classic.wowhead.com/quest=308/distracting-jarven) and [Guarded Thunderbrew Barrel (403)](https://classic.wowhead.com/quest=403/guarded-thunderbrew-barrel) both become unavailable.