### PR TITLE
Fix missing item Unlit Torch

### DIFF
--- a/Database/Corrections/classicItemFixes.lua
+++ b/Database/Corrections/classicItemFixes.lua
@@ -1193,9 +1193,15 @@ function QuestieItemFixes:Load()
             [itemKeys.npcDrops] = {3782,3784},
             [itemKeys.relatedQuests] = {65610},
         },
+        [190307] = {
+            [itemKeys.name] = "Unlit Torch",
+            [itemKeys.objectDrops] = {400014},
+            [itemKeys.flags] = 2, -- Conjured
+            [itemKeys.relatedQuests] = {65602},
+        },
         [190309] = {
             [itemKeys.name] = "Wooden Figurine",
-            [itemKeys.objectDrops] = {400013},
+            [itemKeys.objectDrops] = {375544},
             [itemKeys.relatedQuests] = {65602},
         },
     }

--- a/Database/Corrections/classicObjectFixes.lua
+++ b/Database/Corrections/classicObjectFixes.lua
@@ -231,10 +231,15 @@ function QuestieObjectFixes:Load()
             [objectKeys.spawns] = {[zoneIDs.THOUSAND_NEEDLES]={{39.34,41.53}}},
             [objectKeys.zoneID] = zoneIDs.THOUSAND_NEEDLES,
         },
-        -- Fake IDs
-        [400013] = {
+        [375544] = {
             [objectKeys.name] = "Wooden Figurine",
-            [objectKeys.spawns] = {[zoneIDs.ASHENVALE]={{26.6,22}}},
+            [objectKeys.spawns] = {[zoneIDs.ASHENVALE]={{26.61,22.03}}},
+            [objectKeys.zoneID] = zoneIDs.ASHENVALE,
+        },
+        -- Fake IDs
+        [400014] = {
+            [objectKeys.name] = "Unlit Torch",
+            [objectKeys.spawns] = {[zoneIDs.ASHENVALE]={{26.79,22.43}}},
             [objectKeys.zoneID] = zoneIDs.ASHENVALE,
         },
         [500000] = {


### PR DESCRIPTION
- Fix missing item [Unlit Torch (190307)](https://www.wowhead.com/classic/item=190307/unlit-torch)
- Fix [Wooden Figurine (375544)](https://www.wowhead.com/classic/object=375544/wooden-figurine) object ID and more precise location