### PR TITLE
Hide "In Search for Thaelrid" from horde once again

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -622,9 +622,6 @@ function QuestieQuestFixes:Load()
         [1193] = {
             [questKeys.specialFlags] = 1, -- #1348
         },
-        [1198] = {
-            [questKeys.requiredRaces] = raceIDs.NONE,
-        },
         [1204] = {
             [questKeys.preQuestSingle] = {}, -- #938
         },


### PR DESCRIPTION
## Issue references

Fixes [4080](https://github.com/Questie/Questie/issues/4080)

## Proposed changes

- Remove the correction that shows "In Search of Thaelrid" to all races