### PR TITLE
Fix for DBM Hud issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2711,7 +2711,10 @@
         "Questie_Toggle",
         "Questie_SpecialNPCs",
         "TEMP_Questie2Events",
-        "LQuestie_Create_UIDropDownMenu"
+        "LQuestie_Create_UIDropDownMenu",
+        "GossipAvailableQuestButtonMixin",
+        "GossipActiveQuestButtonMixin",
+        "ChatFontNormal"
     ],
     "Lua.workspace.ignoreDir": [
         "Database/TBC/**", //Because they do not actually differ from classic in structure, load the smallest

--- a/Modules/QuestieDBMIntegration.lua
+++ b/Modules/QuestieDBMIntegration.lua
@@ -25,7 +25,7 @@ local QuestieHUDEnabled = false
 local function AddHudQuestIcon(tableString, icon, AreaID, x, y, r, g, b)
     if tableString and not AddedHudIds[tableString] then
         --Icon based filters, if icon is disabled, return without adding
-        if not Questie.db.global.dbmHUDShowSlay and icon:find("slay") or not Questie.db.global.dbmHUDShowQuest and (icon:find("complete") or icon:find("available")) or not Questie.db.global.dbmHUDShowInteract and icon:find("object") or not Questie.db.global.dbmHUDShowLoot and icon:find("loot") then return end
+        if not Questie.db.global.dbmHUDShowSlay and Questie.usedIcons[Questie.ICON_TYPE_SLAY] or not Questie.db.global.dbmHUDShowQuest and (Questie.usedIcons[Questie.ICON_TYPE_COMPLETE] or Questie.usedIcons[Questie.ICON_TYPE_AVAILABLE]) or not Questie.db.global.dbmHUDShowInteract and Questie.usedIcons[Questie.ICON_TYPE_OBJECT] or not Questie.db.global.dbmHUDShowLoot and Questie.usedIcons[Questie.ICON_TYPE_LOOT] then return end
         if not DBM.HudMap.HUDEnabled then
             --Force a fixed zoom, if one is not set, hudmap tries to zoom out until all registered icons fit, that's no good for world wide quest icons
             DBM.HudMap:SetFixedZoom(Questie.db.global.DBMHUDZoom or 100)
@@ -33,9 +33,9 @@ local function AddHudQuestIcon(tableString, icon, AreaID, x, y, r, g, b)
         end
         --uniqueID, name, texture, x, y, radius, duration, r, g, b, a, blend, useLocalMap, LocalMapId
         if Questie.db.global.dbmHUDShowAlert then
-            DBM.HudMap:RegisterPositionMarker(tableString, "Questie", icon, x, y, Questie.db.global.dbmHUDRadius or 3, nil, r, g, b, 1, nil, true, AreaID):Appear():RegisterForAlerts()
+            DBM.HudMap:RegisterPositionMarker(tableString, "Questie", Questie.usedIcons[icon], x, y, Questie.db.global.dbmHUDRadius or 3, nil, r, g, b, 1, nil, true, AreaID):Appear():RegisterForAlerts()
         else
-            DBM.HudMap:RegisterPositionMarker(tableString, "Questie", icon, x, y, Questie.db.global.dbmHUDRadius or 3, nil, r, g, b, 1, nil, true, AreaID):Appear()
+            DBM.HudMap:RegisterPositionMarker(tableString, "Questie", Questie.usedIcons[icon], x, y, Questie.db.global.dbmHUDRadius or 3, nil, r, g, b, 1, nil, true, AreaID):Appear()
         end
         AddedHudIds[tableString] = true
         --print("Adding "..tableString)

--- a/Modules/QuestieDBMIntegration.lua
+++ b/Modules/QuestieDBMIntegration.lua
@@ -25,7 +25,12 @@ local QuestieHUDEnabled = false
 local function AddHudQuestIcon(tableString, icon, AreaID, x, y, r, g, b)
     if tableString and not AddedHudIds[tableString] then
         --Icon based filters, if icon is disabled, return without adding
-        if not Questie.db.global.dbmHUDShowSlay and Questie.usedIcons[Questie.ICON_TYPE_SLAY] or not Questie.db.global.dbmHUDShowQuest and (Questie.usedIcons[Questie.ICON_TYPE_COMPLETE] or Questie.usedIcons[Questie.ICON_TYPE_AVAILABLE]) or not Questie.db.global.dbmHUDShowInteract and Questie.usedIcons[Questie.ICON_TYPE_OBJECT] or not Questie.db.global.dbmHUDShowLoot and Questie.usedIcons[Questie.ICON_TYPE_LOOT] then return end
+        if  not Questie.db.global.dbmHUDShowSlay and icon == Questie.ICON_TYPE_SLAY or 
+            not Questie.db.global.dbmHUDShowQuest and (icon == Questie.ICON_TYPE_COMPLETE or icon == Questie.ICON_TYPE_AVAILABLE) or 
+            not Questie.db.global.dbmHUDShowInteract and icon == Questie.ICON_TYPE_OBJECT or 
+            not Questie.db.global.dbmHUDShowLoot and icon == Questie.ICON_TYPE_LOOT then 
+            return 
+        end
         if not DBM.HudMap.HUDEnabled then
             --Force a fixed zoom, if one is not set, hudmap tries to zoom out until all registered icons fit, that's no good for world wide quest icons
             DBM.HudMap:SetFixedZoom(Questie.db.global.DBMHUDZoom or 100)


### PR DESCRIPTION
## Issue references

Fixes #4745
reported error with DBM Hud when enabled, causing errors related to changes with the quest icons
```
1x ...ace\AddOns\Questie\Modules\QuestieDBMIntegration.lua:28: attempt to index local 'icon' (a number value)
[string "@Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua"]:28: in function <...ace\AddOns\Questie\Modules\QuestieDBMIntegration.lua:25>
[string "@Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua"]:200: in function `RegisterHudQuestIcon'
[string "@Interface\AddOns\Questie\Modules\Map\QuestieMap.lua"]:684: in function `DrawWorldIcon'
[string "@Interface\AddOns\Questie\Modules\Quest\QuestieQuest.lua"]:631: in function `AddFinisher'
[string "@Interface\AddOns\Questie\Modules\Quest\QuestieQuest.lua"]:473: in function `UpdateQuest'
[string "@Interface\AddOns\Questie\Modules\Quest\QuestieQuest.lua"]:300: in function `?'
[string "@Interface\AddOns\Questie\Modules\Quest\QuestieQuest.lua"]:324: in function <...erface\AddOns\Questie\Modules\Quest\QuestieQuest.lua:323>
[string "@Interface\SharedXML\C_TimerAugment.lua"]:16: in function <Interface\SharedXML\C_TimerAugment.lua:14>

Locals:
tableString = "table: 0000000085866A30"
icon = 8
AreaID = 1429
x = 43.765281
y = 65.794621
r = 0.999998
g = 0.999998
b = 0.999998
(*temporary) = false
(*temporary) = 8
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = "attempt to index local 'icon' (a number value)"
AddedHudIds = <table> {
}
QuestieDBMIntegration = <table> {
 SoftReset = <function> defined @Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua:136
 RegisterHudQuestIcon = <function> defined @Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua:182
 EdgeTo = <function> defined @Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua:290
 EnableHUD = <function> defined @Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua:123
 ClearHudEdge = <function> defined @Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua:308
 ChangeZoomLevel = <function> defined @Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua:276
 ClearAll = <function> defined @Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua:144
 private = <table> {
 }
 ChangeRefreshRate = <function> defined @Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua:282
 UnregisterHudQuestIcon = <function> defined @Interface\AddOns\Questie\Modules\QuestieDBMIntegration.lua:264
}
```

## Proposed changes

-
-

## Screenshots

