### PR TITLE
Fix quest Morganth (249)

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -119,6 +119,9 @@ function QuestieQuestFixes:Load()
         [235] = {
             [questKeys.exclusiveTo] = {742,6382,6383},
         },
+        [249] = {
+            [questKeys.startedBy] = {{313},{31},nil},
+        },
         [254] = {
             [questKeys.parentQuest] = 253,
             [questKeys.specialFlags] = 1,


### PR DESCRIPTION
Fix quest [Morganth (249)](https://www.wowhead.com/classic/quest=249/morganth) ca also be started by npc [Theocritus (313)](https://www.wowhead.com/classic/npc=313/theocritus).