### PR TITLE
[fix] Improve performance. Refactoring == nil

### DIFF
--- a/Database/QuestXP/QuestieXP.lua
+++ b/Database/QuestXP/QuestieXP.lua
@@ -52,7 +52,7 @@ end
 ---@return number experience
 function QuestXP:GetQuestLogRewardXP(questID, ignorePlayerLevel)
     -- Return 0 if quest ID is not found for some reason
-    if (questID == nil) then return 0 end
+    if not questID then return 0 end
     ---@type number
     local adjustedXP = 0
     if QuestXP.db[questID] ~= nil then

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -1016,7 +1016,7 @@ function QuestieDB:GetQuestsByZoneId(zoneId)
                 if (quest.zoneOrSort == zoneId or (alternativeZoneID and quest.zoneOrSort == alternativeZoneID)) then
                     zoneQuests[qid] = quest;
                 end
-            elseif quest.Starts.NPC and zoneQuests[qid] == nil then
+            elseif quest.Starts.NPC and (not zoneQuests[qid]) then
                 local npc = QuestieDB:GetNPC(quest.Starts.NPC[1]);
                 if npc and npc.friendly and npc.spawns then
                     for zone, _ in pairs(npc.spawns) do
@@ -1025,7 +1025,7 @@ function QuestieDB:GetQuestsByZoneId(zoneId)
                         end
                     end
                 end
-            elseif quest.Starts.GameObject and zoneQuests[qid] == nil then
+            elseif quest.Starts.GameObject and (not zoneQuests[qid]) then
                 local obj = QuestieDB:GetObject(quest.Starts.GameObject[1]);
                 if obj and obj.spawns then
                     for zone, _ in pairs(obj.spawns) do

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -641,7 +641,7 @@ end
 ---@return Quest|nil @The quest object or nil if the quest is missing
 function QuestieDB:GetQuest(questId) -- /dump QuestieDB:GetQuest(867)
     if not questId then
-        Questie:Debug(Questie.DEBUG_CRITICAL, "[QuestieDB:GetQuest] Expected questID but received nil!")
+        Questie:Debug(Questie.DEBUG_CRITICAL, "[QuestieDB:GetQuest] No questId.")
         return nil
     end
     if _QuestieDB.questCache[questId] ~= nil then

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -228,7 +228,7 @@ function QuestieDB:Initialize()
 end
 
 function QuestieDB:GetObject(objectId)
-    if objectId == nil then
+    if not objectId then
         return nil
     end
     if _QuestieDB.objectCache[objectId] ~= nil then
@@ -256,7 +256,7 @@ function QuestieDB:GetObject(objectId)
 end
 
 function QuestieDB:GetItem(itemId)
-    if itemId == nil or itemId == 0 then
+    if (not itemId) or (itemId == 0) then
         return nil
     end
     if _QuestieDB.itemCache[itemId] ~= nil then
@@ -434,7 +434,7 @@ end
 ---@param parentID number
 ---@return boolean
 function QuestieDB:IsParentQuestActive(parentID)
-    if parentID == nil or parentID == 0 then
+    if (not parentID) or (parentID == 0) then
         return false
     end
     if QuestiePlayer.currentQuestlog[parentID] then
@@ -453,7 +453,7 @@ function QuestieDB:IsPreQuestGroupFulfilled(preQuestGroup)
         -- If a quest is not complete and no exlusive quest is complete, the requirement is not fulfilled
         if not Questie.db.char.complete[preQuestId] then
             local preQuest = QuestieDB:GetQuest(preQuestId);
-            if preQuest == nil or preQuest.exclusiveTo == nil then
+            if (not preQuest) or (not preQuest.exclusiveTo) then
                 return false
             end
 
@@ -640,7 +640,7 @@ end
 ---@param questId number
 ---@return Quest|nil @The quest object or nil if the quest is missing
 function QuestieDB:GetQuest(questId) -- /dump QuestieDB:GetQuest(867)
-    if questId == nil then
+    if not questId then
         Questie:Debug(Questie.DEBUG_CRITICAL, "[QuestieDB:GetQuest] Expected questID but received nil!")
         return nil
     end
@@ -940,7 +940,7 @@ local playerFaction = UnitFactionGroup("player")
 ---@param npcId number
 ---@return table
 function QuestieDB:GetNPC(npcId)
-    if npcId == nil then
+    if not npcId then
         return nil
     end
     if(_QuestieDB.npcCache[npcId]) then

--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -1150,7 +1150,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
             end
             local typ = types[key]
             local ptr = pointers[id]
-            if ptr == nil then
+            if not ptr then
                 --print("Entry not found! " .. id)
                 return nil
             end
