### PR TITLE
Fix quest Ironband's Compound (1681)

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -879,6 +879,9 @@ function QuestieQuestFixes:Load()
             [questKeys.preQuestSingle] = {1639,1678,1683},
             [questKeys.exclusiveTo] = {1681}, -- #1724
         },
+        [1681] = {
+            [questKeys.preQuestSingle] = {},
+        },
         [1684] = {
             [questKeys.startedBy] = {{2151,3598,3657},nil,nil},
             [questKeys.exclusiveTo] = {1639,1666,1678,1686,1680},


### PR DESCRIPTION
Fix quest [Ironband's Compound (1681)](https://www.wowhead.com/classic/quest=1681/ironbands-compound) missing from map, because quest [Tormus Deepforge (1680)](https://www.wowhead.com/classic/quest=1680/tormus-deepforge) is just a breadcrumb and not a prequest.

Verified on classic era live server with a human warrior level 12 that was able to pick this up even thought he never completed quest 1679, 1678 or 1680.