### PR TITLE
[quest] ADDED: 'Trek Through the Caves' Rune Quest To QuestDB 

### DIFF
--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -269,6 +269,17 @@ function SeasonOfDiscovery:LoadBaseQuests()
             [questKeys.objectivesText] = {"Find the lost rune carried by a Frostmane troll in Coldridge Valley. Use it to learn a new ability, then report back to Thran Khorman in Anvilmar."},
             [questKeys.objectives] = {nil,nil,nil,nil,nil,{{403470}}},
         },
+        [77660] = {
+            [questKeys.name] = "Trek Through the Caves",
+            [questKeys.startedBy] = {{895}},
+            [questKeys.finishedBy] = {{895,}},
+            [questKeys.requiredLevel] = 2,
+            [questKeys.questLevel] = 2,
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.requiredClasses] = classIDs.HUNTER,
+            [questKeys.objectivesText] = {"Recover the stolen rune from the cave of Frostmane trolls in Coldridge Valley. Use the rune to learn a new ability, then report back to Thorgas Grimson in Anvilmar."},
+            [questKeys.objectives] = {nil,nil,nil,nil,nil,{{410121}}},
+        },
         [77661] = {
             [questKeys.name] = "Meditation on the Light",
             [questKeys.startedBy] = {{837}},

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -38,6 +38,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [77652] = true, -- Shaman Overload
     [77655] = true, -- Warrior Victory Rush
     [77656] = true, -- Warrior Victory Rush
+    [77660] = true, -- Hunter Chimera Shot
     [77661] = true, -- Priest Penance
     [77666] = true, -- Warlock Haunt
     [77668] = true, -- Warrior Victory Rush

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -148,6 +148,12 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.zoneOrSort] = sortKeys.WARRIOR,
             [questKeys.requiredSpell] = -403470,
         },
+        [77660] = {
+            [questKeys.objectives] = {nil, nil, nil, nil, nil, {{410121, nil, 206168}}},
+            [questKeys.requiredRaces] = raceIDs.DWARF,
+            [questKeys.zoneOrSort] = sortKeys.HUNTER,
+            [questKeys.requiredSpell] = -410121,
+        },
         [77661] = {
             [questKeys.objectives] = {nil, nil, nil, nil, nil, {{402862, nil, 205951}}},
             [questKeys.zoneOrSort] = sortKeys.PRIEST,


### PR DESCRIPTION
## Issue references

Fixes #5393

## Proposed changes

- ADDED: 'Trek Through the Caves' is now in the QuestDB, and should be accessible to users. 