### PR TITLE
[fix] Show quest starter/finisher on objects

### DIFF
--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -851,7 +851,7 @@ end
 -- A good example for this edge case is [18] The Price of Shoes (118) where upon acceptance, Verner's Note (1283) is given
 -- to the player and the Quest is immediately flagged as Complete. If the note is destroyed then a slightly modified version
 -- of QuestieDB.IsComplete() that uses this function, returns zero allowing the quest updates to properly set the quests state.
----@param questId Number @QuestID
+---@param questId number @QuestID
 ---@param makeObjective boolean @If set to true, then this will create an incomplete objective for the missing quest item
 ---@return boolean @Returns true if quest.sourceItemId matches an item in a players bag
 function QuestieQuest:CheckQuestSourceItem(questId, makeObjective)

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -961,7 +961,7 @@ function QuestieQuest:AddFinisher(quest)
                 end
             end
 
-            QuestieTooltips:RegisterQuestStartTooltip(questId, finisher)
+            QuestieTooltips:RegisterQuestStartTooltip(questId, finisher, key)
 
             local finisherIcons = {}
             local finisherLocs = {}
@@ -1570,6 +1570,8 @@ function _QuestieQuest:DrawAvailableQuest(quest) -- prevent recursion
         for i = 1, #gameObjects do
             local obj = QuestieDB:GetObject(gameObjects[i])
             if (obj ~= nil and obj.spawns ~= nil) then
+                QuestieTooltips:RegisterQuestStartTooltip(quest.Id, obj, "o_" .. obj.id)
+
                 for zone, spawns in pairs(obj.spawns) do
                     if (zone ~= nil and spawns ~= nil) then
                         local coords
@@ -1616,7 +1618,7 @@ function _QuestieQuest:DrawAvailableQuest(quest) -- prevent recursion
             local npc = QuestieDB:GetNPC(npcs[i])
 
             if (npc ~= nil and npc.spawns ~= nil) then
-                QuestieTooltips:RegisterQuestStartTooltip(quest.Id, npc)
+                QuestieTooltips:RegisterQuestStartTooltip(quest.Id, npc, "m_" .. npc.id)
 
                 --Questie:Debug(Questie.DEBUG_DEVELOP, "Adding Quest:", questObject.Id, "StarterNPC:", NPC.Id)
                 local starterIcons = {}

--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -53,8 +53,8 @@ end
 
 ---@param questId number
 ---@param npc table
-function QuestieTooltips:RegisterQuestStartTooltip(questId, npc)
-    local key = "m_" .. npc.id
+---@param key string @Either m_<npcId> or o_<objectId>
+function QuestieTooltips:RegisterQuestStartTooltip(questId, npc, key)
     if not QuestieTooltips.lookupByKey[key] then
         QuestieTooltips.lookupByKey[key] = {};
     end

--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -32,8 +32,6 @@ local MAX_GROUP_MEMBER_COUNT = 6
 
 local _InitObjectiveTexts
 
-local lastTooltipUpdate = GetTime()
-
 ---@param questId number
 ---@param key string monster: m_, items: i_, objects: o_ + string name of the objective
 ---@param objective table


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #5098

This is partly also related to #5092 as the finisher should then show on "Broken Barrel"

## Proposed changes

-
-

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->

Starter:
![grafik](https://github.com/Questie/Questie/assets/33514570/689ef42f-9bad-4433-8341-656c54a8d490)

Finisher:
![grafik](https://github.com/Questie/Questie/assets/33514570/75f03926-00f4-472e-8883-a7ef3bc1708a)
