### PR TITLE
[quest] ADDED: 'The Horn of Xelthos' Now Has ZoneID Link

### DIFF
--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -344,6 +344,7 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.objectivesText] = {"Bring symbols of the three owls to Loganaar in Moonglade. NOTE: To accept this quest, you need to bring at least one symbol, but you can also bring all three at once."},
         },
         [78261] = {
+            [questKeys.zoneOrSort] = zoneIDs.SHADOWFANG_KEEP,
             [questKeys.startedBy] = {nil,{410369}},
             [questKeys.finishedBy] = {nil,{410369}},
             [questKeys.requiredLevel] = 20,

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -344,11 +344,11 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.objectivesText] = {"Bring symbols of the three owls to Loganaar in Moonglade. NOTE: To accept this quest, you need to bring at least one symbol, but you can also bring all three at once."},
         },
         [78261] = {
-            [questKeys.zoneOrSort] = zoneIDs.SHADOWFANG_KEEP,
             [questKeys.startedBy] = {nil,{410369}},
             [questKeys.finishedBy] = {nil,{410369}},
             [questKeys.requiredLevel] = 20,
             [questKeys.childQuests] = {78270},
+            [questKeys.zoneOrSort] = zoneIDs.ROGUE,
         },
         [78265] = {
             [questKeys.objectivesText] = {"Bring 24 Fish Oil to Grizzby."},

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -348,7 +348,7 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.finishedBy] = {nil,{410369}},
             [questKeys.requiredLevel] = 20,
             [questKeys.childQuests] = {78270},
-            [questKeys.zoneOrSort] = zoneIDs.ROGUE,
+            [questKeys.zoneOrSort] = sortKeys.ROGUE,
         },
         [78265] = {
             [questKeys.objectivesText] = {"Bring 24 Fish Oil to Grizzby."},


### PR DESCRIPTION
## Issue references

Fixes #5420

## Proposed changes

- ADDED: 'The Horn of Xelthos' now has a zoneID so the subtitle should now show `Shadowfang Keep` instead of `Unknown Zone` in the tracker. 