### PR TITLE
Fixed messed up ICC raid name translation

### DIFF
--- a/Localization/Translations/Zones/Raids.lua
+++ b/Localization/Translations/Zones/Raids.lua
@@ -244,8 +244,8 @@ local raidLocales = {
         ["zhCN"] = "银色比武场",
     },
     ["Icecrown Citadel"] = {
-        ["ptBR"] = "Цитадель Ледяной Короны",
-        ["ruRU"] = "Cidadela da Coroa de Gelo",
+        ["ptBR"] = "Cidadela da Coroa de Gelo",
+        ["ruRU"] = "Цитадель Ледяной Короны",
         ["deDE"] = "Eiskronenzitadelle",
         ["koKR"] = "얼음왕관 성채",
         ["esMX"] = "Ciudadela de la Corona de Hielo",


### PR DESCRIPTION
## Proposed changes

Localization for `ptBR` and `ruRU` was mixed up with each other.