### PR TITLE
Test datatype overflows at DB compile while debug on.

### DIFF
--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -827,7 +827,7 @@ function QuestieDBCompiler:CompileTableCoroutine(tbl, types, order, lookup, data
     QuestieDBCompiler.index = 0
 
     QuestieDBCompiler.pointerMap = {}
-    QuestieDBCompiler.stream = QuestieStream:GetStream("raw")
+    QuestieDBCompiler.stream = Questie.db.global.debugEnabled and QuestieStream:GetStream("raw_assert") or QuestieStream:GetStream("raw")
 
     while true do
         coroutine.yield()
@@ -836,10 +836,11 @@ function QuestieDBCompiler:CompileTableCoroutine(tbl, types, order, lookup, data
             if QuestieDBCompiler.index == count then
                 Questie.db.global[databaseKey.."Bin"] = QuestieDBCompiler.stream:Save()
                 Questie.db.global[databaseKey.."Ptrs"] = QuestieDBCompiler:EncodePointerMap(QuestieDBCompiler.stream, QuestieDBCompiler.pointerMap)
+                QuestieDBCompiler.stream:finished() -- relief memory pressure
                 return
             end
             local id = indexLookup[QuestieDBCompiler.index]
-            
+
             QuestieDBCompiler.currentEntry = id
             local entry = tbl[id]
 
@@ -902,7 +903,7 @@ function QuestieDBCompiler:Compile()
     if QuestieDBCompiler._isCompiling then
         return
     end
-    
+
     QuestieDBCompiler._isCompiling = true -- some unknown addon that is popular in china causes player_logged_in event to fire many times which triggers db compile multiple times
 
     QuestieDBCompiler.startTime = GetTime()
@@ -972,7 +973,8 @@ function QuestieDBCompiler:ValidateNPCs()
         end
     end
 
-    Questie:Debug(Questie.DEBUG_DEVELOP, "Finished NPC validation without issues!")
+    validator.stream:finished()
+    Questie:Debug(Questie.DEBUG_INFO, "Finished NPCs validation without issues!")
 end
 
 function QuestieDBCompiler:ValidateObjects()
@@ -1008,7 +1010,8 @@ function QuestieDBCompiler:ValidateObjects()
         end
     end
 
-    Questie:Debug(Questie.DEBUG_DEVELOP, "Finished validation without issues!")
+    validator.stream:finished()
+    Questie:Debug(Questie.DEBUG_INFO, "Finished objects validation without issues!")
 end
 
 
@@ -1024,6 +1027,7 @@ function QuestieDBCompiler:ValidateItems()
             for _, oid in pairs(objDrops) do
                 if not obj.QuerySingle(oid, "name") then
                     Questie:Error("Missing object " .. tostring(oid) .. " that drops " .. (validator.QuerySingle(id, "name") or "Missing item name!") .. " " .. tostring(id))
+                    return
                 end
             end
         end
@@ -1033,6 +1037,7 @@ function QuestieDBCompiler:ValidateItems()
                 --print("Validating npcs")
                 if not npc.QuerySingle(nid, "name") then
                     Questie:Error("Missing npc " .. tostring(nid))
+                    return
                 end
             end
         end
@@ -1067,7 +1072,10 @@ function QuestieDBCompiler:ValidateItems()
         --end
     end
 
-    Questie:Debug(Questie.DEBUG_DEVELOP, "Finished Item validation without issues!")
+    validator.stream:finished()
+    obj.stream:finished()
+    npc.stream:finished()
+    Questie:Debug(Questie.DEBUG_INFO, "Finished items validation without issues!")
 end
 
 function QuestieDBCompiler:ValidateQuests()
@@ -1103,7 +1111,8 @@ function QuestieDBCompiler:ValidateQuests()
         end
     end
 
-    Questie:Debug(Questie.DEBUG_DEVELOP, "Finished Quest validation without issues!")
+    validator.stream:finished()
+    Questie:Debug(Questie.DEBUG_INFO, "Finished quests validation without issues!")
 end
 
 function QuestieDBCompiler:Initialize()
@@ -1172,6 +1181,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
     --Questie.db.global.__pointers = pointers
     coroutine.yield()
     stream:Load(data)
+    handle.stream = stream
 
     if overrides then
         handle.QuerySingle = function(id, key)

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -138,7 +138,7 @@ end
 function QuestieStreamLib:_writeByte_assert(val)
     assert(type(val) == "number", "Not a number")
     assert(val >= 0, "Underflow")
-    assert(val <= 255, "Overflow")
+    assert(val <= 255, "Overflow") -- 8 bits
     self:_writeByte(val)
 end
 
@@ -394,7 +394,7 @@ end
 function QuestieStreamLib:_WriteShort_assert(val)
     assert(type(val) == "number", "Not a number")
     assert(val >= 0, "Underflow")
-    assert(val <= 65535, "Overflow")
+    assert(val <= 65535, "Overflow") -- 16 bits
     self:_WriteShort(val)
 end
 
@@ -408,7 +408,7 @@ end
 function QuestieStreamLib:_WriteInt_assert(val)
     assert(type(val) == "number", "Not a number")
     assert(val >= 0, "Underflow")
-    assert(val <= 4294967295, "Overflow")
+    assert(val <= 4294967295, "Overflow") -- 32 bits
     self:_WriteInt(val)
 end
 
@@ -422,7 +422,7 @@ end
 function QuestieStreamLib:_WriteInt24_assert(val)
     assert(type(val) == "number", "Not a number")
     assert(val >= 0, "Underflow")
-    assert(val <= 16777215, "Overflow")
+    assert(val <= 16777215, "Overflow") -- 24 bits
     self:_WriteInt24(val)
 end
 
@@ -435,11 +435,11 @@ end
 function QuestieStreamLib:_WriteInt12Pair_assert(val1, val2)
     assert(type(val1) == "number", "Not a number")
     assert(val1 >= 0, "Underflow")
-    assert(val1 <= 4095, "Overflow")
+    assert(val1 <= 4095, "Overflow") -- 12 bits
 
     assert(type(val2) == "number", "Not a number")
     assert(val2 >= 0, "Underflow")
-    assert(val2 <= 4095, "Overflow")
+    assert(val2 <= 4095, "Overflow") -- 12 bits
 
     self:_WriteInt12Pair(val1, val2)
 end
@@ -458,7 +458,7 @@ end
 function QuestieStreamLib:_WriteLong_assert(val)
     assert(type(val) == "number", "Not a number")
     assert(val >= 0, "Underflow")
-    assert(val <= 18446744073709551615, "Overflow")
+    assert(val <= 18446744073709551615, "Overflow") -- 64 bits
 
     self:_WriteLong(val)
 end

--- a/cli.lua
+++ b/cli.lua
@@ -156,6 +156,7 @@ local function _CheckClassicDatabase()
 
     local QuestieDBCompiler = QuestieLoader:ImportModule("DBCompiler")
 
+    Questie.db.global.debugEnabled = true
     QuestieDBCompiler:Compile(function() end)
     print("\n\27[36mValidating objects...\27[0m")
     QuestieDBCompiler:ValidateObjects()
@@ -224,6 +225,7 @@ local function _CheckTBCDatabase()
 
     local QuestieDBCompiler = QuestieLoader:ImportModule("DBCompiler")
 
+    Questie.db.global.debugEnabled = true
     QuestieDBCompiler:Compile(function() end)
     print("\n\27[36mValidating objects...\27[0m")
     QuestieDBCompiler:ValidateObjects()


### PR DESCRIPTION
Add "raw_assert" mode to test overflows while writing into a raw stream.
This mode is active for DB compile while Questie debug mode is on.
Also:
* Kind of require defining decoding mode to QuestieStream.
* Check mode is correct when using recycled stream.
