### PR TITLE
Add extra objectives to quest Defenders of Darrowshire (5211)

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -1577,6 +1577,7 @@ function QuestieQuestFixes:Load()
         },
         [5211] = {
             [questKeys.preQuestSingle] = {}, -- #983
+            [questKeys.extraObjectives] = {{nil, ICON_TYPE_SLAY, l10n("Slay ghouls to free Darrowshire spirits"), 0, {{"monster", 8530}, {"monster", 8531}, {"monster", 8532}}}},
         },
         [5214] = {
             [questKeys.name] = "The Great Ezra Grimm",

--- a/Localization/Translations/ExtraObjectives/ClassicObjectives.lua
+++ b/Localization/Translations/ExtraObjectives/ClassicObjectives.lua
@@ -110,6 +110,18 @@ local classicObjectiveLocales = {
         ["zhTW"] = false,
         ["zhCN"] = false,
     },
+    ["Slay ghouls to free Darrowshire spirits"] = { -- 5211
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["deDE"] = false,
+        ["koKR"] = false,
+        ["esMX"] = false,
+        ["enUS"] = true,
+        ["frFR"] = false,
+        ["esES"] = false,
+        ["zhTW"] = false,
+        ["zhCN"] = false,
+    },
 }
 
 for k, v in pairs(classicObjectiveLocales) do


### PR DESCRIPTION
Added extra objectives to quest [Defenders of Darrowshire (5211)](https://classic.wowhead.com/quest=5211/defenders-of-darrowshire) so that the ghouls that need to be killed in order to free Darrowshire spirits do appear on the map.