### PR TITLE
Fix quest The Infernal Orb (1954)

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -947,6 +947,9 @@ function QuestieQuestFixes:Load()
         [1950] = {
             [questKeys.triggerEnd] = {"Secret phrase found", {[zoneIDs.THOUSAND_NEEDLES]={{79.56,75.65}}}},
         },
+        [1954] = {
+            [questKeys.preQuestSingle] = {},
+        },
         [1955] = {
             [questKeys.triggerEnd] = {"Kill the Demon of the Orb", {[zoneIDs.DUSTWALLOW_MARSH]={{45.6,57,2}}}},
         },


### PR DESCRIPTION
Fix quest [The Infernal Orb (1954)](https://classic.wowhead.com/quest=1954/the-infernal-orb), the quest [Return to the Marsh (1953)](https://classic.wowhead.com/quest=1953/return-to-the-marsh) is not required to pick up this quest, its only a breadcrumb.