### PR TITLE
[quest]  ADDED: 'Lacerate' Westfall Druid Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -251,6 +251,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90151] = true, -- Hunter Sniper Training Westfall
     [90152] = true, -- Hunter Sniper Training Loch Modan
     [90153] = true, -- Hunter Sniper Training The Barrens
+    [90154] = true, -- Druid Lacerate Westfall
 }
 
 ---@param questId number
@@ -293,6 +294,7 @@ local questsToBlacklistBySoDPhase = {
         [90146] = true, -- Hiding Druid Mangle Mulgore for now as there are too many icons
         [90147] = true, -- Hiding Paladin Hand of Reckoning Westfall for now as there are too many icons
         [90148] = true, -- Hiding Paladin Exorcist Duskwood for now as there are too many icons
+        [90154] = true, -- Hiding Druid Lacerate Westfall for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodNPCFixes.lua
+++ b/Database/Corrections/sodNPCFixes.lua
@@ -194,9 +194,7 @@ function SeasonOfDiscovery:LoadNPCs()
             },
         },
         [210483] = { -- Aggressive Squashling
-            [npcKeys.spawns] = {
-                [zoneIDs.WESTFALL] = {},
-            },
+            [npcKeys.spawns] = {},
         },
         [210537] = { -- Undying Laborer
             [npcKeys.spawns] = {

--- a/Database/Corrections/sodNPCFixes.lua
+++ b/Database/Corrections/sodNPCFixes.lua
@@ -193,6 +193,11 @@ function SeasonOfDiscovery:LoadNPCs()
                 [zoneIDs.DARKSHORE] = {{47.8, 16.0}},
             },
         },
+        [210483] = { -- Aggressive Squashling
+            [npcKeys.spawns] = {
+                [zoneIDs.WESTFALL] = {},
+            },
+        },
         [210537] = { -- Undying Laborer
             [npcKeys.spawns] = {
                 [zoneIDs.WESTFALL] = {{44.9,24},{31.5,45}},

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2550,7 +2550,7 @@ function SeasonOfDiscovery:LoadQuests()
         },
         [90154] = {
             [questKeys.name] = "Lacerate",
-            [questKeys.startedBy] = {{95,504,481,590,589,122,121,449,831,830,1216,1236}},
+            [questKeys.startedBy] = {{95,504,481,590,589,122,121,449,831,830,1216,1236,210483}},
             [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 16,

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2548,6 +2548,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -416091,
             [questKeys.zoneOrSort] = sortKeys.HUNTER,
         },
+        [90154] = {
+            [questKeys.name] = "Lacerate",
+            [questKeys.startedBy] = {{95,504,481,590,589,122,121,449,831,830,1216,1236}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 16,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.DRUID,
+            [questKeys.objectivesText] = {"Kill Defias for Magic Pumpkin Seeds, Crabs for Fishy Bonemeal and Kobolds for Fertile Soil Sample, then go to any farmland in Westfall, and use the seeds to spawn Aggressive Squashling, kill it and loot the rune."},
+            [questKeys.requiredSpell] = -416049,
+            [questKeys.zoneOrSort] = sortKeys.DRUID,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5465 
Linked To #5443 

## Proposed changes

- ADDED: 'Lacerate' Westfall Druid Fake Rune Quest is now in the QuestDB, and is currently hidden due to too many icons being loaded if it is not.