### PR TITLE
two warlock rune fixes

### DIFF
--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -992,7 +992,7 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
             [questKeys.requiredClasses] = classIDs.WARLOCK,
-            [questKeys.objectivesText] = {"Buy Demolition Explosives from Zixil for 5 gold."},
+            [questKeys.objectivesText] = {"Buy Demolition Explosives from Zixil for 1 gold."},
             [questKeys.requiredSpell] = -403937,
             [questKeys.zoneOrSort] = sortKeys.WARLOCK,
         },

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -1451,6 +1451,7 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.objectivesText] = {"Kill Incinerator Gar'im"},
             [questKeys.requiredSpell] = -416015,
             [questKeys.zoneOrSort] = sortKeys.WARLOCK,
+            [questKeys.questFlags] = 1,
         },
         [90071] = {
             [questKeys.name] = "Demonic Tactics",


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #

## Proposed changes
Warlock runes changed:
- Blizzard changed the price of "Demolition Explosives" for "Lake of Fire" rune to 1 gold from 5 gold
- Changes the "Incinerate" rune fake quest to an elite quest (because source is an elite mob + adds)

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->