### PR TITLE
Senir's observations part 2 becomes unavailable if you have completed frostmane hold

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -187,6 +187,9 @@ function QuestieQuestFixes:Load()
         [415] = {
             [questKeys.exclusiveTo] = {413}, -- cant complete rejolds new brew if you do shimmer stout (see issue 567)
         },
+        [420] = {
+            [questKeys.exclusiveTo] = {287}, -- senir's observations part 2 becomes unavailable if you have completed frostmane hold
+        },
         [428] = {
             [questKeys.exclusiveTo] = {429}, -- lost deathstalkers breadcrumb
         },


### PR DESCRIPTION
## Issue references

Fixes #5063

## Proposed changes
Senir's observations part 2 becomes unavailable if you've already completed frost mane hold. Part 1 was already removed using the same method. This PR removes part 2.

