### PR TITLE
[quest] Fix objective locations for "The Rune of Command"

### DIFF
--- a/Database/Corrections/Wotlk/wotlkQuestFixes.lua
+++ b/Database/Corrections/Wotlk/wotlkQuestFixes.lua
@@ -116,6 +116,12 @@ function QuestieWotlkQuestFixes:Load()
         [11346] = {
             [questKeys.preQuestSingle] = {11269,11329},
         },
+        [11348] = {
+            [questKeys.objectives] = {{{23725,"Test Rune of Command"},{24334}}},
+        },
+        [11352] = {
+            [questKeys.objectives] = {{{23725,"Test Rune of Command"},{24334}}},
+        },
         [11355] = {
             [questKeys.preQuestSingle] = {11269,11329},
             [questKeys.objectives] = {{{24329,"Runed Stone Giant Corpse Analyzed"},},nil,nil,nil,},


### PR DESCRIPTION
The quest item can only be used on the regular Stone Giants, not the Captive Stone Giants.

This fixes both the Horde and Alliance versions of this quest, which have the same bug.