### PR TITLE
[fix] Fix objective icons not being redrawn after zone change

### DIFF
--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -201,6 +201,10 @@ function QuestieQuest:ClearAllNotes()
             return
         end
 
+        for _, s in pairs(quest.Objectives) do
+            s.AlreadySpawned = {}
+        end
+
         if next(quest.SpecialObjectives) then
             for _, s in pairs(quest.SpecialObjectives) do
                 s.AlreadySpawned = {}


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #5392

## Proposed changes

- On `QuestieQuest:ClearAllNotes` we need to reset `quest.Objectives.AlreadySpawned` for each objective
- That way the objective icons are redrawn on every `SmoothReset` while the Tracker does not lose the objectives

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->