### PR TITLE
[quest] ADDED: 'Savage Roar' Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -239,6 +239,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90141] = true, -- Warrior Quick Strike Darkshore
     [90142] = true, -- Warrior Quick Strike The Barrens
     [90143] = true, -- Warrior Quick Strike Silverpine Forest
+    [90144] = true, -- Druid Savage Roar Westfall
 }
 
 ---@param questId number
@@ -267,7 +268,7 @@ local questsToBlacklistBySoDPhase = {
         [90078] = true, -- Hiding Warlock Demonic Grace Elwynn Forest for now as there are too many icons
         [90079] = true, -- Hiding Warlock Demonic Grace Durotar for now as there are too many icons
         [90080] = true, -- Hiding Warlock Demonic Grace Tirisfal Galdes for now as there are too many icons
-        [90085] = true, -- Hiding Loch Modan verion of Blade Dance
+        [90085] = true, -- Hiding Loch Modan verion of Blade Dance for now as there are too many icons
         [90133] = true, -- Hiding Rogue Quick Draw Dun Morogh for now as there are too many icons
         [90134] = true, -- Hiding Rogue Quick Draw Elwynn Forest for now as there are too many icons
         [90135] = true, -- Hiding Rogue Quick Draw Teldrassil for now as there are too many icons
@@ -276,6 +277,7 @@ local questsToBlacklistBySoDPhase = {
         [90139] = true, -- Hiding Warrior Quick Strike Loch Modan for now as there are too many icons
         [90140] = true, -- Hiding Warrior Quick Strike Westfall for now as there are too many icons
         [90143] = true, -- Hiding Warrior Quick Strike Silverpine Forest for now as there are too many icons
+        [90144] = true, -- Hiding Druid Savage Roar Westfall for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2418,6 +2418,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -425443,
             [questKeys.zoneOrSort] = sortKeys.WARRIOR,
         },
+        [90144] = {
+            [questKeys.name] = "Savage Roar",
+            [questKeys.startedBy] = {{452,124,117,501,1426,123,453,125,500,1065,98}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 20,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.DRUID,
+            [questKeys.objectivesText] = {"Kill Riverpaw Gnolls until one drops the Ferocious Idol, equip the idol and follow its guidance."},
+            [questKeys.requiredSpell] = -410023,
+            [questKeys.zoneOrSort] = sortKeys.DRUID,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5429 

## Proposed changes

- ADDED: 'Savage Roar' Westfall Fake Rune Quest is now in the QuestDB, and should be accessible to users. 