### PR TITLE
[fix] Fix Tracker not showing 0/1 and 1/1 objectives

### DIFF
--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -844,11 +844,7 @@ function QuestieTracker:Update()
                                     lineEnding = tostring(objective.Collected) .. "/" .. tostring(objective.Needed)
 
                                     -- Set Objective text
-                                    if objective.Needed == 1 then
-                                        line.label:SetText(QuestieLib:GetRGBForObjective(objective) .. objDesc)
-                                    else
-                                        line.label:SetText(QuestieLib:GetRGBForObjective(objective) .. objDesc .. ": " .. lineEnding)
-                                    end
+                                    line.label:SetText(QuestieLib:GetRGBForObjective(objective) .. objDesc .. ": " .. lineEnding)
 
                                     if secondaryButton and secondaryButtonAlpha ~= 0 then
                                         if #quest.Objectives == 1 then


### PR DESCRIPTION
Fixes #4781

<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #4781

## Proposed changes

- The Tracker again shows `0/1` and `1/1`for objectives with just one required objective amount
- This does NOT change/reintroduce it for Achievements

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->

![grafik](https://user-images.githubusercontent.com/33514570/234092650-1abbdd77-37c2-4b72-84ec-457e7e87eff4.png)
