### PR TITLE
[fix] Remove unnecessary timer from questie init.

### DIFF
--- a/Modules/QuestieEventHandler.lua
+++ b/Modules/QuestieEventHandler.lua
@@ -42,28 +42,7 @@ local questCompletedMessage  = string.gsub(ERR_QUEST_COMPLETE_S , "(%%s)", "(.+)
 
 
 function QuestieEventHandler:RegisterEarlyEvents()
-    local savedVarsTimer
-    Questie:RegisterEvent("PLAYER_LOGIN", function()
-        MinimapIcon:Init() -- This needs to happen outside of a Timer
-
-        local maxTickerRuns = 50 -- 50 * 0.1 seconds = 5 seconds
-        local tickCounter = 0
-
-        savedVarsTimer = C_Timer.NewTicker(0.1, function()
-            tickCounter = tickCounter + 1
-            if (not QuestieConfig) then
-                -- The Saved Variables are not loaded yet
-                if tickCounter == (maxTickerRuns - 1) then
-                    -- The time is over, must be a fresh install
-                    _EventHandler:PlayerLogin()
-                end
-                return
-            end
-
-            savedVarsTimer:Cancel()
-            _EventHandler:PlayerLogin()
-        end, maxTickerRuns)
-    end)
+    Questie:RegisterEvent("PLAYER_LOGIN", _EventHandler.PlayerLogin)
 end
 
 function QuestieEventHandler:RegisterLateEvents()
@@ -117,11 +96,18 @@ function QuestieEventHandler:RegisterLateEvents()
             end
         end
     end)
-
-    Questie:ContinueInit() -- continue startup inside Questie.lua
 end
 
 function _EventHandler:PlayerLogin()
+    -- Check config exists
+    if not Questie.db or not QuestieConfig then
+        -- Did you move Questie.db = LibStub("AceDB-3.0"):New("QuestieConfig",.......) out of Questie:OnInitialize() ?
+        Questie:Error("Config DB from saved variables is not loaded and initialized. Please report this issue on Questie github or discord.")
+        error("Config DB from saved variables is not loaded and initialized. Please report this issue on Questie github or discord.")
+        return
+    end
+
+    -- Start real Questie init
     QuestieInit:Init()
 end
 

--- a/Modules/QuestieInit.lua
+++ b/Modules/QuestieInit.lua
@@ -1,6 +1,6 @@
 ---@class QuestieInit
 local QuestieInit = QuestieLoader:CreateModule("QuestieInit")
-local _QuestieInit = {}
+local _QuestieInit = QuestieInit.private
 
 ---@type QuestEventHandler
 local QuestEventHandler = QuestieLoader:ImportModule("QuestEventHandler")
@@ -52,6 +52,24 @@ local QuestieShutUp = QuestieLoader:ImportModule("QuestieShutUp")
 local Hooks = QuestieLoader:ImportModule("Hooks")
 ---@type QuestieValidateGameCache
 local QuestieValidateGameCache = QuestieLoader:ImportModule("QuestieValidateGameCache")
+---@type MinimapIcon
+local MinimapIcon = QuestieLoader:ImportModule("MinimapIcon")
+---@type QuestieComms
+local QuestieComms = QuestieLoader:ImportModule("QuestieComms");
+---@type QuestieOptions
+local QuestieOptions = QuestieLoader:ImportModule("QuestieOptions");
+---@type QuestieCoords
+local QuestieCoords = QuestieLoader:ImportModule("QuestieCoords");
+---@type QuestieTooltips
+local QuestieTooltips = QuestieLoader:ImportModule("QuestieTooltips");
+---@type QuestieDBMIntegration
+local QuestieDBMIntegration = QuestieLoader:ImportModule("QuestieDBMIntegration");
+---@type QuestieQuestTimers
+local QuestieQuestTimers = QuestieLoader:ImportModule("QuestieQuestTimers")
+---@type QuestieCombatQueue
+local QuestieCombatQueue = QuestieLoader:ImportModule("QuestieCombatQueue")
+---@type QuestieSlash
+local QuestieSlash = QuestieLoader:ImportModule("QuestieSlash")
 
 
 
