### PR TITLE
[Fix] #4924

### DIFF
--- a/Modules/Tooltips/TooltipHandler.lua
+++ b/Modules/Tooltips/TooltipHandler.lua
@@ -85,9 +85,12 @@ function _QuestieTooltips:AddObjectDataToTooltip(name)
 
             if type(gameObjectId) == "number" and tooltipData then
                 for _, v in pairs (tooltipData) do
-                    if tooltipData[2] and string.find(tooltipData[2], "1/1") then
-                        -- We don't want to show completed objectives on game objects
-                        break;
+                    if tooltipData[2] then
+                    local _, _, acquired, needed = string.find(tooltipData[2], "(%d+)/(%d+)")
+                        if acquired and acquired == needed then
+                            -- We don't want to show completed objectives on game objects
+                            break;
+                        end
                     end
 
                     GameTooltip:AddLine(v)


### PR DESCRIPTION
updated the _QuestieTooltips:AddObjectDataToTooltip() function to handle item counts that matched "1/1" accidentally

Fixes #4924 
