### PR TITLE
Add support for comms in LFG/LFD.

### DIFF
--- a/Modules/Network/QuestieComms.lua
+++ b/Modules/Network/QuestieComms.lua
@@ -48,6 +48,7 @@ local _DoYell
 --Channel types
 _QuestieComms.QC_WRITE_ALLGUILD = "GUILD"
 _QuestieComms.QC_WRITE_ALLGROUP = "PARTY"
+_QuestieComms.QC_WRITE_ALLINSTANCE = "INSTANCE_CHAT"
 _QuestieComms.QC_WRITE_ALLRAID = "RAID"
 _QuestieComms.QC_WRITE_WHISPER = "WHISPER"
 _QuestieComms.QC_WRITE_CHANNEL = "CHANNEL"
@@ -199,6 +200,8 @@ function _QuestieComms:BroadcastQuestUpdate(questId) -- broadcast quest update t
             questPacket.data.priority = "NORMAL";
             if partyType == "raid" then
                 questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLRAID
+            elseif partyType == "instance" then
+                questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLINSTANCE
             else
                 questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLGROUP
             end
@@ -223,6 +226,8 @@ function _QuestieComms:BroadcastQuestRemove(questId) -- broadcast quest update t
         questPacket.data.priority = "ALERT";
         if partyType == "raid" then
             questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLRAID;
+        elseif partyType == "instance" then
+            questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLINSTANCE
         else
             questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLGROUP;
         end
@@ -597,6 +602,9 @@ function _QuestieComms:BroadcastQuestLog(eventName, sendMode, targetPlayer) -- b
                             if partyType == "raid" then
                                 questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLRAID
                                 questPacket.data.priority = "BULK"
+                            elseif partyType == "instance" then
+                                questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLINSTANCE
+                                questPacket.data.priority = "BULK" -- in case of battlegrounds
                             else
                                 questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLGROUP
                                 questPacket.data.priority = "NORMAL"
@@ -715,6 +723,9 @@ function _QuestieComms:BroadcastQuestLogV2(eventName, sendMode, targetPlayer) --
                             if partyType == "raid" then
                                 questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLRAID
                                 questPacket.data.priority = "BULK"
+                            elseif partyType == "instance" then
+                                questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLINSTANCE
+                                questPacket.data.priority = "BULK" -- in case of battlegrounds
                             else
                                 questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLGROUP
                                 questPacket.data.priority = "NORMAL"
@@ -742,12 +753,13 @@ function _QuestieComms:RequestQuestLog(eventName) -- broadcast quest update to g
         --Do we really need to make this?
         local questPacket = _QuestieComms:CreatePacket(_QuestieComms.QC_ID_REQUEST_FULL_QUESTLIST);
 
+        questPacket.data.priority = "NORMAL";
         if partyType == "raid" then
             questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLRAID;
-            questPacket.data.priority = "NORMAL";
+        elseif partyType == "instance" then
+            questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLINSTANCE
         else
             questPacket.data.writeMode = _QuestieComms.QC_WRITE_ALLGROUP;
-            questPacket.data.priority = "NORMAL";
         end
         questPacket:write();
     end

--- a/Modules/QuestiePlayer.lua
+++ b/Modules/QuestiePlayer.lua
@@ -72,6 +72,8 @@ end
 function QuestiePlayer:GetGroupType()
     if(UnitInRaid("player")) then
         return "raid";
+    elseif(IsInGroup(LE_PARTY_CATEGORY_INSTANCE)) then
+        return "instance";
     elseif(UnitInParty("player")) then
         return "party";
     else

--- a/Modules/QuestiePlayer.lua
+++ b/Modules/QuestiePlayer.lua
@@ -72,7 +72,7 @@ end
 function QuestiePlayer:GetGroupType()
     if(UnitInRaid("player")) then
         return "raid";
-    elseif(IsInGroup(LE_PARTY_CATEGORY_INSTANCE)) then
+    elseif(IsInGroup(Enum.ChatChannelType.PublicParty)) then
         return "instance";
     elseif(UnitInParty("player")) then
         return "party";


### PR DESCRIPTION
## Issue references

Fixes #5165

## Proposed changes

- Add support for broadcasting when in an instance group, such as LFD.

I tested this in-game and it no longer shows the error mentioned in the above issue. I also confirmed that it is sharing data with other members of the instance group. I made it send as BULK in case BG messages are ever enabled.