### PR TITLE
Added Aresella (18991) to first aid profession

### DIFF
--- a/Modules/QuestieMenu.lua
+++ b/Modules/QuestieMenu.lua
@@ -464,7 +464,9 @@ function QuestieMenu:PopulateTownsfolk()
     tinsert(professionTrainers[QuestieProfessions.professionKeys.FISHING], 10216)
 
     -- Fix NPC Aresella (18991) can train first aid profession
-    tinsert(professionTrainers[QuestieProfessions.professionKeys.FIRST_AID], 18991)
+    if Questie.IsTBC then
+        tinsert(professionTrainers[QuestieProfessions.professionKeys.FIRST_AID], 18991)
+    end
 
     Questie.db.global.professionTrainers = professionTrainers
 

--- a/Modules/QuestieMenu.lua
+++ b/Modules/QuestieMenu.lua
@@ -463,6 +463,9 @@ function QuestieMenu:PopulateTownsfolk()
     -- Fix NPC Gubber Blump (10216) can train fishing profession
     tinsert(professionTrainers[QuestieProfessions.professionKeys.FISHING], 10216)
 
+    -- Fix NPC Aresella (18991) can train first aid profession
+    tinsert(professionTrainers[QuestieProfessions.professionKeys.FIRST_AID], 18991)
+
     Questie.db.global.professionTrainers = professionTrainers
 
     if Questie.IsWotlk then


### PR DESCRIPTION
## Proposed changes

- Adds [Aresella](https://www.wowhead.com/wotlk/npc=18991/aresella) as a First Aid profession trainer