### PR TITLE
Fix quest Raene's Cleansing (1046)

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -546,6 +546,9 @@ function QuestieQuestFixes:Load()
             [questKeys.requiredMinRep] = {87,3000},
             [questKeys.requiredMaxRep] = {21,-5999},
         },
+        [1046] = {
+            [questKeys.objectives] = {nil,nil,{{5388,nil},{5462,nil}}},
+        },
         [1047] = {
             [questKeys.exclusiveTo] = {1015,1019},
         },


### PR DESCRIPTION
Got an error from Questie after picking up quest [Raene's Cleansing (1046)](https://www.wowhead.com/classic/quest=1046/raenes-cleansing).

```
Questie: [ERROR] Missing objective data for quest  1046   Dartol's Rod of Transformation
```

This quest has two item objectives, one was missing.