### PR TITLE
Fix item Ring of Zoram (5445)

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -321,6 +321,10 @@ function QuestieItemFixes:Load()
             [itemKeys.npcDrops] = {},
             [itemKeys.objectDrops] = {},
         },
+        [5445] = {
+            [itemKeys.npcDrops] = {3943,10559},
+            [itemKeys.relatedQuests] = {1009},
+        },
         [5455] = {
             [itemKeys.relatedQuests] = {1016},
             [itemKeys.npcDrops] = {},


### PR DESCRIPTION
To my surprise, I just got [Ring of Zoram (5445)](https://classic.wowhead.com/item=5445/ring-of-zoram) dropping for me by NPC [Lady Vespia (10559)](https://classic.wowhead.com/npc=10559/lady-vespia). Also added missing related quest [Ruuzel (1009)](https://classic.wowhead.com/quest=1009/ruuzel).