### PR TITLE
Fix quest The Tome of Nobility (1661)

### DIFF
--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1041,7 +1041,7 @@ function QuestieQuestBlacklist:Load()
         [708] = true,
         [909] = true,
         [1288] = true,
-        [1661] = true,
+        [1661] = QuestieCorrections.WOTLK_ONLY,
         [3366] = true,
         [3381] = true,
         [5627] = true,

--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1041,7 +1041,7 @@ function QuestieQuestBlacklist:Load()
         [708] = true,
         [909] = true,
         [1288] = true,
-        [1661] = QuestieCorrections.WOTLK_ONLY,
+        [1661] = QuestieCorrections.TBC_AND_WOTLK,
         [3366] = true,
         [3381] = true,
         [5627] = true,


### PR DESCRIPTION
Fix quest [The Tome of Nobility (1661)](https://www.wowhead.com/classic/quest=1661/the-tome-of-nobility) not showing up on the NPC in Classic Era. Quest was marked as hidden by Questie. I investigated and found that it was blacklisted. This is a mistake because this quest exists in Classic Era, and also exists in TBC and Wrath.