### PR TITLE
Fix item Lesser Invisibility Potion (3823)

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -184,6 +184,9 @@ function QuestieItemFixes:Load()
             [itemKeys.relatedQuests] = {713,1193},
             [itemKeys.npcDrops] = {},
         },
+        [3823] = {
+            [itemKeys.relatedQuests] = {715}
+        },
         [3864] = {
             [itemKeys.npcDrops] = {},
         },


### PR DESCRIPTION
Fix item [Lesser Invisibility Potion (3823)](https://classic.wowhead.com/item=3823/lesser-invisibility-potion) missing related quest [Liquid Stone (715)](https://classic.wowhead.com/quest=715/liquid-stone).