### PR TITLE
[quest] FIXED: Removed 'Lady Vespia' From npcDrops for 'Ruuzel'

### DIFF
--- a/Database/Corrections/classicItemFixes.lua
+++ b/Database/Corrections/classicItemFixes.lua
@@ -366,7 +366,7 @@ function QuestieItemFixes:Load()
             [itemKeys.class] = itemClasses.QUEST,
         },
         [5445] = {
-            [itemKeys.npcDrops] = {3943,10559},
+            [itemKeys.npcDrops] = {3943},
             [itemKeys.relatedQuests] = {1009},
         },
         [5455] = {


### PR DESCRIPTION
## Issue references

Fixes #5375

## Proposed changes

- FIXED: Removed 'Lady Vespia' from npcDrops so that the mob path for 'Ruuzel' is now fixed.