### PR TITLE
[fix] Fix double complete map icon tooltip

### DIFF
--- a/Modules/FramePool/QuestieFrame.lua
+++ b/Modules/FramePool/QuestieFrame.lua
@@ -6,8 +6,6 @@ local QuestieMap = QuestieLoader:ImportModule("QuestieMap")
 local QuestieDBMIntegration = QuestieLoader:ImportModule("QuestieDBMIntegration")
 ---@type QuestieDB
 local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
----@type QuestieQuestBlacklist
-local QuestieQuestBlacklist = QuestieLoader:ImportModule("QuestieQuestBlacklist")
 ---@type DailyQuests
 local DailyQuests = QuestieLoader:ImportModule("DailyQuests")
 ---@type QuestieLink
@@ -137,7 +135,7 @@ function _Qframe:OnLeave()
 
     --Reset highlighting if it exists.
     if self.data.lineFrames then
-        for k, lineFrame in pairs(self.data.lineFrames) do
+        for _, lineFrame in pairs(self.data.lineFrames) do
             local line = lineFrame.line
             line:SetColorTexture(line.dR, line.dG, line.dB, line.dA)
         end
@@ -151,6 +149,7 @@ function _Qframe:OnLeave()
         end
         self.data.touchedPins = nil;
     end
+    GameTooltip.ShownAsMapIcon = false
 end
 
 function _Qframe:OnClick(button)
@@ -345,7 +344,7 @@ function _Qframe:Unload()
     end
     --Unload potential waypoint frames that are used for pathing.
     if self.data and self.data.lineFrames then
-        for index, lineFrame in pairs(self.data.lineFrames) do
+        for _, lineFrame in pairs(self.data.lineFrames) do
             lineFrame:Unload();
         end
     end

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -1143,21 +1143,23 @@ _RegisterObjectiveTooltips = function(objective, questId, blockItemTooltips)
     Questie:Debug(Questie.DEBUG_INFO, "Registering objective tooltips for", objective.Description)
 
     if objective.spawnList then
-        for id, spawnData in pairs(objective.spawnList) do
-            if spawnData.TooltipKey and (not objective.AlreadySpawned[id]) and (not objective.hasRegisteredTooltips) then
-                QuestieTooltips:RegisterObjectiveTooltip(questId, spawnData.TooltipKey, objective)
+        if (not objective.hasRegisteredTooltips) then
+            for id, spawnData in pairs(objective.spawnList) do
+                if spawnData.TooltipKey and (not objective.AlreadySpawned[id]) then
+                    QuestieTooltips:RegisterObjectiveTooltip(questId, spawnData.TooltipKey, objective)
+                end
             end
-        end
 
-        objective.hasRegisteredTooltips = true
+            objective.hasRegisteredTooltips = true
+        end
     else
         Questie:Error("[QuestieQuest]: [Tooltips] " .. l10n("There was an error populating objectives for %s %s %s %s", objective.Description or "No objective text", questId or "No quest id", 0 or "No objective", "No error"));
     end
 
     if (not objective.registeredItemTooltips) and objective.Type == "item" and (not blockItemTooltips) and objective.Id then
-        local item = QuestieDB.QueryItemSingle(objective.Id, "name")
+        local itemName = QuestieDB.QueryItemSingle(objective.Id, "name")
 
-        if item then
+        if itemName then
             QuestieTooltips:RegisterObjectiveTooltip(questId, "i_" .. objective.Id, objective)
         end
 

--- a/Modules/QuestieNameplate.lua
+++ b/Modules/QuestieNameplate.lua
@@ -91,9 +91,8 @@ function QuestieNameplate:UpdateNameplate()
         if icon then
             local frame = _QuestieNameplate.GetFrame(guid)
             -- check if the texture needs to be changed
-            if (not frame.lastIcon) or icon ~= frame.lastIcon then
+            if frame.lastIcon ~= icon then
                 frame.lastIcon = icon
-                frame.Icon:SetTexture(nil)
                 frame.Icon:SetTexture(icon)
             end
         else

