### PR TITLE
Fix quest Frostmane Hold (287) not appearing on map for humans

### DIFF
--- a/Database/Corrections/Classic/classicQuestFixes.lua
+++ b/Database/Corrections/Classic/classicQuestFixes.lua
@@ -177,9 +177,6 @@ function QuestieQuestFixes:Load()
         [415] = {
             [questKeys.exclusiveTo] = {413}, -- cant complete rejolds new brew if you do shimmer stout (see issue 567)
         },
-        [420] = {
-            [questKeys.nextQuestInChain] = 287,
-        },
         [428] = {
             [questKeys.exclusiveTo] = {429}, -- lost deathstalkers breadcrumb
         },


### PR DESCRIPTION
I never really paid attention to this before, but this morning I just saw that there's a quest when playing human in Dun Morogh that was available on an NPC which wasn't visible on map.