### PR TITLE
[quest] MODIFIED: Druid's "Sunfire" rune locations

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -243,7 +243,6 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90145] = true, -- Druid Lacerate Darkshore
     [90146] = true, -- Druid Mangle Mulgore
     [90147] = true, -- Paladin Hand of Reckoning Westfall
-    [90148] = true, -- Druid Sunfire
 }
 
 ---@param questId number
@@ -285,7 +284,6 @@ local questsToBlacklistBySoDPhase = {
         [90145] = true, -- Hiding Druid Lacerate Darkshore for now as there are too many icons
         [90146] = true, -- Hiding Druid Mangle Mulgore for now as there are too many icons
         [90147] = true, -- Hiding Paladin Hand of Reckoning Westfall for now as there are too many icons
-        [90148] = true, -- Hiding Druid Sunfire for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -243,6 +243,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90145] = true, -- Druid Lacerate Darkshore
     [90146] = true, -- Druid Mangle Mulgore
     [90147] = true, -- Paladin Hand of Reckoning Westfall
+    [90148] = true, -- Druid Sunfire
 }
 
 ---@param questId number
@@ -284,6 +285,7 @@ local questsToBlacklistBySoDPhase = {
         [90145] = true, -- Hiding Druid Lacerate Darkshore for now as there are too many icons
         [90146] = true, -- Hiding Druid Mangle Mulgore for now as there are too many icons
         [90147] = true, -- Hiding Paladin Hand of Reckoning Westfall for now as there are too many icons
+        [90148] = true, -- Hiding Druid Sunfire for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodNPCFixes.lua
+++ b/Database/Corrections/sodNPCFixes.lua
@@ -86,6 +86,11 @@ function SeasonOfDiscovery:LoadNPCs()
                 [zoneIDs.MULGORE] = {{30.6, 61.2}},
             },
         },
+        [207577] = { -- Lunar Stone
+            [npcKeys.spawns] = {
+                [zoneIDs.MULGORE] = {{35.2, 69.6}},
+            },
+        },
         [207743] = { -- Netali Proudwind
             [npcKeys.spawns] = {
                 [zoneIDs.THUNDER_BLUFF] = {{28.6, 18.2}},

--- a/Database/Corrections/sodNPCFixes.lua
+++ b/Database/Corrections/sodNPCFixes.lua
@@ -88,6 +88,7 @@ function SeasonOfDiscovery:LoadNPCs()
         },
         [207577] = { -- Lunar Stone
             [npcKeys.spawns] = {
+                [zoneIDs.TELDRASSIL] = {{52.8, 79.8}},
                 [zoneIDs.MULGORE] = {{35.2, 69.6}},
             },
         },

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2465,6 +2465,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -410001,
             [questKeys.zoneOrSort] = sortKeys.PALADIN,
         },
+        [90148] = {
+            [questKeys.name] = "Sunfire",
+            [questKeys.startedBy] = {{207577}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 5,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.DRUID,
+            [questKeys.objectivesText] = {"Cast Moonfire on each Lunar Stone, and a Lunar Chest will appear, open it and loot the rune."},
+            [questKeys.requiredSpell] = -416044,
+            [questKeys.zoneOrSort] = sortKeys.DRUID,
+        },
     }
 end
 

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -1421,7 +1421,7 @@ function SeasonOfDiscovery:LoadQuests()
         },
         [90057] = {
             [questKeys.name] = "Sunfire",
-            [questKeys.startedBy] = {nil,{404433}},
+            [questKeys.startedBy] = {{207577},{404433}},
             [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 4,
@@ -2464,18 +2464,6 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.objectivesText] = {"Kill Ghouls, Defias Drones or the rare Leprithus until the Libram of Justice drops, equip it and follow its guidance."},
             [questKeys.requiredSpell] = -410001,
             [questKeys.zoneOrSort] = sortKeys.PALADIN,
-        },
-        [90148] = {
-            [questKeys.name] = "Sunfire",
-            [questKeys.startedBy] = {{207577}},
-            [questKeys.finishedBy] = nil,
-            [questKeys.requiredLevel] = 1,
-            [questKeys.questLevel] = 5,
-            [questKeys.requiredRaces] = raceIDs.NONE,
-            [questKeys.requiredClasses] = classIDs.DRUID,
-            [questKeys.objectivesText] = {"Cast Moonfire on each Lunar Stone, and a Lunar Chest will appear, open it and loot the rune."},
-            [questKeys.requiredSpell] = -416044,
-            [questKeys.zoneOrSort] = sortKeys.DRUID,
         },
     }
 end


### PR DESCRIPTION
## Issue references

Fixes #5446 
Linked To #5443 

## Proposed changes

- ADDED: 'Sunfire' Teldrassil Druid Fake Rune Quest is now in the QuestDB, and should be accessible to users. 