--- a/Modules/Tooltips/MapIconTooltip.lua
+++ b/Modules/Tooltips/MapIconTooltip.lua
@@ -408,6 +408,7 @@ function MapIconTooltip:Show()
     end
     Tooltip:_Rebuild() -- we separate this so things like MODIFIER_STATE_CHANGED can redraw the tooltip
     Tooltip:SetFrameStrata("TOOLTIP");
+    Tooltip.ShownAsMapIcon = true
     Tooltip:Show();
 end
 

--- a/Modules/Tooltips/MapIconTooltip.lua
+++ b/Modules/Tooltips/MapIconTooltip.lua
@@ -194,20 +194,20 @@ function MapIconTooltip:Show()
         local firstLine = true;
         local playerIsHuman = QuestiePlayer:GetRaceId() == 1
         local playerIsHonoredWithShaTar = (not QuestieReputation:HasReputation(nil, { 935, 8999 }))
-        for questTitle, quests in pairs(self.npcOrder) do -- this logic really needs to be improved
+        for npcOrObjectName, quests in pairs(self.npcOrder) do -- this logic really needs to be improved
             haveGiver = true
             if shift and (not firstLine) then
                 -- Spacer between NPCs
                 self:AddLine("             ")
             end
             if (firstLine and not shift) then
-                self:AddDoubleLine(questTitle, "(" .. l10n('Hold Shift') .. ")", 0.2, 1, 0.2, 0.43, 0.43, 0.43);
+                self:AddDoubleLine(npcOrObjectName, "(" .. l10n('Hold Shift') .. ")", 0.2, 1, 0.2, 0.43, 0.43, 0.43);
                 firstLine = false;
             elseif (firstLine and shift) then
-                self:AddLine(questTitle, 0.2, 1, 0.2);
+                self:AddLine(npcOrObjectName, 0.2, 1, 0.2);
                 firstLine = false;
             else
-                self:AddLine(questTitle, 0.2, 1, 0.2);
+                self:AddLine(npcOrObjectName, 0.2, 1, 0.2);
             end
 
             for _, questData in pairs(quests) do

--- a/Modules/Tooltips/MapIconTooltip.lua
+++ b/Modules/Tooltips/MapIconTooltip.lua
@@ -93,7 +93,7 @@ function MapIconTooltip:Show()
     --end
 
     local usedText = {}
-    local npcOrder = {};
+    local npcAndObjectOrder = {};
     local questOrder = {};
     local manualOrder = {}
 
@@ -123,12 +123,12 @@ function MapIconTooltip:Show()
             local dist = QuestieLib:Maxdist(icon.x, icon.y, self.x, self.y);
             if dist < maxDistCluster then
                 if iconData.Type == "available" or iconData.Type == "complete" then
-                    if not npcOrder[iconData.Name] then
-                        npcOrder[iconData.Name] = {};
+                    if not npcAndObjectOrder[iconData.Name] then
+                        npcAndObjectOrder[iconData.Name] = {};
                     end
 
                     local tip = _MapIconTooltip:GetAvailableOrCompleteTooltip(icon)
-                    npcOrder[iconData.Name][tip.title] = tip
+                    npcAndObjectOrder[iconData.Name][tip.title] = tip
                 elseif iconData.ObjectiveData and iconData.ObjectiveData.Description then
                     local key = iconData.Id
                     if not questOrder[key] then
@@ -183,7 +183,7 @@ function MapIconTooltip:Show()
         end
     end
 
-    Tooltip.npcOrder = npcOrder
+    Tooltip.npcAndObjectOrder = npcAndObjectOrder
     Tooltip.questOrder = questOrder
     Tooltip.manualOrder = manualOrder
     Tooltip.miniMapIcon = self.miniMapIcon
@@ -194,7 +194,7 @@ function MapIconTooltip:Show()
         local firstLine = true;
         local playerIsHuman = QuestiePlayer:GetRaceId() == 1
         local playerIsHonoredWithShaTar = (not QuestieReputation:HasReputation(nil, { 935, 8999 }))
-        for npcOrObjectName, quests in pairs(self.npcOrder) do -- this logic really needs to be improved
+        for npcOrObjectName, quests in pairs(self.npcAndObjectOrder) do -- this logic really needs to be improved
             haveGiver = true
             if shift and (not firstLine) then
                 -- Spacer between NPCs
