### PR TITLE
Fix item Gyrochronatom (4389)

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -220,6 +220,12 @@ function QuestieItemFixes:Load()
             [itemKeys.vendors] = {1448,6777,2685,11185,14637,5519,5175,3413,3133,3495,8679,1694,2687,4587,8678,6730,9544,2682,2683,2684,2688,9676},
             [itemKeys.relatedQuests] = {174,2609},
         },
+        [4389] = {
+            [itemKeys.npcDrops] = {}, -- Kept empty to not confuse users doing quest #714
+            [itemKeys.itemDrops] = {6357},
+            [itemKeys.vendors] = {5175,2687,8679,5519,9544,3495,2684,4587,8678,6777,3133,1694,6730,2682,2685,3413,1448,2683,11185,14637},
+            [itemKeys.relatedQuests] = {714}
+        },
         [4502] = {
             [itemKeys.relatedQuests] = {669},
             [itemKeys.npcDrops] = {},


### PR DESCRIPTION
Fix item [Gyrochronatom (4389)](https://classic.wowhead.com/item=4389/gyrochronatom) missing just about all information about it.