### PR TITLE
Fix item Worn Junkbox (16883) causing stack overflows

### DIFF
--- a/Database/Corrections/Classic/classicItemFixes.lua
+++ b/Database/Corrections/Classic/classicItemFixes.lua
@@ -925,6 +925,9 @@ function QuestieItemFixes:Load()
         [16882] = {
             [itemKeys.itemDrops] = {},
         },
+        [16883] = {
+            [itemKeys.itemDrops] = {},
+        },
         [16884] = {
             [itemKeys.itemDrops] = {},
         },


### PR DESCRIPTION
Fix item [Worn Junkbox (16883)](https://classic.wowhead.com/item=16883/worn-junkbox) causing stack overflows, because it contained itself in the list of itemDrops.