### PR TITLE
[feature] Add new Tracker Objective color option "Minimalistic"

### DIFF
--- a/Localization/Translations/Options/Tracker.lua
+++ b/Localization/Translations/Options/Tracker.lua
@@ -717,7 +717,7 @@ local trackerOptionsLocales = {
         ["esES"] = "Color de objectivo",
         ["frFR"] = "Couleur des objectifs :",
     },
-    ['Change the color of Objectives in the Questie Tracker by how complete they are.\n\nNOTE: The Minimalistic option will not display the "Blizzard Completion Text" and just lable the Quest as either "Quest Complete!" or "Quest Failed!".'] = {
+    ['Change the color of Objectives in the Questie Tracker by how complete they are.\n\nNOTE: The Minimalistic option will not display the "Blizzard Completion Text" and just label the Quest as either "Quest Complete!" or "Quest Failed!".'] = {
         ["ptBR"] = false,
         ["ruRU"] = false,
         ["deDE"] = false,

--- a/Localization/Translations/Options/Tracker.lua
+++ b/Localization/Translations/Options/Tracker.lua
@@ -152,6 +152,31 @@ local trackerOptionsLocales = {
         ["frFR"] = false,
     },
     ---------------------------------------------------------
+    ["Hide Blizzard Completion Text"] = {
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["deDE"] = false,
+        ["koKR"] = false,
+        ["esMX"] = false,
+        ["enUS"] = true,
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+        ["esES"] = false,
+        ["frFR"] = false,
+    },
+    ['When this is checked, Blizzard Completion Text will be hidden for completed Quests and instead show the old Questie tags: "Quest Complete!" or "Quest Failed!"'] = {
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["deDE"] = false,
+        ["koKR"] = false,
+        ["esMX"] = false,
+        ["enUS"] = true,
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+        ["esES"] = false,
+        ["frFR"] = false,
+    },
+    ---------------------------------------------------------
     -- Wrath of the Lich King only
     ["Hide Completed Achieve Objectives"] = {
         ["ptBR"] = false,

--- a/Localization/Translations/Options/Tracker.lua
+++ b/Localization/Translations/Options/Tracker.lua
@@ -717,17 +717,17 @@ local trackerOptionsLocales = {
         ["esES"] = "Color de objectivo",
         ["frFR"] = "Couleur des objectifs :",
     },
-    ["Change the color of Objectives in the Questie Tracker by how complete they are."] = {
-        ["ptBR"] = "Altere a cor dos objetivos no Rastreador de acordo com a integridade",
-        ["ruRU"] = "Изменение цвета целей заданий в трекере в зависимости от прогресса выполнения",
-        ["deDE"] = "Verändert die Farbe von Questzielen in Abhängigkeit zum Fortschritt.",
-        ["koKR"] = "퀘스트 추적기에서 퀘스트 진행도에 따라 퀘스트 목표 색상을 변경합니다.",
-        ["esMX"] = "Cambia el color de objetivos en el rastreador por lo completos que estén.",
+    ['Change the color of Objectives in the Questie Tracker by how complete they are.\n\nNOTE: The Minimalistic option will not display the "Blizzard Completion Text" and just lable the Quest as either "Quest Complete!" or "Quest Failed!".'] = {
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["deDE"] = false,
+        ["koKR"] = false,
+        ["esMX"] = false,
         ["enUS"] = true,
-        ["zhCN"] = "按照任务目标的进度，对追踪框的任务目标文字染色。",
-        ["zhTW"] = "根據任務目標的進度，著色追蹤框的任務目標文字",
-        ["esES"] = "Cambia el color de objetivos en el rastreador por lo completos que estén.",
-        ["frFR"] = "Change la couleur des objectifs dans le suivi en fonction de leur progression.",
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+        ["esES"] = false,
+        ["frFR"] = false,
     },
     ---------------------------------------------------------
     ["Red to Green"] = {
@@ -777,6 +777,18 @@ local trackerOptionsLocales = {
         ["zhTW"] = "由白至綠",
         ["esES"] = "Blanco a Verde",
         ["frFR"] = "Blanc à vert",
+    },
+    ["Minimalistic"] = {
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["deDE"] = false,
+        ["koKR"] = false,
+        ["esMX"] = false,
+        ["enUS"] = true,
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+        ["esES"] = false,
+        ["frFR"] = false,
     },
     ---------------------------------------------------------
     ["Objective Sorting"] = {

--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -107,7 +107,7 @@ function QuestieLib:GetRGBForObjective(objective)
 
     local float = objective.Collected / objective.Needed
     local trackerColor = Questie.db.global.trackerColorObjectives
-    if not trackerColor or trackerColor == "white" then
+    if not trackerColor or trackerColor == "white" or trackerColor == "minimal" then
         -- White
         return "|cFFEEEEEE"
     elseif trackerColor == "whiteAndGreen" then

--- a/Modules/Options/QuestieOptionsDefaults.lua
+++ b/Modules/Options/QuestieOptionsDefaults.lua
@@ -92,7 +92,7 @@ function QuestieOptionsDefaults:Load()
             stickyVoiceOverFrame = false,
             alwaysShowTracker = false,
             globalTrackerLocation = true,
-            trackerColorObjectives = 'white',
+            trackerColorObjectives = 'minimal',
             trackerSortObjectives = 'byZone',
             trackerbindSetTomTom = 'ctrlleft',
             trackerbindOpenQuestLog = 'left',

--- a/Modules/Options/QuestieOptionsDefaults.lua
+++ b/Modules/Options/QuestieOptionsDefaults.lua
@@ -71,6 +71,7 @@ function QuestieOptionsDefaults:Load()
             trackerShowQuestLevel = true,
             collapseCompletedQuests = false,
             hideCompletedQuestObjectives = false,
+            hideBlizzardCompletionText = false,
             hideCompletedAchieveObjectives = true,
             showBlizzardQuestTimer = false,
             trackerHeaderEnabled = true,

--- a/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
+++ b/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
@@ -115,6 +115,19 @@ function QuestieOptions.tabs.tracker:Initialize()
                     QuestieTracker:Update()
                 end
             },
+            hideBlizzardCompletionText = {
+                type = "toggle",
+                order = 1.55,
+                width = 1.5,
+                name = function() return l10n('Hide Blizzard Completion Text') end,
+                desc = function() return l10n('When this is checked, Blizzard Completion Text will be hidden for completed Quests and instead show the old Questie tags: "Quest Complete!" or "Quest Failed!"') end,
+                disabled = function() return not Questie.db.char.trackerEnabled or Questie.db.global.trackerColorObjectives == "minimal" end,
+                get = function() return Questie.db.global.hideBlizzardCompletionText end,
+                set = function(_, value)
+                    Questie.db.global.hideBlizzardCompletionText = value
+                    QuestieTracker:Update()
+                end
+            },
             -- hideCompletedAchieveObjectives: order = 1.6 | Check WotLK section below
             showQuestTimer = {
                 type = "toggle",

--- a/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
+++ b/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
@@ -514,12 +514,13 @@ function QuestieOptions.tabs.tracker:Initialize()
                         ['white'] = l10n('White'),
                         ['whiteToGreen'] = l10n('White to Green'),
                         ['whiteAndGreen'] = l10n('White and Green'),
-                        ['redToGreen'] = l10n('Red to Green')
+                        ['redToGreen'] = l10n('Red to Green'),
+                        ['minimal'] = l10n('Minimalistic')
                     }
                 end,
                 style = 'dropdown',
                 name = function() return l10n('Objective Color') end,
-                desc = function() return l10n('Change the color of Objectives in the Questie Tracker by how complete they are.') end,
+                desc = function() return l10n('Change the color of Objectives in the Questie Tracker by how complete they are.\n\nNOTE: The Minimalistic option will not display the "Blizzard Completion Text" and just lable the Quest as either "Quest Complete!" or "Quest Failed!".') end,
                 disabled = function() return not Questie.db.char.trackerEnabled end,
                 get = function() return Questie.db.global.trackerColorObjectives end,
                 set = function(_, key)

--- a/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
+++ b/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
@@ -520,7 +520,7 @@ function QuestieOptions.tabs.tracker:Initialize()
                 end,
                 style = 'dropdown',
                 name = function() return l10n('Objective Color') end,
-                desc = function() return l10n('Change the color of Objectives in the Questie Tracker by how complete they are.\n\nNOTE: The Minimalistic option will not display the "Blizzard Completion Text" and just lable the Quest as either "Quest Complete!" or "Quest Failed!".') end,
+                desc = function() return l10n('Change the color of Objectives in the Questie Tracker by how complete they are.\n\nNOTE: The Minimalistic option will not display the "Blizzard Completion Text" and just label the Quest as either "Quest Complete!" or "Quest Failed!".') end,
                 disabled = function() return not Questie.db.char.trackerEnabled end,
                 get = function() return Questie.db.global.trackerColorObjectives end,
                 set = function(_, key)

--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -1000,6 +1000,11 @@ function QuestieTracker:Update()
                         -- Set Completion Text
                         local completionText = TrackerUtils:GetCompletionText(quest)
 
+                        -- Questie Config Options --> Tracker "Hide Blizzard Completion Text" option
+                        if Questie.db.global.hideBlizzardCompletionText then
+                            completionText = nil
+                        end
+
                         -- This removes any blank lines
                         if completionText ~= nil then
                             if strfind(completionText, "\r\n") then

--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -1007,6 +1007,9 @@ function QuestieTracker:Update()
                             else
                                 completionText = completionText:gsub("(.\r?\n?)\r?\n?", "%1")
                             end
+
+                            -- Blizzard Completion Text should always be green
+                            completionText = "|cFF4CFF4C" .. completionText
                         end
 
                         -- Add incomplete Quest Objectives
@@ -1054,9 +1057,9 @@ function QuestieTracker:Update()
                                         trackerLineWidth = math.max(trackerLineWidth, line.label:GetUnboundedStringWidth() + lineWidthQBC)
 
                                         -- Edge case where the quest is still flagged incomplete for single objectives and yet the objective itself is flagged complete
-                                    elseif (objective.Completed == true and completionText ~= nil and #quest.Objectives == 1) then
+                                    elseif (objective.Completed == true and completionText ~= nil and #quest.Objectives == 1) and Questie.db.global.trackerColorObjectives ~= "minimal" then
                                         -- Set Blizzard Completion text for single objectives
-                                        line.label:SetText(QuestieLib:GetRGBForObjective({ Collected = 1, Needed = 1 }) .. completionText)
+                                        line.label:SetText(completionText)
 
                                         -- If the line width is less than the minimum Tracker width then don't wrap text
                                         if line.label:GetUnboundedStringWidth() + objectiveMarginLeft < trackerMinLineWidth then
@@ -1124,9 +1127,9 @@ function QuestieTracker:Update()
                             line.label:SetPoint("TOPLEFT", line, "TOPLEFT", lineWidthQBC, 0)
 
                             -- Set Objective label based on states
-                            if (complete == 1 and completionText ~= nil and #quest.Objectives == 0) or (quest.isComplete == true and completionText ~= nil) then
+                            if ((complete == 1 and completionText ~= nil and #quest.Objectives == 0) or (quest.isComplete == true and completionText ~= nil)) and Questie.db.global.trackerColorObjectives ~= "minimal" then
                                 -- Set Blizzard Completion text for single objectives
-                                line.label:SetText(QuestieLib:GetRGBForObjective({ Collected = 1, Needed = 1 }) .. completionText)
+                                line.label:SetText(completionText)
 
                                 -- If the line width is less than the minimum Tracker width then don't wrap text
                                 if line.label:GetUnboundedStringWidth() + objectiveMarginLeft < trackerMinLineWidth then


### PR DESCRIPTION
## Issue references

Fixes #5000 
Several bug reports and comments on Discord.

## Proposed changes

- Added a new Objective Color option called **Minimalistic**. All Tracked Objectives will always be _White_ and will not show the "Blizzard Completion Text". Instead, it displays the old tags. Either "Quest Complete!" or "Quest Failed!".

- Based on user feedback we've changed the color of the "Blizzard Completion Text" to always be _Green_ in the _White_ Objective Color option.

- Updated the Tracker Default Objective Color option from **White** to **Minimalistic**. This will not change your settings in the next update. If the option isn't already set, usually new installs and new characters, then it'll set it to **Minimalistic**.

- Based on user feedback we've added a new toggle to Questie Config --> Tracker. "Hide Blizzard Completion Text" this will allow you to use the old Questie Tags for completed or failed quests vs the "Blizzard Completion Text" in any **Objective Color** profile.

## Screenshots

### Minimalistic
![image](https://github.com/Questie/Questie/assets/17400948/ed0af01b-ffe2-4d00-971f-22c00233a920)

### Red to Green
![image](https://github.com/Questie/Questie/assets/17400948/b2999f27-c4a7-4ce3-ae6b-8591ef731920)

### White
- NOTE: The Objectives remain _White_ all the time, even when completed.
- Quests with a Single completed objective will change to "Blizzard Completion Text" which will now be colored _Green_. If there is no "Blizzard Completion Text" then it'll show the old tag: "Quest Complete!".
- For Multiple objectives, each completed objective will remain _White_ until the last objective is completed. Then it will show the "Blizzard Completion Text" or again if there isn't any then it'll show the old tag.
- If you'd prefer to use the old tags instead of the "Blizzard Completion Text", this is what the new **Minimalistic** Objective Color option is for! :)

![image](https://github.com/Questie/Questie/assets/17400948/0d653215-c858-42eb-a697-945629895781)

### White and Green
- NOTE: **White and Green** does not _fade into..._ like other Color options. It only turns _Green_ when the objective is completed.

![image](https://github.com/Questie/Questie/assets/17400948/edf05b67-db7d-4140-8106-d467a91efe4d)

### White to Green
![image](https://github.com/Questie/Questie/assets/17400948/27ce79b7-cea8-492b-8e9c-abe0a1bfab0b)
