### PR TITLE
Improve database performance, fix possible DB query error

### DIFF
--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -1223,10 +1223,12 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
             --end
             local ptr = pointers[id]
             local override = overrides[id]
+            local keys = {...}
             if ptr == nil then
                 if override then
                     local ret = {}
-                    for index,key in pairs({...}) do
+                    for index=1,#keys do
+                        local key = keys[index]
                         local rootIndex = keyToRootIndex[key]
                         if rootIndex and override[rootIndex] ~= nil then
                             ret[index] = override[rootIndex]
@@ -1237,7 +1239,8 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                 return nil
             end
             local ret = {}
-            for index,key in pairs({...}) do
+            for index=1,#keys do
+                local key = keys[index]
                 local rootIndex = keyToRootIndex[key]
                 if override and rootIndex and override[rootIndex] ~= nil then
                     ret[index] = override[rootIndex]
@@ -1290,8 +1293,10 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                 --print("Entry not found! " .. id)
                 return nil
             end
+            local keys = {...}
             local ret = {}
-            for index,key in pairs({...}) do
+            for index=1,#keys do
+                local key = keys[index]
                 local typ = types[key]
                 if map[key] ~= nil then -- can skip directly
                     stream._pointer = map[key] + ptr

--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -1203,6 +1203,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                 local targetIndex = keyToIndex[key]
                 if targetIndex == nil then
                     Questie:Error("ERROR: Unhandled db key: " .. key)
+                    return nil
                 end
                 for i = lastIndex, targetIndex-1 do
                     QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
@@ -1228,8 +1229,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                 if override then
                     local ret = {}
                     for index=1,#keys do
-                        local key = keys[index]
-                        local rootIndex = keyToRootIndex[key]
+                        local rootIndex = keyToRootIndex[keys[index]]
                         if rootIndex and override[rootIndex] ~= nil then
                             ret[index] = override[rootIndex]
                         end
@@ -1253,13 +1253,13 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                         local targetIndex = keyToIndex[key]
                         if targetIndex == nil then
                             Questie:Error("ERROR: Unhandled db key: " .. key)
+                            return nil
                         end
                         for i = lastIndex, targetIndex-1 do
                             QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
                         end
                     end
-                    local res = QuestieDBCompiler.readers[typ](stream)
-                    ret[index] = res
+                    ret[index] = QuestieDBCompiler.readers[typ](stream)
                 end
             end
             return ret--unpack(ret)
@@ -1279,6 +1279,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                 local targetIndex = keyToIndex[key]
                 if targetIndex == nil then
                     Questie:Error("ERROR: Unhandled db key: " .. key)
+                    return nil
                 end
                 for i = lastIndex, targetIndex-1 do
                     QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
@@ -1305,13 +1306,13 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                     local targetIndex = keyToIndex[key]
                     if targetIndex == nil then
                         Questie:Error("ERROR: Unhandled db key: " .. key)
+                        return nil
                     end
                     for i = lastIndex, targetIndex-1 do
                         QuestieDBCompiler.readers[types[indexToKey[i]]](stream)
                     end
                 end
-                local res = QuestieDBCompiler.readers[typ](stream)
-                ret[index] = res
+                ret[index] = QuestieDBCompiler.readers[typ](stream)
             end
             return ret--unpack(ret)
         end

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -1334,6 +1334,7 @@ function QuestieQuest:CalculateAndDrawAvailableQuestsIterative(callback)
                 end
             else
                 timer:Cancel()
+                -- UpdateAddOnCPUUsage(); print("Questie CPU usage:", GetAddOnCPUUsage("Questie")) -- Do not remove even commented out. Useful for performance testing.
                 if callback ~= nil then
                     callback()
                 end


### PR DESCRIPTION
I measured 8-10ms less cpu used by Questie once available Quests are populated. (488ms -> 477ms-480ms)

Also adds `return nil` after error prints. Without these code runs to lua error, which is catched.

Please merge so that every commit ends up as an individual commit to master.