### PR TITLE
Fix item Sturdy Junkbox (16884) causing stack overflow

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -925,6 +925,9 @@ function QuestieItemFixes:Load()
         [16882] = {
             [itemKeys.itemDrops] = {},
         },
+        [16884] = {
+            [itemKeys.itemDrops] = {},
+        },
         [16967] = {
             [itemKeys.relatedQuests] = {6607},
             [itemKeys.npcDrops] = {},


### PR DESCRIPTION
Fix item [Sturdy Junkbox (16884)](https://classic.wowhead.com/item=16884/sturdy-junkbox) causing stack overflow because it contained itself in itemDrops list.

Someone should really write a script to sanitize the database to find and fix all these 😄 