### PR TITLE
Remove unused field enableObjectLimit

### DIFF
--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -5,14 +5,10 @@ local QuestieDBCompiler = QuestieLoader:CreateModule("DBCompiler")
 local QuestieStream = QuestieLoader:ImportModule("QuestieStreamLib"):GetStream("raw")
 ---@type QuestieDB
 local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
----@type QuestieSerializer
-local serial = QuestieLoader:ImportModule("QuestieSerializer")
 ---@type QuestieLib
 local QuestieLib = QuestieLoader:ImportModule("QuestieLib")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
-
-serial.enableObjectLimit = false
 
 -- how fast to run operations (lower = slower but less lag)
 local TICKS_PER_YIELD_DEBUG = 4000

--- a/Modules/Libs/QuestieSerializer.lua
+++ b/Modules/Libs/QuestieSerializer.lua
@@ -279,8 +279,6 @@ QuestieSerializer.WriterTable = {
     end
 }
 
-QuestieSerializer.enableObjectLimit = true
-
 function QuestieSerializer:WriteKeyValuePair(key, value, depth)
     if not value or not key then return; end
     if not depth then


### PR DESCRIPTION
The enableObjectLimit is present only in these places, so it is not accessed at all. Only set.