@@ -385,7 +385,7 @@ function MapIconTooltip:Show()
             end
         end
 
-        if next(self.npcOrder) and next(self.manualOrder) then
+        if next(self.npcAndObjectOrder) and next(self.manualOrder) then
             -- Spacer before townsfolk
             self:AddLine("             ")
         end

--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -399,7 +399,7 @@ function QuestieTooltips:Initialize()
                     (not QuestieTooltips.lastGametooltipCount) or
                     _QuestieTooltips:CountTooltip() < QuestieTooltips.lastGametooltipCount
                     or QuestieTooltips.lastGametooltipType ~= "object"
-                ) then
+                ) and (not self.ShownAsMapIcon) then -- We are hovering over a Questie map icon which adds it's own tooltip
                 _QuestieTooltips:AddObjectDataToTooltip(GameTooltipTextLeft1:GetText())
                 QuestieTooltips.lastGametooltipCount = _QuestieTooltips:CountTooltip()
             end

--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -42,9 +42,10 @@ function QuestieTooltips:RegisterObjectiveTooltip(questId, key, objective)
     if not QuestieTooltips.lookupKeysByQuestId[questId] then
         QuestieTooltips.lookupKeysByQuestId[questId] = {}
     end
-    local tooltip = {};
-    tooltip.questId = questId;
-    tooltip.objective = objective
+    local tooltip = {
+        questId = questId,
+        objective = objective,
+    };
     QuestieTooltips.lookupByKey[key][tostring(questId) .. " " .. objective.Index] = tooltip
     table.insert(QuestieTooltips.lookupKeysByQuestId[questId], key)
 end
@@ -59,9 +60,10 @@ function QuestieTooltips:RegisterQuestStartTooltip(questId, npc, key)
     if not QuestieTooltips.lookupKeysByQuestId[questId] then
         QuestieTooltips.lookupKeysByQuestId[questId] = {}
     end
-    local tooltip = {};
-    tooltip.questId = questId
-    tooltip.npc = npc
+    local tooltip = {
+        questId = questId,
+        npc = npc,
+    };
     QuestieTooltips.lookupByKey[key][tostring(questId) .. " " .. npc.name] = tooltip
     table.insert(QuestieTooltips.lookupKeysByQuestId[questId], key)
 end

--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -47,7 +47,7 @@ function QuestieTooltips:RegisterObjectiveTooltip(questId, key, objective)
         objective = objective,
     };
     QuestieTooltips.lookupByKey[key][tostring(questId) .. " " .. objective.Index] = tooltip
-    table.insert(QuestieTooltips.lookupKeysByQuestId[questId], key)
+    tinsert(QuestieTooltips.lookupKeysByQuestId[questId], key)
 end
 
 ---@param questId number
@@ -65,7 +65,7 @@ function QuestieTooltips:RegisterQuestStartTooltip(questId, npc, key)
         npc = npc,
     };
     QuestieTooltips.lookupByKey[key][tostring(questId) .. " " .. npc.name] = tooltip
-    table.insert(QuestieTooltips.lookupKeysByQuestId[questId], key)
+    tinsert(QuestieTooltips.lookupKeysByQuestId[questId], key)
 end
 
 ---@param questId number
@@ -231,7 +231,7 @@ function QuestieTooltips:GetTooltip(key)
             if tooltip.npc then
                 if Questie.db.char.showQuestsInNpcTooltip then
                     local questString = QuestieLib:GetColoredQuestName(tooltip.questId, Questie.db.global.enableTooltipsQuestLevel, true, true)
-                    table.insert(tooltipLines, questString)
+                    tinsert(tooltipLines, questString)
                 end
             else
                 local objective = tooltip.objective


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #5117


## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->
Hovering over an object:
![image](https://github.com/Questie/Questie/assets/33514570/302637f5-ebcc-4677-99e6-d6ff67fe913d)

Hovering over the map icon for that object:
![image](https://github.com/Questie/Questie/assets/33514570/e03169c4-9514-4521-9e9f-f807b2124e85)
