### PR TITLE
Fix item Heartswood (6912)

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -411,6 +411,11 @@ function QuestieItemFixes:Load()
         [6522] = {
             [itemKeys.objectDrops] = {},
         },
+        [6912] = {
+            [itemKeys.npcDrops] = {},
+            [itemKeys.objectDrops] = {93192},
+            [itemKeys.relatedQuests] = {1738}
+        },
         [6992] = {
             [itemKeys.npcDrops] = {},
         },

--- a/Database/Corrections/Classic/classicObjectFixes.lua
+++ b/Database/Corrections/Classic/classicObjectFixes.lua
@@ -73,6 +73,9 @@ function QuestieObjectFixes:Load()
             },
             [objectKeys.zoneID] = zoneIDs.THOUSAND_NEEDLES,
         },
+        [93192] = {
+            [objectKeys.spawns] = {[zoneIDs.ASHENVALE]={{31.55,31.57}}},
+        },
         [103662] = {
             [objectKeys.spawns] = {[zoneIDs.ARATHI_HIGHLANDS]={{52,50.8}}},
             [objectKeys.zoneID] = zoneIDs.ARATHI_HIGHLANDS,


### PR DESCRIPTION
Fix item [Heartswood (6912)](https://classic.wowhead.com/item=6912/heartswood) that is not an NPC drop, but actually a drop from the [Heartswood (93192)](https://classic.wowhead.com/object=93192/heartswood) object in Ashenvale. Also slight fix to Heartswood object coordinates to be more precise.