### PR TITLE
Add compatbility layer for 1.13 to 1.14

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2698,6 +2698,7 @@ globals = {
     "TicketStatusFrame",
     "TimeAlertFrame",
     "TimeManagerFrame",
+    "TooltipBackdropTemplateMixin",
     "TradeFrame",
     "TradeSkillFrame",
     "TutorialFrame",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2664,6 +2664,7 @@
         "TicketStatusFrame",
         "TimeAlertFrame",
         "TimeManagerFrame",
+        "TooltipBackdropTemplateMixin",
         "TradeFrame",
         "TradeSkillFrame",
         "TutorialFrame",

--- a/Modules/Compatibility.lua
+++ b/Modules/Compatibility.lua
@@ -1,13 +1,13 @@
 -- Add missing Seasons object, if not available (e.g. 1.14.0 and below is missing it)
 if not C_Seasons then
-    C_Seasons = {}
-    
-    C_Seasons.HasActiveSeason = function()
+    C_Seasons = {
+        HasActiveSeason = function()
             return false
-    end
-    C_Seasons.GetActiveSeason = function()
-        return 0
-    end
+        end,
+        GetActiveSeason = function()
+            return 0
+        end
+    }
 end
 
 -- Specific subclass of this mixin was added in a minor version and is missing in earlier patches, functionality this makes next to no visual difference

--- a/Modules/Compatibility.lua
+++ b/Modules/Compatibility.lua
@@ -1,0 +1,16 @@
+-- Add missing Seasons object, if not available (e.g. 1.14.0 and below is missing it)
+if not C_Seasons then
+    C_Seasons = {}
+    
+    C_Seasons.HasActiveSeason = function()
+            return false
+    end
+    C_Seasons.GetActiveSeason = function()
+        return 0
+    end
+end
+
+-- Specific subclass of this mixin was added in a minor version and is missing in earlier patches, functionality this makes next to no visual difference
+if not TooltipBackdropTemplateMixin then
+    TooltipBackdropTemplateMixin = BackdropTemplateMixin
+end    

--- a/Questie-Classic.toc
+++ b/Questie-Classic.toc
@@ -10,6 +10,9 @@
 ## X-Curse-Project-ID: 334372
 ## X-Wago-ID: qv634BKb
 
+# Compatibility module for older clients that may still be in use
+Modules\Compatibility.lua
+
 Modules\WorldMapTaintWorkaround.lua
 
 embeds.xml


### PR DESCRIPTION
## Proposed changes

- Fix Questie tracker runtime exceptions, this enables clicking on the tracker and sub menus on 1.14 again