### PR TITLE
[bug] Fix displaying of reputation in Tooltip for quests that do not have a description

### DIFF
--- a/Modules/Tooltips/MapIconTooltip.lua
+++ b/Modules/Tooltips/MapIconTooltip.lua
@@ -255,50 +255,50 @@ function MapIconTooltip:Show()
                             self:AddLine(line, 0.86, 0.86, 0.86);
                         end
                     end
+                end
 
-                    if reputationReward and next(reputationReward) then
-                        local rewardTable = {}
-                        local factionId, factionName
-                        local rewardValue
-                        local aldorPenalty, scryersPenalty
-                        for _, rewardPair in pairs(reputationReward) do
-                            factionId = rewardPair[1]
+                if shift and reputationReward and next(reputationReward) then
+                    local rewardTable = {}
+                    local factionId, factionName
+                    local rewardValue
+                    local aldorPenalty, scryersPenalty
+                    for _, rewardPair in pairs(reputationReward) do
+                        factionId = rewardPair[1]
 
-                            if factionId == 935 and playerIsHonoredWithShaTar and (scryersPenalty or aldorPenalty) then
-                                -- Quests for Aldor and Scryers gives reputation to the Sha'tar but only before being Honored
-                                -- with the Sha'tar
-                                break
-                            end
-
-                            factionName = select(1, GetFactionInfoByID(factionId))
-                            if factionName then
-                                rewardValue = rewardPair[2]
-
-                                if playerIsHuman and rewardValue > 0 then
-                                    -- Humans get 10% more reputation
-                                    rewardValue = math.floor(rewardValue * 1.1)
-                                end
-
-                                if factionId == 932 then     -- Aldor
-                                    scryersPenalty = 0 - math.floor(rewardValue * 1.1)
-                                elseif factionId == 934 then -- Scryers
-                                    aldorPenalty = 0 - math.floor(rewardValue * 1.1)
-                                end
-
-                                rewardTable[#rewardTable + 1] = (rewardValue > 0 and "+" or "") .. rewardValue .. " " .. factionName
-                            end
+                        if factionId == 935 and playerIsHonoredWithShaTar and (scryersPenalty or aldorPenalty) then
+                            -- Quests for Aldor and Scryers gives reputation to the Sha'tar but only before being Honored
+                            -- with the Sha'tar
+                            break
                         end
 
-                        if aldorPenalty then
-                            factionName = select(1, GetFactionInfoByID(932))
-                            rewardTable[#rewardTable + 1] = aldorPenalty .. " " .. factionName
-                        elseif scryersPenalty then
-                            factionName = select(1, GetFactionInfoByID(934))
-                            rewardTable[#rewardTable + 1] = scryersPenalty .. " " .. factionName
-                        end
+                        factionName = select(1, GetFactionInfoByID(factionId))
+                        if factionName then
+                            rewardValue = rewardPair[2]
 
-                        self:AddLine(REPUTATION_ICON_TEXTURE .. " " .. Questie:Colorize(table.concat(rewardTable, " / "), "reputationBlue"), 1, 1, 1, 1, 1, 0)
+                            if playerIsHuman and rewardValue > 0 then
+                                -- Humans get 10% more reputation
+                                rewardValue = math.floor(rewardValue * 1.1)
+                            end
+
+                            if factionId == 932 then     -- Aldor
+                                scryersPenalty = 0 - math.floor(rewardValue * 1.1)
+                            elseif factionId == 934 then -- Scryers
+                                aldorPenalty = 0 - math.floor(rewardValue * 1.1)
+                            end
+
+                            rewardTable[#rewardTable + 1] = (rewardValue > 0 and "+" or "") .. rewardValue .. " " .. factionName
+                        end
                     end
+
+                    if aldorPenalty then
+                        factionName = select(1, GetFactionInfoByID(932))
+                        rewardTable[#rewardTable + 1] = aldorPenalty .. " " .. factionName
+                    elseif scryersPenalty then
+                        factionName = select(1, GetFactionInfoByID(934))
+                        rewardTable[#rewardTable + 1] = scryersPenalty .. " " .. factionName
+                    end
+
+                    self:AddLine(REPUTATION_ICON_TEXTURE .. " " .. Questie:Colorize(table.concat(rewardTable, " / "), "reputationBlue"), 1, 1, 1, 1, 1, 0)
                 end
             end
         end


### PR DESCRIPTION
Currently when a quest has no description the reputation reward when holding shift is not displayed.

For example a quest with a description:

<img width="436" alt="Screenshot 2024-01-05 at 12 33 16" src="https://github.com/Questie/Questie/assets/231804/13a192e0-781f-4377-83de-4f4c3bf57ae2">

Here is a quest without description:
<img width="605" alt="Screenshot 2024-01-05 at 12 42 49" src="https://github.com/Questie/Questie/assets/231804/d247166d-cba6-41c3-9f5b-c3d9f291af6d">

and with the fix:

<img width="432" alt="Screenshot 2024-01-05 at 12 33 29" src="https://github.com/Questie/Questie/assets/231804/c7516ed1-e994-471b-a93a-73c9f53e162d">


All Tooltips above are with holding SHIFT

View the diff without whitespace to see the actually changes.