### PR TITLE
[bug] Add missing constant for undercity and replace more IDs with constants

### DIFF
--- a/Database/Corrections/tbcQuestFixes.lua
+++ b/Database/Corrections/tbcQuestFixes.lua
@@ -24,6 +24,7 @@ function QuestieTBCQuestFixes:Load()
     local questKeys = QuestieDB.questKeys
     local raceIDs = QuestieDB.raceKeys
     local classIDs = QuestieDB.classKeys
+    local factionIDs = QuestieDB.factionIDs
     local zoneIDs = ZoneDB.zoneIDs
     local sortKeys = QuestieDB.sortKeys
     local questFlags = QuestieDB.questFlags
@@ -473,12 +474,12 @@ function QuestieTBCQuestFixes:Load()
         [7792] = {
             [questKeys.startedBy] = {{20604},nil,nil},
             [questKeys.finishedBy] = {{20604},nil},
-            [questKeys.reputationReward] = {{930,350}},
+            [questKeys.reputationReward] = {{factionIDs.EXODAR,350}},
         },
         [7798] = {
             [questKeys.startedBy] = {{20604},nil,nil},
             [questKeys.finishedBy] = {{20604},nil},
-            [questKeys.reputationReward] = {{930,350}},
+            [questKeys.reputationReward] = {{factionIDs.EXODAR,350}},
         },
         [7800] = {
             [questKeys.preQuestGroup] = {7799,10352,10354},
@@ -1013,7 +1014,7 @@ function QuestieTBCQuestFixes:Load()
         [9491] = {
             [questKeys.preQuestSingle] = {},
         },
-        [9494] = { 
+        [9494] = {
             [questKeys.extraObjectives] = {{nil, Questie.ICON_TYPE_OBJECT, l10n("Gather a Fel Ember using Grand Warlock's Amulet"), 0, {{"object", 181679}}}},
         },
         [9498] = {
@@ -1769,12 +1770,12 @@ function QuestieTBCQuestFixes:Load()
         [10352] = {
             [questKeys.startedBy] = {{14725},nil,nil},
             [questKeys.finishedBy] = {{14725},nil},
-            [questKeys.reputationReward] = {{69,350}},
+            [questKeys.reputationReward] = {{factionIDs.DARNASSUS,350}},
         },
         [10354] = {
             [questKeys.startedBy] = {{14725},nil,nil},
             [questKeys.finishedBy] = {{14725},nil},
-            [questKeys.reputationReward] = {{69,350}},
+            [questKeys.reputationReward] = {{factionIDs.DARNASSUS,350}},
         },
         [10357] = {
             [questKeys.preQuestGroup] = {7792,7798,10356},

--- a/Database/Corrections/wotlkQuestFixes.lua
+++ b/Database/Corrections/wotlkQuestFixes.lua
@@ -35,6 +35,7 @@ function QuestieWotlkQuestFixes:Load()
     local questKeys = QuestieDB.questKeys
     local raceIDs = QuestieDB.raceKeys
     local classIDs = QuestieDB.classKeys
+    local factionIDs = QuestieDB.factionIDs
     local zoneIDs = ZoneDB.zoneIDs
     local sortKeys = QuestieDB.sortKeys
     local profKeys = QuestieProfessions.professionKeys
@@ -847,7 +848,7 @@ function QuestieWotlkQuestFixes:Load()
         [11472] = {
             [questKeys.objectives] = {{{24797,"Reef Bull led to a Reef Cow"}}},
             [questKeys.extraObjectives] = {{nil, Questie.ICON_TYPE_EVENT, l10n("Lure Reef Bull with Tasty Reef Fish"), 0, {{"monster", 24786},{"monster", 24804}}}},
-            [questKeys.reputationReward] = {{1073,500}},
+            [questKeys.reputationReward] = {{factionIDs.THE_KALUAK,500}},
         },
         [11475] = {
             [questKeys.preQuestSingle] = {11244},
@@ -1110,7 +1111,7 @@ function QuestieWotlkQuestFixes:Load()
             [questKeys.objectives] = {{{26127,"Captured Nexus Drake"},},nil,nil,nil,},
         },
         [11945] = {
-            [questKeys.reputationReward] = {{1073,500}},
+            [questKeys.reputationReward] = {{factionIDs.THE_KALUAK,500}},
         },
         [11956] = {
             [questKeys.extraObjectives] = {
@@ -1128,7 +1129,7 @@ function QuestieWotlkQuestFixes:Load()
             [questKeys.objectives] = {{{26196,"Loguhn's Blood Smeared"}}},
         },
         [11960] = {
-            [questKeys.reputationReward] = {{1073,500}},
+            [questKeys.reputationReward] = {{factionIDs.THE_KALUAK,500}},
         },
         [11969] = {
             [questKeys.extraObjectives] = {{nil, Questie.ICON_TYPE_EVENT, l10n("Use Raelorasz' Spark"),0,{{"object", 194151}}}},
@@ -6403,7 +6404,7 @@ function QuestieWotlkQuestFixes:Load()
             [questKeys.zoneOrSort] = 4395,
             [questKeys.questFlags] = 4232,
             [questKeys.specialFlags] = 1,
-            [questKeys.reputationReward] = {{1090,75}},
+            [questKeys.reputationReward] = {{factionIDs.KIRIN_TOR,75}},
         },
         [78753] = {
             [questKeys.name] = "Proof of Demise: Threats to Azeroth",
@@ -6417,7 +6418,7 @@ function QuestieWotlkQuestFixes:Load()
             [questKeys.zoneOrSort] = 4395,
             [questKeys.questFlags] = 4232,
             [questKeys.specialFlags] = 1,
-            [questKeys.reputationReward] = {{1090,75}},
+            [questKeys.reputationReward] = {{factionIDs.KIRIN_TOR,75}},
         },
     }
 end

--- a/Database/questDB.lua
+++ b/Database/questDB.lua
@@ -113,7 +113,12 @@ QuestieDB.questFlags = {
 }
 
 QuestieDB.factionIDs = {
+    UNDERCITY = 68,
+    DARNASSUS = 69,
     DARKMOON_FAIRE = 909,
+    EXODAR = 930,
+    THE_KALUAK = 1073,
+    KIRIN_TOR = 1090,
 }
 
 -- temporary, until we remove the old db funcitons


### PR DESCRIPTION
I noticed that the constant I used in my previous PR does not even exist. 
 https://github.com/Questie/Questie/blob/master/Database/questDB.lua#L115

As the file where `factionIDs` are defined (right now only darkmoon) is not game-version specific, I wasn't sure if classic factions should be added there? I haven't played retail in a long time and I'm not sure if factions work the same through all versions?

So for now I reverted to the integer value for Undercity.

ref #5381 