@@ -1159,7 +1159,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
             else -- need to skip over some variably sized data
                 stream._pointer = lastPtr + ptr
                 local targetIndex = keyToIndex[key]
-                if targetIndex == nil then
+                if not targetIndex then
                     Questie:Error("ERROR: Unhandled db key: " .. key)
                     return nil
                 end
@@ -1183,7 +1183,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
             local ptr = pointers[id]
             local override = overrides[id]
             local keys = {...}
-            if ptr == nil then
+            if not ptr then
                 if override then
                     local ret = {}
                     for index=1,#keys do
@@ -1209,7 +1209,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                     else -- need to skip over some variably sized data
                         stream._pointer = lastPtr + ptr
                         local targetIndex = keyToIndex[key]
-                        if targetIndex == nil then
+                        if not targetIndex then
                             Questie:Error("ERROR: Unhandled db key: " .. key)
                             return nil
                         end
@@ -1226,7 +1226,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
         handle.QuerySingle = function(id, key)
             local typ = types[key]
             local ptr = pointers[id]
-            if ptr == nil then
+            if not ptr then
                 --print("Entry not found! " .. id)
                 return nil
             end
@@ -1235,7 +1235,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
             else -- need to skip over some variably sized data
                 stream._pointer = lastPtr + ptr
                 local targetIndex = keyToIndex[key]
-                if targetIndex == nil then
+                if not targetIndex then
                     Questie:Error("ERROR: Unhandled db key: " .. key)
                     return nil
                 end
@@ -1248,7 +1248,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
 
         handle.Query = function(id, ...)
             local ptr = pointers[id]
-            if ptr == nil then
+            if not ptr then
                 --print("Entry not found! " .. id)
                 return nil
             end
@@ -1262,7 +1262,7 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipMap, keyToRootIndex, 
                 else -- need to skip over some variably sized data
                     stream._pointer = lastPtr + ptr
                     local targetIndex = keyToIndex[key]
-                    if targetIndex == nil then
+                    if not targetIndex then
                         Questie:Error("ERROR: Unhandled db key: " .. key)
                         return nil
                     end

--- a/Localization/l10n.lua
+++ b/Localization/l10n.lua
@@ -98,7 +98,7 @@ function _l10n:translate(key, ...)
     end
 
     local translationEntry = l10n.translations[key]
-    if translationEntry == nil then
+    if not translationEntry then
         Questie:Debug(Questie.DEBUG_ELEVATED, "ERROR: Translations for '" .. tostring(key) .. "' is missing completely!")
         return string.format(key, unpack(args))
     end

--- a/Modules/Auto/QuestieAuto.lua
+++ b/Modules/Auto/QuestieAuto.lua
@@ -183,7 +183,7 @@ function QuestieAuto:QUEST_DETAIL(event, ...)
         local quest = QuestieDB:GetQuest(questId)
 
         if not quest then
