### PR TITLE
fix callback queue to work

### DIFF
--- a/Modules/QuestieValidateGameCache.lua
+++ b/Modules/QuestieValidateGameCache.lua
@@ -142,7 +142,7 @@ local function OnQuestLogUpdate()
     -- Call all callbacks
     while (#callbacks > 0) do
         local callback = tremove(callbacks, 1)
-        local func, args = tunpack(callback)
+        local func, args = callback[1], callback[2]
         Questie:Debug(Questie.DEBUG_DEVELOP, "[QuestieValidateGameCache] Calling a callback.")
         func(tunpack(args))
     end


### PR DESCRIPTION
Seems timing is good enough on all users to run callbacks imediately
instead of via queue.
The bug stops Questie init fully, when timing is suitable.
