### PR TITLE
Fix quest Elmore's Task (1097)

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -576,6 +576,7 @@ function QuestieQuestFixes:Load()
             [questKeys.triggerEnd] = {"Keep Piznik safe while he mines the mysterious ore", {[zoneIDs.STONETALON_MOUNTAINS]={{71.76, 60.22}}}},
         },
         [1097] = {
+            [questKeys.startedBy] = {{415,514},nil,nil},
             [questKeys.exclusiveTo] = {353}, -- #2364
         },
         [1100] = {


### PR DESCRIPTION
Fix quest [Elmore's Task (1097)](https://www.wowhead.com/classic/quest=1097/elmores-task) missing [Verner Osgood (415)](https://www.wowhead.com/classic/npc=415/verner-osgood) as starter.