### PR TITLE
Add requiredSpell and requiredSpecialization to quest database

### DIFF
--- a/Database/Classic/classicQuestDB.lua
+++ b/Database/Classic/classicQuestDB.lua
@@ -41,6 +41,8 @@ QuestieDB.questKeys = {
     ['parentQuest'] = 25, -- int, the ID of the parent quest that needs to be active for the current one to be available. See also 'childQuests' (field 14)
     ['rewardReputation'] = 26, --table: {{faction(int), value(int)},...}, a list of reputation rewarded upon quest completion
     ['extraObjectives'] = 27, -- table: {{spawnlist, iconFile, text, objectiveIndex (optional), {{dbReferenceType, id}, ...} (optional)},...}, a list of hidden special objectives for a quest. Similar to requiredSourceItems
+    ['requiredSpell'] = 28, -- int: quest is only available if character has this spellID
+    ['requiredSpecialization'] = 29, -- int: quest is only available if character meets the spec requirements. Use QuestieProfessions.specializationKeys for having a spec, or QuestieProfessions.professionKeys to indicate having the profession with no spec. See QuestieProfessions.lua for more info.
 }
 
 QuestieDB.questData = [[return {

--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -36,6 +36,8 @@ function QuestieQuestFixes:Load()
     local raceIDs = QuestieDB.raceKeys
     local classIDs = QuestieDB.classKeys
     local sortKeys = QuestieDB.sortKeys
+    local profKeys = QuestieProfessions.professionKeys
+    local specKeys = QuestieProfessions.specializationKeys
 
     return {
         [2] = {

--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -7,6 +7,8 @@ local QuestieQuestFixes = QuestieLoader:CreateModule("QuestieQuestFixes")
 local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
 ---@type ZoneDB
 local ZoneDB = QuestieLoader:ImportModule("ZoneDB")
+---@type QuestieProfessions
+local QuestieProfessions = QuestieLoader:ImportModule("QuestieProfessions")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
 

--- a/Database/Corrections/tbcQuestFixes.lua
+++ b/Database/Corrections/tbcQuestFixes.lua
@@ -26,6 +26,8 @@ function QuestieTBCQuestFixes:Load()
     local classIDs = QuestieDB.classKeys
     local zoneIDs = ZoneDB.zoneIDs
     local sortKeys = QuestieDB.sortKeys
+    local profKeys = QuestieProfessions.professionKeys
+    local specKeys = QuestieProfessions.specializationKeys
 
     return {
         [62] = {

--- a/Database/Corrections/tbcQuestFixes.lua
+++ b/Database/Corrections/tbcQuestFixes.lua
@@ -6,6 +6,8 @@ local _QuestieTBCQuestFixes = {}
 local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
 ---@type ZoneDB
 local ZoneDB = QuestieLoader:ImportModule("ZoneDB")
+---@type QuestieProfessions
+local QuestieProfessions = QuestieLoader:ImportModule("QuestieProfessions")
 ---@type QuestieCorrections
 local QuestieCorrections = QuestieLoader:ImportModule("QuestieCorrections")
 ---@type l10n

--- a/Database/Corrections/wotlkQuestFixes.lua
+++ b/Database/Corrections/wotlkQuestFixes.lua
@@ -5,6 +5,8 @@ local QuestieWotlkQuestFixes = QuestieLoader:CreateModule("QuestieWotlkQuestFixe
 local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
 ---@type ZoneDB
 local ZoneDB = QuestieLoader:ImportModule("ZoneDB")
+---@type QuestieProfessions
+local QuestieProfessions = QuestieLoader:ImportModule("QuestieProfessions")
 ---@type QuestieCorrections
 local QuestieCorrections = QuestieLoader:ImportModule("QuestieCorrections")
 ---@type l10n

--- a/Database/Corrections/wotlkQuestFixes.lua
+++ b/Database/Corrections/wotlkQuestFixes.lua
@@ -28,6 +28,8 @@ function QuestieWotlkQuestFixes:Load()
     local classIDs = QuestieDB.classKeys
     local zoneIDs = ZoneDB.zoneIDs
     local sortKeys = QuestieDB.sortKeys
+    local profKeys = QuestieProfessions.professionKeys
+    local specKeys = QuestieProfessions.specializationKeys
 
     return {
         [236] = {

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -633,7 +633,7 @@ function QuestieDB.IsDoable(questId, debugPrint)
     local requiredSpecialization = QuestieDB.QueryQuestSingle(questId, "requiredSpecialization")
     if (requiredSpecialization) and (requiredSpecialization > 0) then
         local hasSpecialization = QuestieProfessions:HasSpecialization(requiredSpecialization)
-        if (not (hasSpecialization)) then
+        if (not hasSpecialization) then
             if debugPrint then Questie:Debug(Questie.DEBUG_SPAM, "[QuestieDB.IsDoable] Player does not meet spell requirements for", questId) end
             --? We don't blacklist purely based on lacking the spell, since it's rare and can change quickly
             --if(not hasSpell) then
@@ -646,7 +646,7 @@ function QuestieDB.IsDoable(questId, debugPrint)
     local requiredSpell = QuestieDB.QueryQuestSingle(questId, "requiredSpell")
     if (requiredSpell) and (requiredSpell > 0) then
         local hasSpell = IsSpellKnownOrOverridesKnown(requiredSpell)
-        if (not (hasSpell)) then
+        if (not hasSpell) then
             if debugPrint then Questie:Debug(Questie.DEBUG_SPAM, "[QuestieDB.IsDoable] Player does not meet spell requirements for", questId) end
             --? We don't blacklist purely based on lacking the spell, since it's rare and can change quickly
             --if(not hasSpell) then

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -630,6 +630,32 @@ function QuestieDB.IsDoable(questId, debugPrint)
         return false
     end
 
+    local requiredSpecialization = QuestieDB.QueryQuestSingle(questId, "requiredSpecialization")
+    if (requiredSpecialization) and (requiredSpecialization > 0) then
+        local hasSpecialization = QuestieProfessions:HasSpecialization(requiredSpecialization)
+        if (not (hasSpecialization)) then
+            if debugPrint then Questie:Debug(Questie.DEBUG_SPAM, "[QuestieDB.IsDoable] Player does not meet spell requirements for", questId) end
+            --? We don't blacklist purely based on lacking the spell, since it's rare and can change quickly
+            --if(not hasSpell) then
+            --    QuestieQuest.autoBlacklist[questId] = "spell"
+            --end
+            return false
+        end
+    end
+
+    local requiredSpell = QuestieDB.QueryQuestSingle(questId, "requiredSpell")
+    if (requiredSpell) and (requiredSpell > 0) then
+        local hasSpell = IsSpellKnownOrOverridesKnown(requiredSpell)
+        if (not (hasSpell)) then
+            if debugPrint then Questie:Debug(Questie.DEBUG_SPAM, "[QuestieDB.IsDoable] Player does not meet spell requirements for", questId) end
+            --? We don't blacklist purely based on lacking the spell, since it's rare and can change quickly
+            --if(not hasSpell) then
+            --    QuestieQuest.autoBlacklist[questId] = "spell"
+            --end
+            return false
+        end
+    end
+
     return true
 end
 

--- a/Database/TBC/tbcQuestDB.lua
+++ b/Database/TBC/tbcQuestDB.lua
@@ -41,6 +41,8 @@ QuestieDB.questKeys = {
     ['parentQuest'] = 25, -- int, the ID of the parent quest that needs to be active for the current one to be available. See also 'childQuests' (field 14)
     ['rewardReputation'] = 26, --table: {{faction(int), value(int)},...}, a list of reputation rewarded upon quest completion
     ['extraObjectives'] = 27, -- table: {{spawnlist, iconFile, text, objectiveIndex (optional), {{dbReferenceType, id}, ...} (optional)},...}, a list of hidden special objectives for a quest. Similar to requiredSourceItems
+    ['requiredSpell'] = 28, -- int: quest is only available if character has this spellID
+    ['requiredSpecialization'] = 29, -- int: quest is only available if character meets the spec requirements. Use QuestieProfessions.specializationKeys for having a spec, or QuestieProfessions.professionKeys to indicate having the profession with no spec. See QuestieProfessions.lua for more info.
 }
 
 QuestieDB.questData = [[return {

--- a/Database/Wotlk/wotlkQuestDB.lua
+++ b/Database/Wotlk/wotlkQuestDB.lua
@@ -41,6 +41,8 @@ QuestieDB.questKeys = {
     ['parentQuest'] = 25, -- int, the ID of the parent quest that needs to be active for the current one to be available. See also 'childQuests' (field 14)
     ['rewardReputation'] = 26, --table: {{faction(int), value(int)},...}, a list of reputation rewarded upon quest completion
     ['extraObjectives'] = 27, -- table: {{spawnlist, iconFile, text, objectiveIndex (optional), {{dbReferenceType, id}, ...} (optional)},...}, a list of hidden special objectives for a quest. Similar to requiredSourceItems
+    ['requiredSpell'] = 28, -- int: quest is only available if character has this spellID
+    ['requiredSpecialization'] = 29, -- int: quest is only available if character meets the spec requirements. Use QuestieProfessions.specializationKeys for having a spec, or QuestieProfessions.professionKeys to indicate having the profession with no spec. See QuestieProfessions.lua for more info.
 }
 
 QuestieDB.questData = [[return {

--- a/Database/questDB.lua
+++ b/Database/questDB.lua
@@ -40,6 +40,7 @@ QuestieDB.questKeys = {
     ['parentQuest'] = 25, -- int, the ID of the parent quest that needs to be active for the current one to be available. See also 'childQuests' (field 14)
     ['reputationReward'] = 26, -- table: {{FACTION,VALUE}, ...}, A list of reputation reward for factions
     ['extraObjectives'] = 27, -- table: {{spawnlist, iconFile, text, objectiveIndex (optional), {{dbReferenceType, id}, ...} (optional)},...}, a list of hidden special objectives for a quest. Similar to requiredSourceItems
+    ['requiredSpell'] = 28, -- int: quest is only available if character has this spellID
 }
 
 QuestieDB.questKeysReversed = {}
@@ -75,12 +76,13 @@ QuestieDB.questCompilerTypes = {
     ['parentQuest'] = "u24", -- int, the ID of the parent quest that needs to be active for the current one to be available. See also 'childQuests' (field 14)
     ['reputationReward'] = "u8s24pairs",
     ['extraObjectives'] = "extraobjectives",
+    ['requiredSpell'] = "u24",
 }
 
 QuestieDB.questCompilerOrder = { -- order easily skipable data first for efficiency
     --static size
     'requiredLevel', 'questLevel', 'requiredRaces', 'requiredClasses', 'sourceItemId', 'zoneOrSort', 'requiredSkill',
-    'requiredMinRep', 'requiredMaxRep', 'nextQuestInChain', 'questFlags', 'specialFlags', 'parentQuest',
+    'requiredMinRep', 'requiredMaxRep', 'nextQuestInChain', 'questFlags', 'specialFlags', 'parentQuest', 'requiredSpell',
 
     -- variable size
     'name', 'preQuestGroup', 'preQuestSingle', 'childQuests', 'inGroupWith', 'exclusiveTo', 'requiredSourceItems',

--- a/Database/questDB.lua
+++ b/Database/questDB.lua
@@ -41,6 +41,7 @@ QuestieDB.questKeys = {
     ['reputationReward'] = 26, -- table: {{FACTION,VALUE}, ...}, A list of reputation reward for factions
     ['extraObjectives'] = 27, -- table: {{spawnlist, iconFile, text, objectiveIndex (optional), {{dbReferenceType, id}, ...} (optional)},...}, a list of hidden special objectives for a quest. Similar to requiredSourceItems
     ['requiredSpell'] = 28, -- int: quest is only available if character has this spellID
+    ['requiredSpecialization'] = 29, -- int: quest is only available if character meets the spec requirements. Use QuestieProfessions.specializationKeys for having a spec, or QuestieProfessions.professionKeys to indicate having the profession with no spec. See QuestieProfessions.lua for more info.
 }
 
 QuestieDB.questKeysReversed = {}
@@ -77,12 +78,14 @@ QuestieDB.questCompilerTypes = {
     ['reputationReward'] = "u8s24pairs",
     ['extraObjectives'] = "extraobjectives",
     ['requiredSpell'] = "u24",
+    ['requiredSpecialization'] = "u24",
 }
 
 QuestieDB.questCompilerOrder = { -- order easily skipable data first for efficiency
     --static size
     'requiredLevel', 'questLevel', 'requiredRaces', 'requiredClasses', 'sourceItemId', 'zoneOrSort', 'requiredSkill',
     'requiredMinRep', 'requiredMaxRep', 'nextQuestInChain', 'questFlags', 'specialFlags', 'parentQuest', 'requiredSpell',
+    'requiredSpecialization',
 
     -- variable size
     'name', 'preQuestGroup', 'preQuestSingle', 'childQuests', 'inGroupWith', 'exclusiveTo', 'requiredSourceItems',

--- a/Modules/QuestieProfessions.lua
+++ b/Modules/QuestieProfessions.lua
@@ -276,7 +276,7 @@ end
 
 ---@return string
 function QuestieProfessions:GetSpecializationName(specializationKey)
-    return specializationNames[professionKey]
+    return specializationNames[specializationKey]
 end
 
 ---@return number

--- a/Modules/QuestieProfessions.lua
+++ b/Modules/QuestieProfessions.lua
@@ -125,6 +125,52 @@ function QuestieProfessions:HasProfessionAndSkillLevel(requiredSkill)
     return _HasProfession(profession), _HasSkillLevel(profession, skillLevel)
 end
 
+---@param requiredSpecialization { [1]: number } [1] = professionId
+---@return boolean HasSpecialization
+function QuestieProfessions:HasSpecialization(requiredSpecialization)
+    if not requiredSpecialization then
+        --? We return true here because otherwise we would have to check for nil everywhere
+        return true
+    end
+    for _, value in pairs(QuestieProfessions.professionKeys) do
+        if value == requiredSpecialization then -- if we determine input is a profession
+            if requiredSpecialization == QuestieProfessions.professionKeys.ALCHEMY then
+                return not (IsSpellKnown(QuestieProfessions.specializationKeys.ALCHEMY_ELIXIR)
+                or IsSpellKnown(QuestieProfessions.specializationKeys.ALCHEMY_POTION)
+                or IsSpellKnown(QuestieProfessions.specializationKeys.ALCHEMY_TRANSMUTATION))
+                -- if the profession is alchemy, we only return true if the player does NOT know
+                -- the spells for elixir, potion, or transmutation master; otherwise return false
+            elseif requiredSpecialization == QuestieProfessions.professionKeys.BLACKSMITHING then
+                return not (IsSpellKnown(QuestieProfessions.specializationKeys.BLACKSMITHING_ARMOR)
+                or IsSpellKnown(QuestieProfessions.specializationKeys.BLACKSMITHING_WEAPON))
+            
+            elseif requiredSpecialization == QuestieProfessions.professionKeys.ENGINEERING then
+                return not (IsSpellKnown(QuestieProfessions.specializationKeys.ENGINEERING_GNOMISH)
+                or IsSpellKnown(QuestieProfessions.specializationKeys.ENGINEERING_GOBLIN))
+            
+            elseif requiredSpecialization == QuestieProfessions.professionKeys.LEATHERWORKING then
+                return not (IsSpellKnown(QuestieProfessions.specializationKeys.LEATHERWORKING_DRAGONSCALE)
+                or IsSpellKnown(QuestieProfessions.specializationKeys.LEATHERWORKING_ELEMENTAL)
+                or IsSpellKnown(QuestieProfessions.specializationKeys.LEATHERWORKING_TRIBAL))
+            
+            elseif requiredSpecialization == QuestieProfessions.professionKeys.TAILORING then
+                return not (IsSpellKnown(QuestieProfessions.specializationKeys.TAILORING_MOONCLOTH)
+                or IsSpellKnown(QuestieProfessions.specializationKeys.TAILORING_SHADOWEAVE)
+                or IsSpellKnown(QuestieProfessions.specializationKeys.TAILORING_SPELLFIRE))
+            
+            end
+            return _HasProfession(requiredSpecialization)
+            -- if the profession is not one with known specs, return true if the player has that profession
+        end
+    end
+    for _, value in pairs(QuestieProfessions.specializationKeys) do
+        if value == requiredSpecialization then -- if we determine input is a specialization
+            return IsSpellKnownOrOverridesKnown(requiredSpecialization) -- return true if the spell is known, false if not
+        end
+    end
+    return true
+end
+
 ---@enum ProfessionEnum
 QuestieProfessions.professionKeys = {
     FIRST_AID = 129,

--- a/Modules/QuestieProfessions.lua
+++ b/Modules/QuestieProfessions.lua
@@ -9,11 +9,11 @@ local l10n = QuestieLoader:ImportModule("l10n")
 local playerProfessions = {}
 local professionTable = {}
 local professionNames = {}
-local specializationNames = {}
+local specializationNames
 local alternativeProfessionNames = {}
 
 -- Fast local references
-local ExpandSkillHeader, GetNumSkillLines, GetSkillLineInfo = ExpandSkillHeader, GetNumSkillLines, GetSkillLineInfo
+local ExpandSkillHeader, GetNumSkillLines, GetSkillLineInfo, IsSpellKnown = ExpandSkillHeader, GetNumSkillLines, GetSkillLineInfo, IsSpellKnown
 
 hooksecurefunc("AbandonSkill", function(skillIndex)
     local skillName = GetSkillLineInfo(skillIndex)
@@ -132,40 +132,42 @@ function QuestieProfessions:HasSpecialization(requiredSpecialization)
         --? We return true here because otherwise we would have to check for nil everywhere
         return true
     end
+    local professionKeys = QuestieProfessions.professionKeys
+    local specializationKeys = QuestieProfessions.specializationKeys
     for _, value in pairs(QuestieProfessions.professionKeys) do
         if value == requiredSpecialization then -- if we determine input is a profession
-            if requiredSpecialization == QuestieProfessions.professionKeys.ALCHEMY then
-                return not (IsSpellKnown(QuestieProfessions.specializationKeys.ALCHEMY_ELIXIR)
-                or IsSpellKnown(QuestieProfessions.specializationKeys.ALCHEMY_POTION)
-                or IsSpellKnown(QuestieProfessions.specializationKeys.ALCHEMY_TRANSMUTATION))
+            if requiredSpecialization == professionKeys.ALCHEMY then
+                return not (IsSpellKnown(specializationKeys.ALCHEMY_ELIXIR)
+                or IsSpellKnown(specializationKeys.ALCHEMY_POTION)
+                or IsSpellKnown(specializationKeys.ALCHEMY_TRANSMUTATION))
                 -- if the profession is alchemy, we only return true if the player does NOT know
                 -- the spells for elixir, potion, or transmutation master; otherwise return false
-            elseif requiredSpecialization == QuestieProfessions.professionKeys.BLACKSMITHING then
-                return not (IsSpellKnown(QuestieProfessions.specializationKeys.BLACKSMITHING_ARMOR)
-                or IsSpellKnown(QuestieProfessions.specializationKeys.BLACKSMITHING_WEAPON))
+            elseif requiredSpecialization == professionKeys.BLACKSMITHING then
+                return not (IsSpellKnown(specializationKeys.BLACKSMITHING_ARMOR)
+                or IsSpellKnown(specializationKeys.BLACKSMITHING_WEAPON))
             
-            elseif requiredSpecialization == QuestieProfessions.professionKeys.ENGINEERING then
-                return not (IsSpellKnown(QuestieProfessions.specializationKeys.ENGINEERING_GNOMISH)
-                or IsSpellKnown(QuestieProfessions.specializationKeys.ENGINEERING_GOBLIN))
+            elseif requiredSpecialization == professionKeys.ENGINEERING then
+                return not (IsSpellKnown(specializationKeys.ENGINEERING_GNOMISH)
+                or IsSpellKnown(specializationKeys.ENGINEERING_GOBLIN))
             
-            elseif requiredSpecialization == QuestieProfessions.professionKeys.LEATHERWORKING then
-                return not (IsSpellKnown(QuestieProfessions.specializationKeys.LEATHERWORKING_DRAGONSCALE)
-                or IsSpellKnown(QuestieProfessions.specializationKeys.LEATHERWORKING_ELEMENTAL)
-                or IsSpellKnown(QuestieProfessions.specializationKeys.LEATHERWORKING_TRIBAL))
+            elseif requiredSpecialization == professionKeys.LEATHERWORKING then
+                return not (IsSpellKnown(specializationKeys.LEATHERWORKING_DRAGONSCALE)
+                or IsSpellKnown(specializationKeys.LEATHERWORKING_ELEMENTAL)
+                or IsSpellKnown(specializationKeys.LEATHERWORKING_TRIBAL))
             
-            elseif requiredSpecialization == QuestieProfessions.professionKeys.TAILORING then
-                return not (IsSpellKnown(QuestieProfessions.specializationKeys.TAILORING_MOONCLOTH)
-                or IsSpellKnown(QuestieProfessions.specializationKeys.TAILORING_SHADOWEAVE)
-                or IsSpellKnown(QuestieProfessions.specializationKeys.TAILORING_SPELLFIRE))
+            elseif requiredSpecialization == professionKeys.TAILORING then
+                return not (IsSpellKnown(specializationKeys.TAILORING_MOONCLOTH)
+                or IsSpellKnown(specializationKeys.TAILORING_SHADOWEAVE)
+                or IsSpellKnown(specializationKeys.TAILORING_SPELLFIRE))
             
             end
             return _HasProfession(requiredSpecialization)
             -- if the profession is not one with known specs, return true if the player has that profession
         end
     end
-    for _, value in pairs(QuestieProfessions.specializationKeys) do
+    for _, value in pairs(specializationKeys) do
         if value == requiredSpecialization then -- if we determine input is a specialization
-            return IsSpellKnownOrOverridesKnown(requiredSpecialization) -- return true if the spell is known, false if not
+            return IsSpellKnown(requiredSpecialization) -- return true if the spell is known, false if not
         end
     end
     return true

--- a/Modules/QuestieProfessions.lua
+++ b/Modules/QuestieProfessions.lua
@@ -9,6 +9,7 @@ local l10n = QuestieLoader:ImportModule("l10n")
 local playerProfessions = {}
 local professionTable = {}
 local professionNames = {}
+local specializationNames = {}
 local alternativeProfessionNames = {}
 
 -- Fast local references
@@ -179,9 +180,57 @@ local sortIds = {
     --[QuestieProfessions.professionKeys.RIDING] = ,
 }
 
+QuestieProfessions.specializationKeys = { -- specializations use spellID, professions use skillID
+    ALCHEMY = QuestieProfessions.professionKeys.ALCHEMY,
+    ALCHEMY_ELIXIR = 28677,
+    ALCHEMY_POTION = 28675,
+    ALCHEMY_TRANSMUTATION = 28672,
+    BLACKSMITHING = QuestieProfessions.professionKeys.BLACKSMITHING,
+    BLACKSMITHING_ARMOR = 9788,
+    BLACKSMITHING_WEAPON = 9787,
+    BLACKSMITHING_WEAPON_AXE = 17041,
+    BLACKSMITHING_WEAPON_HAMMER = 17040,
+    BLACKSMITHING_WEAPON_SWORD = 17039,
+    ENGINEERING = QuestieProfessions.professionKeys.ENGINEERING,
+    ENGINEERING_GNOMISH = 20219,
+    ENGINEERING_GOBLIN = 20222,
+    LEATHERWORKING = QuestieProfessions.professionKeys.LEATHERWORKING,
+    LEATHERWORKING_DRAGONSCALE = 10656,
+    LEATHERWORKING_ELEMENTAL = 10658,
+    LEATHERWORKING_TRIBAL = 10660,
+    TAILORING = QuestieProfessions.professionKeys.TAILORING,
+    TAILORING_MOONCLOTH = 26798,
+    TAILORING_SHADOWEAVE = 26801,
+    TAILORING_SPELLFIRE = 26797,
+}
+
+specializationNames = {
+    [QuestieProfessions.specializationKeys.ALCHEMY_ELIXIR] = "Elixir Master",
+    [QuestieProfessions.specializationKeys.ALCHEMY_POTION] = "Potion Master",
+    [QuestieProfessions.specializationKeys.ALCHEMY_TRANSMUTATION] = "Transmutation Master",
+    [QuestieProfessions.specializationKeys.BLACKSMITHING_ARMOR] = "Armorsmith",
+    [QuestieProfessions.specializationKeys.BLACKSMITHING_WEAPON] = "Weaponsmith",
+    [QuestieProfessions.specializationKeys.BLACKSMITHING_WEAPON_AXE] = "Master Axesmith",
+    [QuestieProfessions.specializationKeys.BLACKSMITHING_WEAPON_HAMMER] = "Master Hammersmith",
+    [QuestieProfessions.specializationKeys.BLACKSMITHING_WEAPON_SWORD] = "Master Swordsmith",
+    [QuestieProfessions.specializationKeys.ENGINEERING_GNOMISH] = "Gnomish Engineer",
+    [QuestieProfessions.specializationKeys.ENGINEERING_GOBLIN] = "Goblin Engineer",
+    [QuestieProfessions.specializationKeys.LEATHERWORKING_DRAGONSCALE] = "Dragonscale Leatherworking",
+    [QuestieProfessions.specializationKeys.LEATHERWORKING_ELEMENTAL] = "Elemental Leatherworking",
+    [QuestieProfessions.specializationKeys.LEATHERWORKING_TRIBAL] = "Tribal Leatherworking",
+    [QuestieProfessions.specializationKeys.TAILORING_MOONCLOTH] = "Mooncloth Tailoring",
+    [QuestieProfessions.specializationKeys.TAILORING_SHADOWEAVE] = "Shadoweave Tailoring",
+    [QuestieProfessions.specializationKeys.TAILORING_SPELLFIRE] = "Spellfire Tailoring",
+}
+
 ---@return string
 function QuestieProfessions:GetProfessionName(professionKey)
     return professionNames[professionKey]
+end
+
+---@return string
+function QuestieProfessions:GetSpecializationName(specializationKey)
+    return specializationNames[professionKey]
 end
 
 ---@return number


### PR DESCRIPTION
This PR adds two DB parameters, `requiredSpell` and `requiredSpecialization`. It also adds a list of specializationKeys to QuestieProfessions.

`requiredSpell` means the quest will not show as available if the player lacks the spellID specified.

`requiredSpecialization` has some slightly complex logic. If fed a specializationKey (new), the quest will be hidden if the player does not have that specialization, checked with the basic `IsSpellKnown()` API call. If fed a professionKey, the quest will be hidden if the player either lacks that profession entirely, or has the profession *and* any of its specializations learned. In essence, this is a test to see if the player has *just* the base profession learned, and is therefore eligible to learn a specialization.

By default, all quests have these fields set to `nil`, and these logic trees are only entered (during QuestieDB.IsDoable) if data is found in these fields. Because these cases are so rare, these are the absolute last fields checked - if the quest is ruled as "not doable" from any other requirement prior, we don't even reach this logic.

`requiredSpell` is, as far as I know, not currently needed for any quests up to Wrath, but it may be required for something in Cataclysm. `requiredSpecialization` is already needed in Vanilla.