### PR TITLE
[quest] ADDED: 'Sunfire' Druid Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -243,6 +243,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90145] = true, -- Druid Lacerate Darkshore
     [90146] = true, -- Druid Mangle Mulgore
     [90147] = true, -- Paladin Hand of Reckoning Westfall
+    [90148] = true, -- Druid Sunfire
 }
 
 ---@param questId number
@@ -284,6 +285,7 @@ local questsToBlacklistBySoDPhase = {
         [90145] = true, -- Hiding Druid Lacerate Darkshore for now as there are too many icons
         [90146] = true, -- Hiding Druid Mangle Mulgore for now as there are too many icons
         [90147] = true, -- Hiding Paladin Hand of Reckoning Westfall for now as there are too many icons
+        [90148] = true, -- Hiding Druid Sunfire for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2465,6 +2465,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -410001,
             [questKeys.zoneOrSort] = sortKeys.PALADIN,
         },
+        [90148] = {
+            [questKeys.name] = "Sunfire",
+            [questKeys.startedBy] = {{207577}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 5,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.DRUID,
+            [questKeys.objectivesText] = {"Cast Moonfire on each Lunar Stone, and a Lunar Chest will appear, open it and loot the rune."},
+            [questKeys.requiredSpell] = -416044,
+            [questKeys.zoneOrSort] = sortKeys.DRUID,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5446 

## Proposed changes

- ADDED: 'Sunfire' Druid Fake Rune Quest is now in the QuestDB, and should be accessible to users. 