### PR TITLE
[quest] Fix reputation gain from "The Crown of Will"

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -262,6 +262,7 @@ function QuestieQuestFixes:Load()
         },
         [518] = {
             [questKeys.preQuestSingle] = {},
+            [questKeys.reputationReward] = {{factionIDs.UNDERCITY,100}}
         },
         [522] = {
             [questKeys.startedBy] = {{2434},nil,{3668}},


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #

## Proposed changes

- The quest gives reputation with undercity not Orgrimmar, see also https://www.wowhead.com/classic/quest=518/the-crown-of-will
-

## Screenshots
<img width="676" alt="Screenshot 2023-12-29 at 13 27 17" src="https://github.com/Questie/Questie/assets/231804/269274d8-f0b3-4ca8-a6bc-b4983026dffb">

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->