### PR TITLE
Fix quest Summon Felsteed (4490)

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -1373,6 +1373,9 @@ function QuestieQuestFixes:Load()
         [4486] = {
             [questKeys.exclusiveTo] = {1661,4485},
         },
+        [4490] = {
+            [questKeys.preQuestSingle] = {3631,4487,4488,4489},
+        },
         [4491] = {
             [questKeys.triggerEnd] = {"Escort Ringo to Spraggle Frock at Marshal's Refuge", {[zoneIDs.UN_GORO_CRATER]={{43.71,8.29}}}},
         },


### PR DESCRIPTION
Fix quest [Summon Felsteed (4490)](https://classic.wowhead.com/quest=4490/summon-felsteed) that requires one of the prequest to be completed before we can pick it up.