### PR TITLE
Ensure MapTitleText is valid

### DIFF
--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -55,7 +55,8 @@ function QuestieCoords:WriteCoords()
         end
     end
     -- if main map
-    if Questie.db.profile.mapCoordinatesEnabled and WorldMapFrame:IsVisible() then
+    local mapTitleText = GetMapTitleText()
+    if Questie.db.profile.mapCoordinatesEnabled and WorldMapFrame:IsVisible() and mapTitleText then
         -- get cursor position
         local curX, curY = GetCursorPosition();
 
@@ -78,7 +79,7 @@ function QuestieCoords:WriteCoords()
 
         worldmapCoordsText = worldmapCoordsText.."|  Player: "..format(precision.. " X , ".. precision .." Y", posX, posY);
         -- Add text to world map
-        GetMapTitleText():SetText(worldmapCoordsText)
+        mapTitleText:SetText(worldmapCoordsText)
     end
 end
 


### PR DESCRIPTION
## Description
- Sometimes the title text is nil, even when mapCoordinates is enabled and the world map frame is visible.
- This is the case when using addons such as GW2UI which probably does something funky.

## Issue references
#5299 

## Proposed changes

- Add a null check before attempting to call 'setText()' on the map title text object.