### PR TITLE
[quest] ADDED: 'Exorcist' Duskwood Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -241,7 +241,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90143] = true, -- Warrior Quick Strike Silverpine Forest
     [90144] = true, -- Druid Savage Roar Westfall
     [90145] = true, -- Druid Lacerate Darkshore
-    [90147] = true, -- Druid Mangle Mulgore
+    [90146] = true, -- Druid Mangle Mulgore
     [90147] = true, -- Paladin Exorcist Duskwood
 }
 

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -240,6 +240,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90142] = true, -- Warrior Quick Strike The Barrens
     [90143] = true, -- Warrior Quick Strike Silverpine Forest
     [90144] = true, -- Druid Savage Roar Westfall
+    [90145] = true, -- Druid Lacerate Darkshore
 }
 
 ---@param questId number
@@ -278,6 +279,7 @@ local questsToBlacklistBySoDPhase = {
         [90140] = true, -- Hiding Warrior Quick Strike Westfall for now as there are too many icons
         [90143] = true, -- Hiding Warrior Quick Strike Silverpine Forest for now as there are too many icons
         [90144] = true, -- Hiding Druid Savage Roar Westfall for now as there are too many icons
+        [90145] = true, -- Hiding Druid Lacerate Darkshore for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -241,6 +241,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90143] = true, -- Warrior Quick Strike Silverpine Forest
     [90144] = true, -- Druid Savage Roar Westfall
     [90145] = true, -- Druid Lacerate Darkshore
+    [90146] = true, -- Paladin Exorcist Duskwood
 }
 
 ---@param questId number
@@ -280,6 +281,7 @@ local questsToBlacklistBySoDPhase = {
         [90143] = true, -- Hiding Warrior Quick Strike Silverpine Forest for now as there are too many icons
         [90144] = true, -- Hiding Druid Savage Roar Westfall for now as there are too many icons
         [90145] = true, -- Hiding Druid Lacerate Darkshore for now as there are too many icons
+        [90146] = true, -- Hiding Paladin Exorcist Duskwood for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2430,6 +2430,17 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -410023,
             [questKeys.zoneOrSort] = sortKeys.DRUID,
         },
+        [90145] = {
+            [questKeys.name] = "Lacerate",
+            [questKeys.startedBy] = {{2167,2324,2171,2168,2169,2170,2234}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 15,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.DRUID,
+            [questKeys.objectivesText] = {"Kill Furlbogs until Crab Treats drop, use them to feed a Young Reef Crawler and receive the rune."},
+            [questKeys.requiredSpell] = -416049,
+        },
     }
 end
 

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2440,6 +2440,19 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredClasses] = classIDs.DRUID,
             [questKeys.objectivesText] = {"Kill Furlbogs until Crab Treats drop, use them to feed a Young Reef Crawler and receive the rune."},
             [questKeys.requiredSpell] = -416049,
+            [questKeys.zoneOrSort] = sortKeys.DRUID,
+        },
+        [90146] = {
+            [questKeys.name] = "Exorcist",
+            [questKeys.startedBy] = {{215,909,910}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 25,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.PALADIN,
+            [questKeys.objectivesText] = {"Kill Defias until one drops the Libram of Banishment, equip the libram and follow its guidance."},
+            [questKeys.requiredSpell] = -416037,
+            [questKeys.zoneOrSort] = sortKeys.PALADIN,
         },
     }
 end

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2442,7 +2442,7 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -416049,
             [questKeys.zoneOrSort] = sortKeys.DRUID,
         },
-        [90146] = {
+        [90147] = {
             [questKeys.name] = "Exorcist",
             [questKeys.startedBy] = {{215,909,910}},
             [questKeys.finishedBy] = nil,

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2442,18 +2442,6 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -416049,
             [questKeys.zoneOrSort] = sortKeys.DRUID,
         },
-        [90147] = {
-            [questKeys.name] = "Exorcist",
-            [questKeys.startedBy] = {{215,909,910}},
-            [questKeys.finishedBy] = nil,
-            [questKeys.requiredLevel] = 1,
-            [questKeys.questLevel] = 25,
-            [questKeys.requiredRaces] = raceIDs.NONE,
-            [questKeys.requiredClasses] = classIDs.PALADIN,
-            [questKeys.objectivesText] = {"Kill Defias until one drops the Libram of Banishment, equip the libram and follow its guidance."},
-            [questKeys.requiredSpell] = -416037,
-            [questKeys.zoneOrSort] = sortKeys.PALADIN,
-        },
         [90146] = {
             [questKeys.name] = "Mangle",
             [questKeys.startedBy] = {{3566,2960}},
@@ -2465,6 +2453,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.objectivesText] = {"Kill Flatland Prowlers or Prairie Wolf Alphas until the Idol of Ursine Rage drops. Equip it and follow its guidance."},
             [questKeys.requiredSpell] = -410025,
             [questKeys.zoneOrSort] = sortKeys.DRUID,
+        },
+        [90147] = {
+            [questKeys.name] = "Exorcist",
+            [questKeys.startedBy] = {{215,909,910}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 25,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.PALADIN,
+            [questKeys.objectivesText] = {"Kill Defias until one drops the Libram of Banishment, equip the libram and follow its guidance."},
+            [questKeys.requiredSpell] = -416037,
+            [questKeys.zoneOrSort] = sortKeys.PALADIN,
         },
     }
 end


### PR DESCRIPTION
## Issue references

Fixes #5425
Linked To #5443 

## Proposed changes

- ADDED: 'Exorcist' Duskwood Fake Rune Quest is now in the QuestDB, and should be accessible to users. 