### PR TITLE
Fix npc Arei (9598)

### DIFF
--- a/Database/Corrections/classicNPCFixes.lua
+++ b/Database/Corrections/classicNPCFixes.lua
@@ -1109,7 +1109,7 @@ function QuestieNPCFixes:Load()
             [npcKeys.spawns] = {[zoneIDs.BLACKROCK_DEPTHS] = {{-1,-1}}},
         },
         [9598] = {
-            [npcKeys.spawns] = {[zoneIDs.FELWOOD]={{49.4,31}}}, -- #1516
+            [npcKeys.spawns] = {[zoneIDs.FELWOOD]={{49.57,29.60}}}, -- #1516
             [npcKeys.zoneID] = zoneIDs.FELWOOD, -- #1516
         },
         [9621] = {


### PR DESCRIPTION
Fix npc [Arei (9598)](https://www.wowhead.com/classic/npc=9598/arei) location that was off by quite a few yards.