@@ -62,6 +80,10 @@ local QuestieValidateGameCache = QuestieLoader:ImportModule("QuestieValidateGame
 QuestieInit.Stages = {}
 
 QuestieInit.Stages[1] = function() -- run as a coroutine
+    Questie:Debug(Questie.DEBUG_CRITICAL, "[QuestieInit:Stage1] Starting the real init.")
+
+    MinimapIcon:Init()
+
     HBDHooks:Init()
 
     QuestieFramePool:SetIcons()
@@ -74,8 +96,6 @@ QuestieInit.Stages[1] = function() -- run as a coroutine
     end
 
     QuestieShutUp:ToggleFilters(Questie.db.global.questieShutUp)
-
-    Questie:Debug(Questie.DEBUG_CRITICAL, "[Questie:OnInitialize] Questie addon loaded")
 
     coroutine.yield()
     ZoneDB:Initialize()
@@ -140,8 +160,60 @@ QuestieInit.Stages[2] = function() -- not a coroutine
 end
 
 QuestieInit.Stages[3] = function() -- run as a coroutine
+    Questie:Debug(Questie.DEBUG_INFO, "[QuestieInit:Stage3] Stage 3 start.")
+
     -- register events that rely on questie being initialized
     QuestieEventHandler:RegisterLateEvents()
+
+    -- ** OLD ** Questie:ContinueInit() ** START **
+    QuestieTooltips:Initialize()
+    QuestieCoords:Initialize()
+    QuestieQuestTimers:Initialize()
+    QuestieCombatQueue:Initialize()
+    QuestieComms:Initialize()
+
+    QuestieSlash.RegisterSlashCommands()
+
+    QuestieOptions:Initialize()
+
+    --Initialize the DB settings.
+    Questie:Debug(Questie.DEBUG_DEVELOP, l10n("Setting clustering value, clusterLevelHotzone set to %s : Redrawing!", Questie.db.global.clusterLevelHotzone))
+
+
+    -- Update the default text on the map show/hide button for localization
+    if Questie.db.char.enabled then
+        Questie_Toggle:SetText(l10n("Hide Questie"));
+    else
+        Questie_Toggle:SetText(l10n("Show Questie"));
+    end
+
+    -- Update status of Map button on hide between play sessions
+    if Questie.db.global.mapShowHideEnabled then
+        Questie_Toggle:Show();
+    else
+        Questie_Toggle:Hide();
+    end
+
+    -- Change position of Map button when continent dropdown is hidden
+    C_Timer.After(1, function()
+        if not WorldMapContinentDropDown:IsShown() then
+            Questie_Toggle:ClearAllPoints();
+            if AtlasToggleFromWorldMap and AtlasToggleFromWorldMap:IsShown() then -- #1498
+                AtlasToggleFromWorldMap:SetScript("OnHide", function() Questie_Toggle:SetPoint('RIGHT', WorldMapFrameCloseButton, 'LEFT', 0, 0) end)
+                AtlasToggleFromWorldMap:SetScript("OnShow", function() Questie_Toggle:SetPoint('RIGHT', AtlasToggleFromWorldMap, 'LEFT', 0, 0) end)
+                Questie_Toggle:SetPoint('RIGHT', AtlasToggleFromWorldMap, 'LEFT', 0, 0);
+            else
+                Questie_Toggle:SetPoint('RIGHT', WorldMapFrameCloseButton, 'LEFT', 0, 0);
+            end
+        end
+    end)
+
+    if Questie.db.global.dbmHUDEnable then
+        QuestieDBMIntegration:EnableHUD()
+    end
+    -- ** OLD ** Questie:ContinueInit() ** END **
+
+
     QuestEventHandler:RegisterEvents()
     ChatFilter:RegisterEvents()
     coroutine.yield()
@@ -208,6 +280,8 @@ QuestieInit.Stages[3] = function() -- run as a coroutine
             Questie.db.char.lastDailyRequestResetTime = GetQuestResetTime();
         end
     end
+
+    Questie:Debug(Questie.DEBUG_INFO, "[QuestieInit:Stage3] Questie init done.")
 end
 
 -- End of QuestieInit.Stages ******************************************************

--- a/Modules/QuestieSlash.lua
+++ b/Modules/QuestieSlash.lua
@@ -16,8 +16,12 @@ local QuestieMap = QuestieLoader:ImportModule("QuestieMap")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
 
+function QuestieSlash.RegisterSlashCommands()
+    Questie:RegisterChatCommand("questieclassic", QuestieSlash.HandleCommands)
+    Questie:RegisterChatCommand("questie", QuestieSlash.HandleCommands)
+end
 
-function QuestieSlash:HandleCommands(input)
+function QuestieSlash.HandleCommands(input)
     input = string.trim(input, " ");
 
     local commands = {}

--- a/Questie.lua
+++ b/Questie.lua
@@ -12,30 +12,12 @@ local band = bit.band
 -------------------------
 --Import modules.
 -------------------------
----@type QuestieComms
-local QuestieComms = QuestieLoader:ImportModule("QuestieComms");
----@type QuestieOptions
-local QuestieOptions = QuestieLoader:ImportModule("QuestieOptions");
 ---@type QuestieOptionsDefaults
 local QuestieOptionsDefaults = QuestieLoader:ImportModule("QuestieOptionsDefaults")
----@type QuestieCoords
-local QuestieCoords = QuestieLoader:ImportModule("QuestieCoords");
 ---@type QuestieEventHandler
 local QuestieEventHandler = QuestieLoader:ImportModule("QuestieEventHandler");
----@type QuestieTooltips
-local QuestieTooltips = QuestieLoader:ImportModule("QuestieTooltips");
----@type QuestieDBMIntegration
-local QuestieDBMIntegration = QuestieLoader:ImportModule("QuestieDBMIntegration");
----@type QuestieQuestTimers
-local QuestieQuestTimers = QuestieLoader:ImportModule("QuestieQuestTimers")
----@type QuestieCombatQueue
-local QuestieCombatQueue = QuestieLoader:ImportModule("QuestieCombatQueue")
----@type QuestieSlash
-local QuestieSlash = QuestieLoader:ImportModule("QuestieSlash")
 ---@type QuestieValidateGameCache
 local QuestieValidateGameCache = QuestieLoader:ImportModule("QuestieValidateGameCache")
----@type l10n
-local l10n = QuestieLoader:ImportModule("l10n")
 
 
 function Questie:OnInitialize()
@@ -47,71 +29,12 @@ function Questie:OnInitialize()
     QuestieEventHandler:RegisterEarlyEvents()
 end
 
-function Questie:ContinueInit()
-    --QuestieTracker:Initialize() --moved to stage 2 init event function
-    QuestieTooltips:Initialize()
-    QuestieCoords:Initialize()
-    QuestieQuestTimers:Initialize()
-    QuestieCombatQueue:Initialize()
-    QuestieComms:Initialize()
-
-    -- Register Slash Commands
-    Questie:RegisterChatCommand("questieclassic", "HandleSlash")
-    Questie:RegisterChatCommand("questie", "HandleSlash")
-
-    QuestieOptions:Initialize()
-
-    --Initialize the DB settings.
-    Questie:Debug(Questie.DEBUG_DEVELOP, l10n("Setting clustering value, clusterLevelHotzone set to %s : Redrawing!", Questie.db.global.clusterLevelHotzone))
-
-
-    -- Update the default text on the map show/hide button for localization
-    if Questie.db.char.enabled then
-        Questie_Toggle:SetText(l10n("Hide Questie"));
-    else
-        Questie_Toggle:SetText(l10n("Show Questie"));
-    end
-
-    -- Update status of Map button on hide between play sessions
-    if Questie.db.global.mapShowHideEnabled then
-        Questie_Toggle:Show();
-    else
-        Questie_Toggle:Hide();
-    end
-
-    -- Change position of Map button when continent dropdown is hidden
-    C_Timer.After(1, function()
-        if not WorldMapContinentDropDown:IsShown() then
-            Questie_Toggle:ClearAllPoints();
-            if AtlasToggleFromWorldMap and AtlasToggleFromWorldMap:IsShown() then -- #1498
-                AtlasToggleFromWorldMap:SetScript("OnHide", function() Questie_Toggle:SetPoint('RIGHT', WorldMapFrameCloseButton, 'LEFT', 0, 0) end)
-                AtlasToggleFromWorldMap:SetScript("OnShow", function() Questie_Toggle:SetPoint('RIGHT', AtlasToggleFromWorldMap, 'LEFT', 0, 0) end)
-                Questie_Toggle:SetPoint('RIGHT', AtlasToggleFromWorldMap, 'LEFT', 0, 0);
-            else
-                Questie_Toggle:SetPoint('RIGHT', WorldMapFrameCloseButton, 'LEFT', 0, 0);
-            end
-        end
-    end)
-
-    if Questie.db.global.dbmHUDEnable then
-        QuestieDBMIntegration:EnableHUD()
-    end
-end
-
-function Questie:OnUpdate()
-
-end
-
 function Questie:OnEnable()
     -- Called when the addon is enabled
 end
 
 function Questie:OnDisable()
     -- Called when the addon is disabled
-end
-
-function Questie:HandleSlash(input)
-    QuestieSlash:HandleCommands(input)
 end
 
 function Questie:Colorize(str, color)


### PR DESCRIPTION
Removed unnecessary timer waiting savedvars.
Move init code to more correct modules.
Hopefully this made it more readable.
Order of init processing is not modified.
