### PR TITLE
Hide "In Search for Thaelrid" from horde once again

### DIFF
--- a/Database/Corrections/Wotlk/wotlkQuestFixes.lua
+++ b/Database/Corrections/Wotlk/wotlkQuestFixes.lua
@@ -16,6 +16,9 @@ function QuestieWotlkQuestFixes:Load()
     local sortKeys = QuestieDB.sortKeys
 
     return {
+        [1198] = {
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+        },
         [4740] = {
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
         },


### PR DESCRIPTION
## Issue references

Fixes: [4080](https://github.com/Questie/Questie/issues/4080)

## Proposed changes

- Revert the correction that shows "In Search of Thaelrid" to all races so that it now only shows to Alliance races

(This is a PR to the `wotlk-support` branch)