### PR TITLE
Fix quest Catch and Release (9629)

### DIFF
--- a/Database/Corrections/Wotlk/wotlkQuestFixes.lua
+++ b/Database/Corrections/Wotlk/wotlkQuestFixes.lua
@@ -52,6 +52,9 @@ function QuestieWotlkQuestFixes:Load()
         [9247] = {
             [questKeys.finishedBy] = {{16281}},
         },
+        [9629] = {
+            [questKeys.objectives] = {{{17326}}},
+        },
         [9648] = {
             [questKeys.name] = "Maatparm Mushroom Menagerie",
         },


### PR DESCRIPTION
Fix quest [Catch and Release (9629)](https://www.wowhead.com/tbc/quest=9629/catch-and-release) missing extra objectives.