### PR TITLE
Add "Second Story Work" rogue quest (Shadowstrike rune)

### DIFF
--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -71,6 +71,17 @@ function SeasonOfDiscovery:LoadBaseQuests()
             [questKeys.objectivesText] = {"Recover the relic from the grellkin in Shadowglen. Follow the relic's guidance to learn a new ability, then report back to Mardant Strongoak."},
             [questKeys.objectives] = {nil,nil,nil,nil,nil,{{410061}}},
         },
+        [77573] = {
+            [questKeys.name] = "Second-Story Work",
+            [questKeys.startedBy] = {{3594}},
+            [questKeys.finishedBy] = {{3594,}},
+            [questKeys.requiredLevel] = 2,
+            [questKeys.questLevel] = 2,
+            [questKeys.requiredRaces] = raceIDs.NIGHTELF,
+            [questKeys.requiredClasses] = classIDs.ROGUE,
+            [questKeys.objectivesText] = {"Retrieve the rune from the hidden idol, then use it to learn a new ability. Afterwards, return to Frahun Shadewhisper."},
+            [questKeys.objectives] = {nil,nil,nil,nil,nil,{{400105}}},
+        },
         [77574] = {
             [questKeys.name] = "Meditation on Elune",
             [questKeys.startedBy] = {{3595}},

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -20,6 +20,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [76240] = true, -- Shaman Lava Lash Part 3
     [77568] = true, -- Hunter Rune of Chimera
     [77571] = true, -- Druid Fury of Stormrage
+    [77573] = true, -- Rogue Shadowstrike Alliance Teldrassil
     [77574] = true, -- Priest Penance
     [77575] = true, -- Warrior Victory Rush
     [77582] = true, -- Warrior Victory Rush

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -48,6 +48,11 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.zoneOrSort] = sortKeys.DRUID,
             [questKeys.requiredSpell] = -410061,
         },
+        [77573] = {
+            [questKeys.objectives] = {nil, nil, nil, nil, nil, {{400105, nil, 204795}}},
+            [questKeys.zoneOrSort] = sortKeys.ROGUE,
+            [questKeys.requiredSpell] = -400105,
+        },
         [77574] = {
             [questKeys.objectives] = {nil, nil, nil, nil, nil, {{402862, nil, 205951}}},
             [questKeys.zoneOrSort] = sortKeys.PRIEST,

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -170,7 +170,7 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -403470,
         },
         [77669] = {
-            [questKeys.objectives] = {nil, nil, nil, nil, nil, {{410002, nil, 205420}}},
+            [questKeys.objectives] = {nil, nil, nil, nil, nil, {{400105, nil, 205420}}},
             [questKeys.requiredRaces] = raceIDs.UNDEAD,
             [questKeys.zoneOrSort] = sortKeys.ROGUE,
             [questKeys.requiredSpell] = -400105,


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #

## Proposed changes

-Adds "Second-Story Work" Night Elf Rogue quest related to Shadowstrike Rune.

-Also saw by coincidence that the other Shadowstrike Rune by mistake had the wrong spellobjective. 
Was Engrave Gloves - Crusader Strike (the paladin rune).
Is now Engrave Gloves - Shadowstrike.
Fixed in a separate commit
## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->