### PR TITLE
Always return false when C_Calender does not exist for darkmoon faire

### DIFF
--- a/Database/Corrections/QuestieEvent.lua
+++ b/Database/Corrections/QuestieEvent.lua
@@ -144,6 +144,10 @@ end
 ---@param dayOfMonth number
 ---@return boolean
 _IsDarkmoonFaireActive = function(dayOfMonth)
+    local C_Calendar = C_Calendar
+    if C_Calendar == nil then
+        return false
+    end
     local baseInfo = C_Calendar.GetMonthInfo() -- In Era+SoD this returns `GetMinDate` (November 2004)
     local currentDate = C_DateAndTime.GetCurrentCalendarTime()
     -- Calculate the offset in months from GetMinDate to make C_Calendar.GetMonthInfo return the correct month

--- a/Database/Corrections/QuestieEvent.lua
+++ b/Database/Corrections/QuestieEvent.lua
@@ -144,8 +144,9 @@ end
 ---@param dayOfMonth number
 ---@return boolean
 _IsDarkmoonFaireActive = function(dayOfMonth)
-    local C_Calendar = C_Calendar
     if C_Calendar == nil then
+        -- This is a band aid fix for private servers which do not support the `C_Calendar` API.
+        -- They won't see Darkmoon Faire quests, but that's the price to pay.
         return false
     end
     local baseInfo = C_Calendar.GetMonthInfo() -- In Era+SoD this returns `GetMinDate` (November 2004)


### PR DESCRIPTION
Return false for darkmoonfaireactive when C_Calender is null

<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #

#5326 

## Proposed changes
always return false when C_Calender does not exist
-
-

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->
No errors any more
![image](https://github.com/Questie/Questie/assets/100043421/fa6bf0e7-03f6-441e-b58c-39f3ce560799)
