### PR TITLE
[fix] Improve Database performance (sort ids)

### DIFF
--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -819,11 +819,23 @@ end
 function QuestieDBCompiler:CompileTableCoroutine(tbl, types, order, lookup, databaseKey, kind, entriesPerTick)
     local count = 0
     local indexLookup = {};
+
+    local max_id = 0
     for id in pairs(tbl) do
-        count = count + 1
-        indexLookup[count] = id
+        assert(type(id) == "number", "CompileTableCoroutine: tbl id is not a number")
+        if id > max_id then
+            max_id = id
+        end
+    end
+    -- iterate table tbl in numerical order to get ids in order to indexLoopup list. iterating over pairs(tbl) gives ids in non determined order
+    for id=0,max_id do
+        if tbl[id] then
+            count = count + 1
+            indexLookup[count] = id
+        end
     end
     count = count + 1
+
     QuestieDBCompiler.index = 0
 
     QuestieDBCompiler.pointerMap = {}


### PR DESCRIPTION
Databases were saved in randomish id order into database string. This PR keeps ids in sorted order.
Sorted order hopefully keeps memoryaccess more prefetchable.

This seemt to cut about 10ms from Questie cpu usage during login and map population.

Most likely slight regression to database compile. I didn't try to measure.