### PR TITLE
[fix] Fix complete sound on teleport

### DIFF
--- a/Modules/Quest/QuestLogCache.lua
+++ b/Modules/Quest/QuestLogCache.lua
@@ -168,43 +168,42 @@ function QuestLogCache.CheckForChanges(questIdsToCheck)
                 local newObjectives, changedObjIds = GetNewObjectives(questId, cachedObjectives)
 
                 if newObjectives then
-                    if (not cachedQuest) or (#cachedObjectives == #newObjectives) then
-                        if (not cachedQuest) or (cachedQuest.title ~= title) or (cachedQuest.questTag ~= questTag) or (cachedQuest.isComplete ~= isComplete) then
-                            -- Mark all objectives changed to force update those too.
-                            -- changedObjIds is nil from GetObjectives() for quests not having objectives. This is easiest place to change it to {}.
+                    if (not cachedQuest) or (#cachedObjectives == #newObjectives and
+                        (cachedQuest.title ~= title or cachedQuest.questTag ~= questTag or cachedQuest.isComplete ~= isComplete)) then
+                        -- Mark all objectives changed to force update those too.
 
-                            changedObjIds = {}
+                        -- changedObjIds is nil from GetObjectives() for quests not having objectives. This is easiest place to change it to {}.
+                        changedObjIds = {}
+                        for i=1, #newObjectives do
+                            changedObjIds[i] = i
+                        end
+
+                        if isComplete == 1 then
+                            -- Set all objectives finished if whole quest isComplete.
+                            -- Because of: Game API returns "event" type objectives as unfinished while whole quest isComplete.
+
+                            local o
                             for i=1, #newObjectives do
-                                changedObjIds[i] = i
-                            end
-
-                            if isComplete == 1 then
-                                -- Set all objectives finished if whole quest isComplete.
-                                -- Because of: Game API returns "event" type objectives as unfinished while whole quest isComplete.
-
-                                local o
-                                for i=1, #newObjectives do
-                                    o = newObjectives[i]
-                                    o.finished = true
-                                    o.numFulfilled = o.numRequired
-                                end
+                                o = newObjectives[i]
+                                o.finished = true
+                                o.numFulfilled = o.numRequired
                             end
                         end
+                    end
 
-                        if cachedQuest and (not cachedQuest.isComplete) and isComplete == 1 then
-                            Sounds.PlayQuestComplete()
-                        end
+                    if cachedQuest and (not cachedQuest.isComplete) and isComplete == 1 then
+                        Sounds.PlayQuestComplete()
+                    end
 
-                        if changedObjIds then
-                            -- Save to cache
-                            cache[questId] = {
-                                title = title,
-                                questTag = questTag,
-                                isComplete = isComplete,
-                                objectives = newObjectives,
-                            }
-                            changes[questId] = changedObjIds
-                        end
+                    if changedObjIds then
+                        -- Save to cache
+                        cache[questId] = {
+                            title = title,
+                            questTag = questTag,
+                            isComplete = isComplete,
+                            objectives = newObjectives,
+                        }
+                        changes[questId] = changedObjIds
                     end
                 else
                     cacheMiss = true

--- a/Modules/Quest/QuestLogCache.lua
+++ b/Modules/Quest/QuestLogCache.lua
@@ -168,10 +168,7 @@ function QuestLogCache.CheckForChanges(questIdsToCheck)
                 local newObjectives, changedObjIds = GetNewObjectives(questId, cachedObjectives)
 
                 if newObjectives then
-                    if cachedQuest and (#cachedObjectives ~= #newObjectives) then
-                        -- Quest was cached before and now the objectives are different. This only happens after a loading screen, while the API returns
-                        -- invalid data. We just skip this case.
-                    else
+                    if (not cachedQuest) or (#cachedObjectives == #newObjectives) then
                         if (not cachedQuest) or (cachedQuest.title ~= title) or (cachedQuest.questTag ~= questTag) or (cachedQuest.isComplete ~= isComplete) then
                             -- Mark all objectives changed to force update those too.
                             -- changedObjIds is nil from GetObjectives() for quests not having objectives. This is easiest place to change it to {}.

--- a/Modules/Quest/QuestLogCache.lua
+++ b/Modules/Quest/QuestLogCache.lua
@@ -168,7 +168,7 @@ function QuestLogCache.CheckForChanges(questIdsToCheck)
                 local newObjectives, changedObjIds = GetNewObjectives(questId, cachedObjectives)
 
                 if newObjectives then
-                    if (not cachedQuest) or (#cachedObjectives == #newObjectives and
+                    if (not cachedQuest) or (#cachedObjectives == #newObjectives and #cachedObjectives > 0 and
                         (cachedQuest.title ~= title or cachedQuest.questTag ~= questTag or cachedQuest.isComplete ~= isComplete)) then
                         -- Mark all objectives changed to force update those too.
 

--- a/Modules/Quest/QuestLogCache.lua
+++ b/Modules/Quest/QuestLogCache.lua
@@ -169,10 +169,8 @@ function QuestLogCache.CheckForChanges(questIdsToCheck)
 
                 if newObjectives then
                     if cachedQuest and (#cachedObjectives ~= #newObjectives) then
-                        Questie:Debug(Questie.DEBUG_CRITICAL, "Please report on Github or Discord! Number of the objectives of the quest changed. questId, oldNum, newNum", questId, #cachedObjectives, #newObjectives)
-                        -- Number of the objectives changed?! Shouldn't be possible.
-                        -- For now go as nothing in the quest changed.
-                        cacheMiss = true
+                        -- Quest was cached before and now the objectives are different. This only happens after a loading screen, while the API returns
+                        -- invalid data. We just skip this case.
                     else
                         if (not cachedQuest) or (cachedQuest.title ~= title) or (cachedQuest.questTag ~= questTag) or (cachedQuest.isComplete ~= isComplete) then
                             -- Mark all objectives changed to force update those too.

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -201,8 +201,6 @@ function QuestieQuest:ClearAllNotes()
             return
         end
 
-        quest.Objectives = {}
-
         if next(quest.SpecialObjectives) then
             for _, s in pairs(quest.SpecialObjectives) do
                 s.AlreadySpawned = {}


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #5078

## Proposed changes

- Remove the code-path for "number of objectives changed", because this only happens when the API returns invalid data after a teleport/loading screen and fixes itself soon after
- Restructured code-path to have less `if`s
- Remove reset of `quest.Objectives` on `SmoothReset` as that is fired after teleport and causes the Tracker to stop showing objectives for a short moment

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->