### PR TITLE
Fix quest Fragments of the Orb of Orahil (1799)

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -900,6 +900,9 @@ function QuestieQuestFixes:Load()
         [1794] = {
             [questKeys.exclusiveTo] = {1649},
         },
+        [1799] = {
+            [questKeys.preQuestSingle] = {4965,4967,4968,4969},
+        },
         [1800] = {
             [questKeys.triggerEnd] = {"Go to the old Lordaeron Throne Room that lies just before descending into the Undercity.", {[zoneIDs.UNDERCITY]={{65.97,36.12}}}},
             [questKeys.zoneOrSort] = sortKeys.SEASONAL,


### PR DESCRIPTION
Fix quest [Fragments of the Orb of Orahil (1799)](https://classic.wowhead.com/quest=1799/fragments-of-the-orb-of-orahil) which requires one of the "Knowledge of the Orb of Orahil" prequest to be completed before it can be picked up.