### PR TITLE
[quest] Fx quests of "Harvest Festival"

### DIFF
--- a/Database/Corrections/classicItemFixes.lua
+++ b/Database/Corrections/classicItemFixes.lua
@@ -1118,12 +1118,6 @@ function QuestieItemFixes:Load()
         [19808] = {
             [itemKeys.objectDrops] = {},
         },
-        [19850] = {
-            [itemKeys.objectDrops] = {180204},
-        },
-        [19851] = {
-            [itemKeys.objectDrops] = {180205},
-        },
         [19975] = {
             [itemKeys.objectDrops] = {},
         },

--- a/Database/Corrections/classicObjectFixes.lua
+++ b/Database/Corrections/classicObjectFixes.lua
@@ -228,10 +228,12 @@ function QuestieObjectFixes:Load()
             [objectKeys.spawns] = {[zoneIDs.THE_HINTERLANDS]={{53.3,38.8},{57.4,42.6},{57.5,42.6},{66.4,44.8},{71,48.6},{72.6,52.9}}},
         },
         [180204] = {
-            [objectKeys.spawns] = {[zoneIDs.WESTERN_PLAGUELANDS]={{52,83}}},
+            [objectKeys.name] = "Uther the Lightbringer",
+            [objectKeys.spawns] = {[zoneIDs.WESTERN_PLAGUELANDS]={{52.08,83.28}}},
         },
         [180205] = {
-            [objectKeys.spawns] = {[zoneIDs.ASHENVALE]={{83,78}}},
+            [objectKeys.name] = "Monument to Grom Hellscream",
+            [objectKeys.spawns] = {[zoneIDs.ASHENVALE]={{82.8,79.09}}},
         },
         [180453] = {
             [objectKeys.spawns] = {[zoneIDs.SILITHUS]={{51,99}}},

--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -2669,13 +2669,12 @@ function QuestieQuestFixes:Load()
             [questKeys.requiredMinRep] = {510,42000},
         },
         [8149] = {
-            [questKeys.requiredSourceItems] = {19850},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.extraObjectives] = {{nil, Questie.ICON_TYPE_EVENT, l10n("Place a tribute at Uther's Tomb"),0,{{"object", 180204},}}},
         },
         [8150] = {
-            [questKeys.requiredSourceItems] = {19851},
-            [questKeys.exclusiveTo] = {2851},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
+            [questKeys.extraObjectives] = {{nil, Questie.ICON_TYPE_EVENT, l10n("Place a tribute at Grom's Monument"),0,{{"object", 180205},}}},
         },
         [8166] = {
             [questKeys.specialFlags] = 0,

--- a/Database/Corrections/wotlkQuestFixes.lua
+++ b/Database/Corrections/wotlkQuestFixes.lua
@@ -251,9 +251,13 @@ function QuestieWotlkQuestFixes:Load()
         [7800] = {
             [questKeys.preQuestSingle] = {},
         },
+        [8149] = {
+            [questKeys.objectives] = {nil,{{180204,"Place a tribute at Uther's Tomb"}}},
+            [questKeys.extraObjectives] = {},
+        },
         [8150] = {
-            [questKeys.requiredSourceItems] = {}, -- Overriding Classic correction
-            [questKeys.triggerEnd] = {"Place a tribute at Grom's Monument",{[zoneIDs.ASHENVALE]={{83,78,},},},},
+            [questKeys.objectives] = {nil,{{180205,"Place a tribute at Grom's Monument"}}},
+            [questKeys.extraObjectives] = {},
         },
         [8166] = {
             [questKeys.requiredMaxLevel] = 49,

--- a/Localization/Translations/ExtraObjectives/ClassicObjectives.lua
+++ b/Localization/Translations/ExtraObjectives/ClassicObjectives.lua
@@ -566,6 +566,30 @@ local classicObjectiveLocales = {
         ["zhTW"] = false,
         ["zhCN"] = false,
     },
+    ["Place a tribute at Uther's Tomb"] = { -- 8149
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["deDE"] = false,
+        ["koKR"] = false,
+        ["esMX"] = false,
+        ["enUS"] = true,
+        ["frFR"] = false,
+        ["esES"] = false,
+        ["zhTW"] = false,
+        ["zhCN"] = false,
+    },
+    ["Place a tribute at Grom's Monument"] = { -- 8150
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["deDE"] = false,
+        ["koKR"] = false,
+        ["esMX"] = false,
+        ["enUS"] = true,
+        ["frFR"] = false,
+        ["esES"] = false,
+        ["zhTW"] = false,
+        ["zhCN"] = false,
+    },
 }
 
 for k, v in pairs(classicObjectiveLocales) do


### PR DESCRIPTION
Classic/TBC quests dont have objectives.
WOTLK quests do have objectives.
Renamed the 2 monuments so we can link the tooltips to them.
Fixed coords for the monuments, maps are identical across expansions.
Removed the "sourceitemid into requiredsourceitems" corrections, as that's plain wrong.
Removed object sources for the sourceitemid.
Classic corrections - added an extraobjective field for them, which is nil'ed in wotlk corrections.
Wotlk corrections now have objectives, linked to the monuments.
Tooltips should be visible on map and monuments in both era and wotlk.
Translations for the extraobjective definitions.