### PR TITLE
Fix quest Jonespyre's Request (3787, 3788) not visible on map

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -1288,6 +1288,12 @@ function QuestieQuestFixes:Load()
             [questKeys.exclusiveTo] = {1275}, -- corruption abroad breadcrumb
             [questKeys.requiredLevel] = 18,
         },
+        [3787] = {
+            [questKeys.preQuestSingle] = {3781},
+        },
+        [3788] = {
+            [questKeys.preQuestSingle] = {3781},
+        },
         [3789] = {
             [questKeys.exclusiveTo] = {3763,3790,3764},
         },


### PR DESCRIPTION
Fix quest [Jonespyre's Request (3787)](https://www.wowhead.com/classic/quest=3787/jonespyres-request) and [Jonespyre's Request (3788)](https://www.wowhead.com/classic/quest=3788/jonespyres-request) not showing on map because the pre-req quest was wrong.