### PR TITLE
Fix Minimap icon to also show version for alpha/beta builds

### DIFF
--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -330,7 +330,10 @@ end
 
 local cachedTitle
 local cachedVersion
--- Move to Questie.lua after QuestieOptions move.
+
+---Returns the build version information set in the specific TOC file.
+---For example v7.0.0-alpha.0 will be split into 7, 0, 0, alpha, 0
+---@return number, number, number, string, number
 function QuestieLib:GetAddonVersionInfo()
     if (not cachedTitle) or (not cachedVersion) then
         local name, title = GetAddOnInfo("Questie")
@@ -339,36 +342,27 @@ function QuestieLib:GetAddonVersionInfo()
     end
 
     -- %d = digit, %p = punctuation character, %x = hexadecimal digits.
-    local major, minor, patch = string.match(cachedVersion, "(%d+)%p(%d+)%p(%d+)")
-    local hash = "nil"
+    local major, minor, patch, buildType, buildVersion = string.match(cachedVersion, "(%d+)%p(%d+)%p(%d+)-(alpha|beta)%p(%d+)")
 
-    local buildType
-
-    if string.match(cachedTitle, "ALPHA") then
-        buildType = "ALPHA"
-    elseif string.match(cachedTitle, "BETA") then
-        buildType = "BETA"
-    end
-
-    return tonumber(major), tonumber(minor), tonumber(patch), tostring(hash), tostring(buildType)
+    return tonumber(major), tonumber(minor), tonumber(patch), tostring(buildType), tonumber(buildVersion)
 end
 
 function QuestieLib:GetAddonVersionString()
-    local major, minor, patch, buildType, hash = QuestieLib:GetAddonVersionInfo()
+    local major, minor, patch, buildType, buildVersion = QuestieLib:GetAddonVersionInfo()
 
     if buildType and buildType ~= "nil" then
-        buildType = " - " .. buildType
+        buildType = "-" .. buildType
     else
         buildType = ""
     end
 
-    if hash and hash ~= "nil" then
-        hash = "-" .. hash
+    if buildVersion then
+        buildVersion = "." .. buildVersion
     else
-        hash = ""
+        buildVersion = ""
     end
 
-    return "v" .. tostring(major) .. "." .. tostring(minor) .. "." .. tostring(patch) .. hash .. buildType
+    return "v" .. major .. "." .. minor .. "." .. patch .. buildType .. buildVersion
 end
 
 function QuestieLib:Count(table) -- according to stack overflow, # and table.getn arent reliable (I've experienced this? not sure whats up)

--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -341,10 +341,17 @@ function QuestieLib:GetAddonVersionInfo()
         cachedVersion = GetAddOnMetadata(name, "Version")
     end
 
-    -- %d = digit, %p = punctuation character, %x = hexadecimal digits.
-    local major, minor, patch, buildType, buildVersion = string.match(cachedVersion, "(%d+)%p(%d+)%p(%d+)-(alpha|beta)%p(%d+)")
+    local major, minor, patch, alphaBuild, betaBuild, buildVersion
 
-    return tonumber(major), tonumber(minor), tonumber(patch), tostring(buildType), tonumber(buildVersion)
+    major, minor, patch, alphaBuild, buildVersion = string.match(cachedVersion, "(%d+)%p(%d+)%p(%d+)-(alpha)%p(%d+)")
+    if (not major) then -- no alpha build
+        major, minor, patch, betaBuild, buildVersion = string.match(cachedVersion, "(%d+)%p(%d+)%p(%d+)-(beta)%p(%d+)")
+    end
+    if (not major) then -- no beta build
+        major, minor, patch = string.match(cachedVersion, "(%d+)%p(%d+)%p(%d+)")
+    end
+
+    return tonumber(major), tonumber(minor), tonumber(patch), tostring(alphaBuild or betaBuild), tonumber(buildVersion)
 end
 
 function QuestieLib:GetAddonVersionString()


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->


## Proposed changes

- The Minimap icon should now show "Questie v7.0.0-alpha.0" and not just "Questie v7.0.0"

NEEDS TO BE TESTED FIRST

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->