### PR TITLE
Update `The Darkreaver Menace`

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -2353,7 +2353,7 @@ function QuestieQuestFixes:Load()
             [questKeys.sourceItemId] = 18746,
             [questKeys.zoneOrSort] = 1637,
             [questKeys.exclusiveTo] = {8258}, -- 8258 after Phase 4
-            [questKeys.childQuests] = {7769},
+            [questKeys.childQuests] = {7669},
         },
         [7669] = { --#1449
             [questKeys.name] = "Again Into the Great Ossuary",
@@ -2538,7 +2538,7 @@ function QuestieQuestFixes:Load()
         },
         [8258] = {
             [questKeys.exclusiveTo] = {7668}, -- 7668 before Phase 4
-            [questKeys.childQuests] = {7769},
+            [questKeys.childQuests] = {7669},
         },
         [8262] = {
             [questKeys.requiredMinRep] = {509,3000},


### PR DESCRIPTION
Typos where made when setting `childQuests`.

`7769` is non existant. `7669` exists and is actually the child quest