-            Questie:Debug(Questie.DEBUG_DEVELOP, "[QuestieAuto] quest == nil, retrying in 1 second")
+            Questie:Debug(Questie.DEBUG_DEVELOP, "[QuestieAuto] No quest object, retrying in 1 second")
             C_Timer.After(1, function ()
                 questId = GetQuestID()
                 ---@type Quest

--- a/Modules/Auto/QuestieAuto.lua
+++ b/Modules/Auto/QuestieAuto.lua
@@ -182,13 +182,13 @@ function QuestieAuto:QUEST_DETAIL(event, ...)
         ---@type Quest
         local quest = QuestieDB:GetQuest(questId)
 
-        if quest == nil then
+        if not quest then
             Questie:Debug(Questie.DEBUG_DEVELOP, "[QuestieAuto] quest == nil, retrying in 1 second")
             C_Timer.After(1, function ()
                 questId = GetQuestID()
                 ---@type Quest
                 quest = QuestieDB:GetQuest(questId)
-                if quest == nil then
+                if not quest then
                     Questie:Debug(Questie.DEBUG_DEVELOP, "[QuestieAuto] retry failed. Quest", questId, "might not be in the DB!")
                 elseif (not quest:IsTrivial()) or Questie.db.char.acceptTrivial then
                     Questie:Debug(Questie.DEBUG_INFO, "[QuestieAuto] Questie Auto-Acceping quest")

--- a/Modules/FramePool/QuestieFramePool.lua
+++ b/Modules/FramePool/QuestieFramePool.lua
@@ -198,13 +198,11 @@ function QuestieFramePool:CreateWaypoints(iconFrame, waypointTable, lineWidth, c
     for _, waypointSubTable in pairs(waypointTable) do
         lastPos = nil
         for _, waypoint in pairs(waypointSubTable) do
-            if (lastPos == nil) then
-                lastPos = waypoint;
-            else
+            if lastPos then
                 local lineFrame = QuestieFramePool:CreateLine(iconFrame, lastPos[1], lastPos[2], waypoint[1], waypoint[2], lWidth, col, areaId)
                 tinsert(lineFrameList, lineFrame);
-                lastPos = waypoint;
             end
+            lastPos = waypoint
         end
     end
     return lineFrameList;
@@ -251,7 +249,7 @@ function QuestieFramePool:CreateLine(iconFrame, startX, startY, endX, endY, line
     lineFrame.type = "line"
 
     --Include the line in the iconFrame.
-    if (iconFrame.data.lineFrames == nil) then
+    if not iconFrame.data.lineFrames then
         iconFrame.data.lineFrames = {};
     end
     tinsert(iconFrame.data.lineFrames, lineFrame);

--- a/Modules/Journey/QuestieJourney.lua
+++ b/Modules/Journey/QuestieJourney.lua
@@ -56,7 +56,7 @@ function QuestieJourney:Initialize()
 end
 
 function QuestieJourney:BuildMainFrame()
-    if (QuestieJourneyFrame == nil) then
+    if not QuestieJourneyFrame then
         local journeyFrame = AceGUI:Create("Frame")
         journeyFrame:SetCallback("OnClose", function()
             isWindowShown = false

--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -84,7 +84,7 @@ end
 local function FloatRGBToHex(r, g, b) return RGBToHex(r * 254, g * 254, b * 254) end
 
 function QuestieLib:GetRGBForObjective(objective)
-    if objective.fulfilled ~= nil and objective.Collected == nil then
+    if objective.fulfilled ~= nil and (not objective.Collected) then
         objective.Collected = objective.fulfilled
         objective.Needed = objective.required
     end
@@ -414,7 +414,7 @@ function QuestieLib:MathRandom(low_or_high_arg, high_arg)
 
     randomSeed = (randomSeed * 214013 + 2531011) % 2^32
     local rand = (math.floor(randomSeed / 2^16) % 2^15) / 0x7fff
-    if high == nil then
+    if not high then
         return rand
     end
     return low + math.floor(rand * high)

--- a/Modules/Map/QuestieMap.lua
+++ b/Modules/Map/QuestieMap.lua
@@ -79,7 +79,7 @@ end
 
 function QuestieMap:UnloadQuestFrames(questId, iconType)
     if QuestieMap.questIdFrames[questId] then
-        if iconType == nil then
+        if not iconType then
             for _, frame in pairs(QuestieMap:GetFramesForQuest(questId)) do
                 frame:Unload();
             end
@@ -324,7 +324,7 @@ function QuestieMap:ShowNPC(npcID, icon, scale, title, body, disableShiftToRemov
     end
     -- get the NPC data
     local npc = QuestieDB:GetNPC(npcID)
-    if npc == nil or npc.spawns == nil then return end
+    if (not npc) or (not npc.spawns) then return end
 
     -- create the icon data
     local data = {}
@@ -380,7 +380,7 @@ function QuestieMap:ShowObject(objectID, icon, scale, title, body, disableShiftT
     if type(objectID) ~= "number" then return end
     -- get the gameobject data
     local object = QuestieDB:GetObject(objectID)
-    if object == nil then return end
+    if not object then return end
 
     -- create the icon data
     local data = {}
@@ -465,10 +465,10 @@ function QuestieMap:DrawManualIcon(data, areaID, x, y, typ)
     -- Save new zone ID format, used in QuestieFramePool
     -- create a list for all frames belonging to a NPC (id > 0) or an object (id < 0)
     typ = typ or "any"
-    if(QuestieMap.manualFrames[typ] == nil) then
+    if not QuestieMap.manualFrames[typ] then
         QuestieMap.manualFrames[typ] = {}
     end
-    if(QuestieMap.manualFrames[typ][data.id] == nil) then
+    if not QuestieMap.manualFrames[typ][data.id] then
         QuestieMap.manualFrames[typ][data.id] = {}
     end
 
@@ -567,7 +567,7 @@ function QuestieMap:DrawWorldIcon(data, areaID, x, y, showFlag)
     end
 
     --print("UIMAPID: " .. tostring(uiMapId))
-    if uiMapId == nil then
+    if not uiMapId then
         --ZoneDB:GetUiMapIdByAreaId
         error("No UiMapID or fitting uiMapId for areaId : ".. areaID .. " - ".. tostring(data.Name))
         return nil, nil
@@ -663,7 +663,7 @@ function QuestieMap:DrawWorldIcon(data, areaID, x, y, showFlag)
     local r, g, b = iconMinimap.texture:GetVertexColor()
     QuestieDBMIntegration:RegisterHudQuestIcon(tostring(iconMap), data.Icon, uiMapId, x, y, r, g, b)
 
-    if(QuestieMap.questIdFrames[data.Id] == nil) then
+    if not QuestieMap.questIdFrames[data.Id] then
         QuestieMap.questIdFrames[data.Id] = {}
     end
 
@@ -812,9 +812,7 @@ function QuestieMap:FindClosestStarter()
 end
 
 function QuestieMap:GetNearestSpawn(objective)
-    if objective == nil then
-        return nil
-    end
+    if not objective then return end
     local playerX, playerY, playerI = HBD:GetPlayerWorldPosition()
     local bestDistance = 999999999
     local bestSpawn, bestSpawnZone, bestSpawnId, bestSpawnType, bestSpawnName
@@ -847,9 +845,7 @@ end
 
 ---@param quest Quest
 function QuestieMap:GetNearestQuestSpawn(quest)
-    if quest == nil then
-        return nil
-    end
+    if not quest then return end
     if quest:IsComplete() == 1 then
         local finisherSpawns
         local finisherName

--- a/Modules/Map/QuestieMap.lua
+++ b/Modules/Map/QuestieMap.lua
@@ -812,7 +812,9 @@ function QuestieMap:FindClosestStarter()
 end
 
 function QuestieMap:GetNearestSpawn(objective)
-    if not objective then return end
+    if not objective then
+        return nil
+    end
     local playerX, playerY, playerI = HBD:GetPlayerWorldPosition()
     local bestDistance = 999999999
     local bestSpawn, bestSpawnZone, bestSpawnId, bestSpawnType, bestSpawnName
@@ -845,7 +847,9 @@ end
 
 ---@param quest Quest
 function QuestieMap:GetNearestQuestSpawn(quest)
-    if not quest then return end
+    if not quest then
+        return nil
+    end
     if quest:IsComplete() == 1 then
         local finisherSpawns
         local finisherName

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -90,7 +90,7 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
 
     for j=1, pointsCount do
         local point = points[j]
-        if(point.touched == nil) then
+        if not point.touched then
             point.touched = true
             local notes = { point }
 
@@ -105,7 +105,7 @@ function QuestieMap.utils:CalcHotzones(points, rangeR, count)
             for i=j+1, pointsCount do
                 local point2 = points[i]
                 --We only want to cluster icons that are on the same map.
-                if (point2.touched == nil) and (point.UiMapID == point2.UiMapID) then
+                if (not point2.touched) and (point.UiMapID == point2.UiMapID) then
                     local distance = QuestieLib:Euclid(aX, aY, point2.worldX, point2.worldY)
                     if (distance < movingRange) then
                         point2.touched = true

--- a/Modules/Network/QuestieComms.lua
+++ b/Modules/Network/QuestieComms.lua
@@ -826,8 +826,8 @@ _QuestieComms.packets = {
             _QuestieComms:Broadcast(self.data);
         end,
         read = function(remoteQuestPacket)
-            if(remoteQuestPacket == nil) then
-                Questie:Error("[QuestieComms] QC_ID_BROADCAST_QUEST_UPDATE remoteQuestPacket = nil");
+            if not remoteQuestPacket then
+                Questie:Error("[QuestieComms] QC_ID_BROADCAST_QUEST_UPDATE no remoteQuestPacket")
             end
             --These are not strictly needed but helps readability.
             local playerName = remoteQuestPacket.playerName;
@@ -844,8 +844,8 @@ _QuestieComms.packets = {
         _QuestieComms:Broadcast(self.data);
       end,
       read = function(remoteQuestPacket)
-        if(remoteQuestPacket == nil) then
-            Questie:Error("[QuestieComms] QC_ID_BROADCAST_QUEST_REMOVE remoteQuestPacket = nil");
+        if not remoteQuestPacket then
+            Questie:Error("[QuestieComms] QC_ID_BROADCAST_QUEST_REMOVE no remoteQuestPacket")
         end
         Questie:Debug(Questie.DEBUG_DEVELOP, "[QuestieComms] Received: QC_ID_BROADCAST_QUEST_REMOVE")
 
@@ -865,8 +865,8 @@ _QuestieComms.packets = {
             _QuestieComms:Broadcast(self.data);
         end,
         read = function(remoteQuestList)
-            if(remoteQuestList == nil) then
-                Questie:Error("[QuestieComms] QC_ID_BROADCAST_FULL_QUESTLIST remoteQuestList = nil");
+            if not remoteQuestList then
+                Questie:Error("[QuestieComms] QC_ID_BROADCAST_FULL_QUESTLIST no remoteQuestList")
             end
             --These are not strictly needed but helps readability.
             local playerName = remoteQuestList.playerName;

--- a/Modules/Options/SocialTab/QuestieOptionsSocial.lua
+++ b/Modules/Options/SocialTab/QuestieOptionsSocial.lua
@@ -164,5 +164,5 @@ end
 
 ---@return boolean
 _IsAnnounceDisabled = function()
-    return Questie.db.char.questAnnounceChannel == nil or Questie.db.char.questAnnounceChannel == "disabled";
+    return (not Questie.db.char.questAnnounceChannel) or (Questie.db.char.questAnnounceChannel == "disabled")
 end

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -98,15 +98,15 @@ function _QuestieQuest:ShowQuestIcons()
 
     local trackerHiddenQuests = Questie.db.char.TrackerHiddenQuests
     for questId, frameList in pairs(QuestieMap.questIdFrames) do
-        if (trackerHiddenQuests == nil) or (trackerHiddenQuests[questId] == nil) then -- Skip quests which are completly hidden from the Tracker menu
+        if (not trackerHiddenQuests) or (not trackerHiddenQuests[questId]) then -- Skip quests which are completly hidden from the Tracker menu
             for _, frameName in pairs(frameList) do -- this may seem a bit expensive, but its actually really fast due to the order things are checked
                 ---@type IconFrame
                 local icon = _G[frameName];
-                if icon.data == nil then
+                if not icon.data then
                     error("Desync! Icon has not been removed correctly, but has already been resetted. Skipping frame \"" .. frameName .. "\" for quest " .. questId)
                 else
                     local objectiveString = tostring(questId) .. " " .. tostring(icon.data.ObjectiveIndex)
-                    if (Questie.db.char.TrackerHiddenObjectives == nil) or (Questie.db.char.TrackerHiddenObjectives[objectiveString] == nil) then
+                    if (not Questie.db.char.TrackerHiddenObjectives) or (not Questie.db.char.TrackerHiddenObjectives[objectiveString]) then
                         if icon ~= nil and icon.hidden and (not icon:ShouldBeHidden()) then
                             icon:FakeShow()
 
@@ -340,7 +340,7 @@ end
 
 ---@param questId number
 function QuestieQuest:AcceptQuest(questId)
-    if(QuestiePlayer.currentQuestlog[questId] == nil) then
+    if not QuestiePlayer.currentQuestlog[questId] then
         Questie:Debug(Questie.DEBUG_INFO, "[QuestieQuest] Accepted Quest:", questId)
 
         local quest = QuestieDB:GetQuest(questId)
@@ -1039,7 +1039,7 @@ function QuestieQuest:PopulateQuestLogInfo(quest)
             if (not quest.ObjectiveData) or (not quest.ObjectiveData[objectiveIndex]) then
                 Questie:Error("Missing objective data for quest " .. quest.Id .. " and objective " .. objective.text)
             else
-                if quest.Objectives[objectiveIndex] == nil then
+                if not quest.Objectives[objectiveIndex] then
                     quest.Objectives[objectiveIndex] = {
                         Id = quest.ObjectiveData[objectiveIndex].Id,
                         Index = objectiveIndex,

--- a/Modules/Quest/QuestieQuestPrivates.lua
+++ b/Modules/Quest/QuestieQuestPrivates.lua
@@ -140,7 +140,7 @@ _QuestieQuest.objectiveSpawnListCallTable = {
             for _, source in pairs(item.Sources) do
                 if _QuestieQuest.objectiveSpawnListCallTable[source.Type] and source.Type ~= "item" then -- anti-recursive-loop check, should never be possible but would be bad if it was
                     local sourceList = _QuestieQuest.objectiveSpawnListCallTable[source.Type](source.Id, objective)
-                    if sourceList == nil then
+                    if not sourceList then
                         Questie:Error("Missing objective data for", source.Type, "'", objective, "'", source.Id)
                     else
                         for id, sourceData in pairs(sourceList) do

--- a/Modules/QuestieAnnounce.lua
+++ b/Modules/QuestieAnnounce.lua
@@ -109,7 +109,9 @@ function QuestieAnnounce:ItemLooted(text, notPlayerName, _, _, playerName)
         local itemId = tonumber(string.match(text, "item:(%d+)"))
 
         local startQuestId = itemCache[itemId]
-        if (startQuestId == nil) and QuestieDB.QueryItemSingle then -- check QueryItemSingle because this event can fire before db init is complete
+        -- startQuestId can have boolean false as value, need to compare to nil
+        -- check QueryItemSingle because this event can fire before db init is complete
+        if (startQuestId == nil) and QuestieDB.QueryItemSingle then
             startQuestId = QuestieDB.QueryItemSingle(itemId, "startQuest")
             -- filter 0 values away so itemCache value is a valid questId if it evaluates to true
             -- we do "or false" here because nil would mean not cached

--- a/Modules/QuestieInit.lua
+++ b/Modules/QuestieInit.lua
@@ -248,7 +248,7 @@ QuestieInit.Stages[3] = function() -- run as a coroutine
 
     local dateToday = date("%y-%m-%d")
 
-    if Questie.db.char.showAQWarEffortQuests and (Questie.db.char.aqWarningPrintDate == nil or Questie.db.char.aqWarningPrintDate < dateToday) then
+    if Questie.db.char.showAQWarEffortQuests and ((not Questie.db.char.aqWarningPrintDate) or (Questie.db.char.aqWarningPrintDate < dateToday)) then
         Questie.db.char.aqWarningPrintDate = dateToday
         C_Timer.After(2, function()
             print("|cffff0000-----------------------------|r")

--- a/Modules/QuestieNameplate.lua
+++ b/Modules/QuestieNameplate.lua
@@ -152,7 +152,7 @@ function QuestieNameplate:DrawTargetFrame()
         return
     end
 
-    if activeTargetFrame == nil then
+    if not activeTargetFrame then
         activeTargetFrame = _QuestieNameplate.GetTargetFrameIconFrame()
     end
 

--- a/Modules/QuestieProfessions.lua
+++ b/Modules/QuestieProfessions.lua
@@ -39,7 +39,7 @@ function QuestieProfessions:Update()
         if i > 14 then break; end -- We don't have to go through all the weapon skills
 
         local skillName, isHeader, _, skillRank, _, _, _, _, _, _, _, _, _ = GetSkillLineInfo(i)
-        if isHeader == nil and professionTable[skillName] then
+        if (not isHeader) and professionTable[skillName] then
             isProfessionUpdate = true -- A profession leveled up, not something like "Defense"
             playerProfessions[professionTable[skillName]] = {skillName, skillRank}
         end
@@ -71,7 +71,7 @@ local function _HasSkillLevel(profession, skillLevel)
 end
 
 function QuestieProfessions:HasProfessionAndSkillLevel(requiredSkill)
-    if requiredSkill == nil then
+    if not requiredSkill then
         return true
     end
 

--- a/Modules/QuestieProfessions.lua
+++ b/Modules/QuestieProfessions.lua
@@ -63,11 +63,11 @@ function QuestieProfessions:GetPlayerProfessionNames()
 end
 
 local function _HasProfession(profession)
-    return profession == nil or playerProfessions[profession] ~= nil
+    return (not profession) or playerProfessions[profession] ~= nil
 end
 
 local function _HasSkillLevel(profession, skillLevel)
-    return skillLevel == nil or playerProfessions[profession][2] >= skillLevel
+    return (not skillLevel) or playerProfessions[profession][2] >= skillLevel
 end
 
 function QuestieProfessions:HasProfessionAndSkillLevel(requiredSkill)

--- a/Modules/QuestieReputation.lua
+++ b/Modules/QuestieReputation.lua
@@ -16,7 +16,7 @@ function QuestieReputation:Update(isInit)
 
     for i=1, GetNumFactions() do
         local name, _, standingId, _, _, barValue, _, _, isHeader, _, _, _, _, factionID, _, _ = GetFactionInfo(i)
-        if isHeader == nil or isHeader == false then
+        if not isHeader then
             local previousValues = playerReputations[factionID]
             playerReputations[factionID] = {standingId, barValue}
 

--- a/Modules/QuestieReputation.lua
+++ b/Modules/QuestieReputation.lua
@@ -34,7 +34,7 @@ end
 
 ---@return boolean
 _ReachedNewStanding = function(previousValues, standingId)
-    return previousValues == nil -- New faction
+    return (not previousValues) -- New faction
         or (previousValues[1] ~= standingId) -- Standing changed
 end
 

--- a/Modules/QuestieSlash.lua
+++ b/Modules/QuestieSlash.lua
@@ -103,7 +103,7 @@ function QuestieSlash.HandleCommands(input)
     end
 
     if mainCommand == "tomap" then
-        if subCommand == nil then
+        if not subCommand then
             subCommand = UnitName("target")
         end
 

--- a/Modules/QuestieStream.lua
+++ b/Modules/QuestieStream.lua
@@ -164,9 +164,7 @@ function QuestieStreamLib:_ReadByte_b89()
 end
 
 function QuestieStreamLib:_WriteByte_b89(e)
-    if e == nil then
-        return 
-    end
+    if not e then return end
     local level = math.floor(e / 86);
     if self._level ~= level then
         self._level = level

--- a/Modules/Tooltips/MapIconTooltip.lua
+++ b/Modules/Tooltips/MapIconTooltip.lua
@@ -78,7 +78,7 @@ function MapIconTooltip:Show()
     -- happens when a note doesn't get removed after a quest has been finished, see #1170
     -- TODO: change how the logic works, so this [ObjectiveIndex?] can be nil
     -- it is nil on some notes like starters/finishers, because its for objectives. However, it needs to be an number here for duplicate checks
-    if self.data.ObjectiveIndex == nil then
+    if not self.data.ObjectiveIndex then
         self.data.ObjectiveIndex = 0
     end
 
@@ -96,7 +96,7 @@ function MapIconTooltip:Show()
     local function handleMapIcon(icon)
         local iconData = icon.data
 
-        if iconData == nil then
+        if not iconData then
             Questie:Error("[MapIconTooltip:Show] handleMapIcon - iconData is nil! self.data.Id =", self.data.Id, "- Aborting!")
             return
         end
@@ -116,7 +116,7 @@ function MapIconTooltip:Show()
             local dist = QuestieLib:Maxdist(icon.x, icon.y, self.x, self.y);
             if dist < maxDistCluster then
                 if iconData.Type == "available" or iconData.Type == "complete" then
-                    if npcOrder[iconData.Name] == nil then
+                    if not npcOrder[iconData.Name] then
                         npcOrder[iconData.Name] = {};
                     end
 
@@ -536,7 +536,7 @@ function _MapIconTooltip:AddTooltipsForQuest(icon, tip, quest, usedText)
         local data = {}
         data[text] = nameTable;
         --Add the data for the first time
-        if usedText[text] == nil then
+        if not usedText[text] then
             tinsert(quest, data)
             usedText[text] = true;
         else

--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -95,7 +95,9 @@ end
 ---@param key string
 function QuestieTooltips:GetTooltip(key)
     Questie:Debug(Questie.DEBUG_SPAM, "[QuestieTooltips:GetTooltip]", key)
-    if not key then return end
+    if not key then
+        return nil
+    end
 
     if GetNumGroupMembers() > 15 then
         return nil -- temporary disable tooltips in raids, we should make a proper fix

--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -32,10 +32,10 @@ local _InitObjectiveTexts
 ---@param key string monster: m_, items: i_, objects: o_ + string name of the objective
 ---@param objective table
 function QuestieTooltips:RegisterObjectiveTooltip(questId, key, objective)
-    if QuestieTooltips.lookupByKey[key] == nil then
+    if not QuestieTooltips.lookupByKey[key] then
         QuestieTooltips.lookupByKey[key] = {};
     end
-    if QuestieTooltips.lookupKeysByQuestId[questId] == nil then
+    if not QuestieTooltips.lookupKeysByQuestId[questId] then
         QuestieTooltips.lookupKeysByQuestId[questId] = {}
     end
     local tooltip = {};
@@ -49,10 +49,10 @@ end
 ---@param npc table
 function QuestieTooltips:RegisterQuestStartTooltip(questId, npc)
     local key = "m_" .. npc.id
-    if QuestieTooltips.lookupByKey[key] == nil then
+    if not QuestieTooltips.lookupByKey[key] then
         QuestieTooltips.lookupByKey[key] = {};
     end
-    if QuestieTooltips.lookupKeysByQuestId[questId] == nil then
+    if not QuestieTooltips.lookupKeysByQuestId[questId] then
         QuestieTooltips.lookupKeysByQuestId[questId] = {}
     end
     local tooltip = {};
@@ -95,9 +95,7 @@ end
 ---@param key string
 function QuestieTooltips:GetTooltip(key)
     Questie:Debug(Questie.DEBUG_SPAM, "[QuestieTooltips:GetTooltip]", key)
-    if key == nil then
-        return nil
-    end
+    if not key then return end
 
     if GetNumGroupMembers() > 15 then
         return nil -- temporary disable tooltips in raids, we should make a proper fix

--- a/Modules/Tracker/QuestieQuestTimers.lua
+++ b/Modules/Tracker/QuestieQuestTimers.lua
@@ -8,11 +8,11 @@ local timer
 function QuestieQuestTimers:Initialize()
     Questie:Debug(Questie.DEBUG_DEVELOP, "QuestieQuestTimers:Initialize")
 
-    if QuestTimerFrame_Update == nil then
-        Questie:Debug(Questie.DEBUG_CRITICAL, "QuestTimerFrame_Update is nil. Retrying to hooksecurefunc in 5 seconds.")
+    if not QuestTimerFrame_Update then
+        Questie:Debug(Questie.DEBUG_CRITICAL, "No QuestTimerFrame_Update. Retrying to hooksecurefunc in 5 seconds.")
         C_Timer.After(5, function()
-            if QuestTimerFrame_Update == nil then
-                Questie:Debug(Questie.DEBUG_CRITICAL, "QuestTimerFrame_Update is still nil. Something is strange.")
+            if not QuestTimerFrame_Update then
+                Questie:Debug(Questie.DEBUG_CRITICAL, "Still no QuestTimerFrame_Update. Something is strange.")
                 return
             end
             hooksecurefunc("QuestTimerFrame_Update", _QuestieQuestTimers.UpdateTimerFrame)

--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -1804,7 +1804,7 @@ function QuestieTracker:Update()
     end
 
 
-    if _QuestieTracker.IsFirstRun == nil then
+    if not _QuestieTracker.IsFirstRun then
         _QuestieTracker.baseFrame:Show()
     else
         _QuestieTracker.baseFrame:Hide()
@@ -2100,7 +2100,7 @@ _OnClick = function(self, button)
         return
     end
 
-    if self.Quest == nil then
+    if not self.Quest then
         return
     end
 

--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -121,8 +121,6 @@ function QuestieTracker:Initialize()
 
     -- Santity checks and settings applied at login
     C_Timer.After(0.4, function()
-        if Questie.db[Questie.db.global.questieTLoc].TrackerLocation == nil then return end
-
         -- Make sure the saved tracker location cords are on the players screen
         if Questie.db[Questie.db.global.questieTLoc].TrackerLocation and Questie.db[Questie.db.global.questieTLoc].TrackerLocation[2] and Questie.db[Questie.db.global.questieTLoc].TrackerLocation[2] == "MinimapCluster" or Questie.db[Questie.db.global.questieTLoc].TrackerLocation[2] == "UIParent" then
             local baseFrame = QuestieTracker:GetBaseFrame()
@@ -1481,7 +1479,7 @@ function QuestieTracker:Update()
             line:SetWidth(line.label:GetWidth())
 
             if Questie.db.global.collapseCompletedQuests and (complete == 1 or complete == -1) then
-                if Questie.db.char.collapsedQuests[quest.Id] == nil then
+                if not Questie.db.char.collapsedQuests[quest.Id] then
                     Questie.db.char.collapsedQuests[quest.Id] = true
                     line.expandQuest:SetMode(1)
                 end
@@ -1524,7 +1522,7 @@ function QuestieTracker:Update()
                         self:SetParent(self.line)
                         self:Show()
 
-                        if Questie.db.char.collapsedQuests[quest.Id] == nil then
+                        if not Questie.db.char.collapsedQuests[quest.Id] then
                             self.line.expandQuest:Hide()
                         else
                             self:SetParent(UIParent)
@@ -2383,7 +2381,7 @@ _GetDistanceToClosestObjective = function(questId)
     local closestDistance;
     for _, _ in pairs(coordinates) do
         local distance = _GetDistance(player.x, player.y, worldPosition.x, worldPosition.y);
-        if closestDistance == nil or distance < closestDistance then
+        if (not closestDistance) or (distance < closestDistance) then
             closestDistance = distance;
         end
     end

--- a/Modules/Tracker/QuestieTrackerMenu.lua
+++ b/Modules/Tracker/QuestieTrackerMenu.lua
@@ -86,7 +86,7 @@ _AddTomTomOption = function (menu, quest, objective)
     tinsert(menu, {text = l10n('Set |cFF54e33bTomTom|r Target'), func = function()
         LibDropDown:CloseDropDownMenus()
         local spawn, zone, name = QuestieMap:GetNearestQuestSpawn(quest)
-        if spawn == nil and objective ~= nil then
+        if (not spawn) and objective ~= nil then
             spawn, zone, name = QuestieMap:GetNearestSpawn(objective)
         end
         if spawn then


### PR DESCRIPTION
Convert `x == nil` comparisons to `not x`, if `x` doesn't have different meanings for `nil` and `false`.

`(not x)` is more readable than `x == nil` most of time. As a bonus it is slightly faster (around 5%).

NOT REVIEWED. NOT TESTED.