### PR TITLE
Fix item Branch of Cenarius (5461)

### DIFF
--- a/Database/Corrections/classicItemFixes.lua
+++ b/Database/Corrections/classicItemFixes.lua
@@ -344,6 +344,9 @@ function QuestieItemFixes:Load()
             [itemKeys.npcDrops] = {},
             [itemKeys.objectDrops] = {},
         },
+        [5461] = {
+            [itemKeys.npcDrops] = {4619},
+        },
         [5475] = {
             [itemKeys.relatedQuests] = {},
             [itemKeys.npcDrops] = {3919,3834},


### PR DESCRIPTION
Fix item [Branch of Cenarius (5461)](https://www.wowhead.com/classic/item=5461/branch-of-cenarius) that can only be dropped by [Geltharis (4619)](https://www.wowhead.com/classic/npc=4619/geltharis), it is **not** dropped by [Prince Raze (10647)](https://www.wowhead.com/classic/npc=10647/prince-raze).