### PR TITLE
Fix quest The Tome of Valor (1793, 1794)

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -918,9 +918,12 @@ function QuestieQuestFixes:Load()
         },
         [1793] = {
             [questKeys.exclusiveTo] = {1649},
+            [questKeys.specialFlags] = 1,
         },
         [1794] = {
+            [questKeys.startedBy] = {{6179},nil,nil},
             [questKeys.exclusiveTo] = {1649},
+            [questKeys.specialFlags] = 1,
         },
         [1799] = {
             [questKeys.preQuestSingle] = {4965,4967,4968,4969},


### PR DESCRIPTION
Fix Paladin quest The Tome of Valor
- Quest [The Tome of Valor (1793)](https://www.wowhead.com/classic/quest=1793/the-tome-of-valor) is repeatable
- Quest [The Tome of Valor (1794)](https://www.wowhead.com/classic/quest=1794/the-tome-of-valor) is started by [Tiza Battleforge (6179)](https://www.wowhead.com/classic/npc=6179/tiza-battleforge) and is repeatable