### PR TITLE
Fix item Battered Junkbox (16882) causing stack overflow

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -908,6 +908,9 @@ function QuestieItemFixes:Load()
             [itemKeys.npcDrops] = {},
             [itemKeys.objectDrops] = {},
         },
+        [16882] = {
+            [itemKeys.itemDrops] = {}
+        },
         [16967] = {
             [itemKeys.relatedQuests] = {6607},
             [itemKeys.npcDrops] = {},


### PR DESCRIPTION
Fix item [Battered Junkbox (16882)](https://classic.wowhead.com/item=16882/battered-junkbox) causing stack overflow, because it contained itself.