### PR TITLE
[quest] ADDED: 'Ice Lance' Elwynn Forest Mage Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -203,6 +203,17 @@ function SeasonOfDiscovery:LoadBaseQuests()
             [questKeys.objectivesText] = {"Slay kobolds in Echo Ridge Mine to receive a memory. Kneel within Northshire Abbey to meditate on the light, then use the memory to learn a new ability. Afterwards, return to Priestess Anetta."},
             [questKeys.objectives] = {nil,nil,nil,nil,nil,{{402862}}},
         },
+        [77620] = {
+            [questKeys.name] = "Spell Research",
+            [questKeys.startedBy] = {{198}},
+            [questKeys.finishedBy] = {{198,}},
+            [questKeys.requiredLevel] = 2,
+            [questKeys.questLevel] = 2,
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.requiredClasses] = classIDs.MAGE,
+            [questKeys.objectivesText] = {"Recover research notes from the Defias bandits and use them to learn a new spell, then return to Khelden Bremen in Northshire."},
+            [questKeys.objectives] = {nil,nil,nil,nil,nil,{{401760}}},
+        },
         [77621] = {
             [questKeys.name] = "Stolen Power",
             [questKeys.startedBy] = {{459}},

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -32,6 +32,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [77616] = true, -- Warrior Victory Rush
     [77617] = true, -- Paladin Crusader Strike Elwynn Forest
     [77619] = true, -- Priest Penance
+    [77620] = true, -- Mage Ice Lance Elwynn Forest
     [77621] = true, -- Warlock Haunt
     [77642] = true, -- Priest Penance
     [77648] = true, -- Druid Fury of Stormrage

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -117,7 +117,7 @@ function SeasonOfDiscovery:LoadQuests()
         },
         [77620] = {
             [questKeys.objectives] = {nil, nil, nil, nil, nil, {{401760, nil, 203751}}},
-            [questKeys.zoneOrSort] = sortKeys.PRIEST,
+            [questKeys.zoneOrSort] = sortKeys.MAGE,
             [questKeys.requiredSpell] = -401760,
         },
         [77621] = {

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -115,6 +115,11 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
             [questKeys.requiredSpell] = -402862,
         },
+        [77620] = {
+            [questKeys.objectives] = {nil, nil, nil, nil, nil, {{401760, nil, 203751}}},
+            [questKeys.zoneOrSort] = sortKeys.PRIEST,
+            [questKeys.requiredSpell] = -401760,
+        },
         [77621] = {
             [questKeys.objectives] = {nil, nil, nil, nil, nil, {{403919, nil, 205230}}},
             [questKeys.zoneOrSort] = sortKeys.WARLOCK,


### PR DESCRIPTION
## Issue references

Fixes #5460 
Linked To #5443

## Proposed changes

- ADDED: 'Ice Lance' Elwynn Forest Mage Rune Quest is now in the QuestDB, and should be accessible to users. 