### PR TITLE
[quest] ADDED: 'Friend of the Library' Mage Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -1230,7 +1230,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79097] = {
             [questKeys.name] = "Baxtan: On Destructive Magics",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211033,}},
+            [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,

--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -1203,7 +1203,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79094] = {
             [questKeys.name] = "The Lessons of Ta'zo",
             [questKeys.startedBy] = {{211022}},
-            [questKeys.finishedBy] = nill,
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1212,7 +1212,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79095] = {
             [questKeys.name] = "The Apothecary's Metaphysical Primer",
             [questKeys.startedBy] = {{211022}},
-            [questKeys.finishedBy] = nill,
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1221,7 +1221,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79096] = {
             [questKeys.name] = "Ataeric: On Arcane Curiosities",
             [questKeys.startedBy] = {{211022}},
-            [questKeys.finishedBy] = nill,
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,

--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -481,7 +481,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78124] = {
             [questKeys.name] = "Nar'thalas Almanac",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211022,211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -490,7 +490,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78127] = {
             [questKeys.name] = "The Dalaran Digest",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211022,211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -529,7 +529,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78142] = {
             [questKeys.name] = "Bewitchments and Glamours",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211022,211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -538,7 +538,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78143] = {
             [questKeys.name] = "Secrets of the Dreamers",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211022,211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -558,7 +558,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78145] = {
             [questKeys.name] = "Arcanic Systems Manual",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211022,211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -567,7 +567,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78146] = {
             [questKeys.name] = "Goaz Scrolls",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211022,211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -576,7 +576,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78147] = {
             [questKeys.name] = "Crimes Against Anatomy",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211022,211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -585,7 +585,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78148] = {
             [questKeys.name] = "Runes of the Sorceror-Kings",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211022,211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -594,6 +594,15 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78149] = {
             [questKeys.name] = "Fury of the Land",
             [questKeys.startedBy] = {{211033}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 20,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.MAGE,
+        },
+        [78150] = {
+            [questKeys.name] = "Friend of the Library",
+            [questKeys.startedBy] = {{211033,211022,}},
             [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
@@ -1167,7 +1176,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79091] = {
             [questKeys.name] = "Archmage Antonidas: The Unabridged Autobiography",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1176,7 +1185,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79092] = {
             [questKeys.name] = "Archmage Theocritus's Research Journal",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1185,7 +1194,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79093] = {
             [questKeys.name] = "Rumi of Gnomeregan: The Collected Works",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1194,7 +1203,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79094] = {
             [questKeys.name] = "The Lessons of Ta'zo",
             [questKeys.startedBy] = {{211022}},
-            [questKeys.finishedBy] = {{211022,}},
+            [questKeys.finishedBy] = nill,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1203,7 +1212,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79095] = {
             [questKeys.name] = "The Apothecary's Metaphysical Primer",
             [questKeys.startedBy] = {{211022}},
-            [questKeys.finishedBy] = {{211022,}},
+            [questKeys.finishedBy] = nill,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1212,7 +1221,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79096] = {
             [questKeys.name] = "Ataeric: On Arcane Curiosities",
             [questKeys.startedBy] = {{211022}},
-            [questKeys.finishedBy] = {{211022,}},
+            [questKeys.finishedBy] = nill,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1221,7 +1230,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79097] = {
             [questKeys.name] = "Baxtan: On Destructive Magics",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = {{211022,211033,}},
+            [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,

--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -481,7 +481,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78124] = {
             [questKeys.name] = "Nar'thalas Almanac",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -490,7 +490,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78127] = {
             [questKeys.name] = "The Dalaran Digest",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -529,7 +529,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78142] = {
             [questKeys.name] = "Bewitchments and Glamours",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -538,7 +538,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78143] = {
             [questKeys.name] = "Secrets of the Dreamers",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -558,7 +558,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78145] = {
             [questKeys.name] = "Arcanic Systems Manual",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -567,7 +567,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78146] = {
             [questKeys.name] = "Goaz Scrolls",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -576,7 +576,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78147] = {
             [questKeys.name] = "Crimes Against Anatomy",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -585,7 +585,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78148] = {
             [questKeys.name] = "Runes of the Sorceror-Kings",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -594,7 +594,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [78149] = {
             [questKeys.name] = "Fury of the Land",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1176,7 +1176,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79091] = {
             [questKeys.name] = "Archmage Antonidas: The Unabridged Autobiography",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1185,7 +1185,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79092] = {
             [questKeys.name] = "Archmage Theocritus's Research Journal",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1194,7 +1194,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79093] = {
             [questKeys.name] = "Rumi of Gnomeregan: The Collected Works",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1203,7 +1203,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79094] = {
             [questKeys.name] = "The Lessons of Ta'zo",
             [questKeys.startedBy] = {{211022}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1212,7 +1212,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79095] = {
             [questKeys.name] = "The Apothecary's Metaphysical Primer",
             [questKeys.startedBy] = {{211022}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1221,7 +1221,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79096] = {
             [questKeys.name] = "Ataeric: On Arcane Curiosities",
             [questKeys.startedBy] = {{211022}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211022,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,
@@ -1230,7 +1230,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
         [79097] = {
             [questKeys.name] = "Baxtan: On Destructive Magics",
             [questKeys.startedBy] = {{211033}},
-            [questKeys.finishedBy] = nil,
+            [questKeys.finishedBy] = {{211033,}},
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 20,
             [questKeys.requiredRaces] = raceIDs.NONE,

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -70,6 +70,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [78147] = true, -- Mage Icy Veins
     [78148] = true, -- Mage Icy Veins
     [78149] = true, -- Mage Icy Veins
+    [78150] = true, -- Mage Icy Veins
     [78229] = true, -- Druid Wild Growth
     [78261] = true, -- Rogue Deadly Brew Part 2
     [78265] = true, -- Grizzby prequest for multiple runes

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2607,7 +2607,7 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
             [questKeys.objectivesText] = {"Collect 'Fury of the Land' and bring it to Owen Thadd in Undercity."},
         },
         [78150] = {
-            [questkeys.startedBy] = {{211022}},
+            [questKeys.startedBy] = {{211022}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"You will need to hand in 10 books to receive the rune, however you can hand 1 in at any time."},
         },
@@ -2693,7 +2693,7 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
             [questKeys.objectivesText] = {"Collect 'Fury of the Land' and bring it to Garion Wendell in Stormwind."},
         },
         [78150] = {
-            [questkeys.startedBy] = {{211033}},
+            [questKeys.startedBy] = {{211033}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"You will need to hand in 10 books to receive the rune, however you can hand 1 in at any time."},
         },

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2562,47 +2562,47 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
 
     local questFixesHorde = {
         [78124] = {
-            [questKeys.startedBy] = {{409496}},
+            [questKeys.startedBy] = {nil,{409496}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"Collect 'Nar'thalas Almanac, Vol. 74' and bring it to Owen Thadd in Undercity."},
         },
         [78127] = {
-            [questKeys.startedBy] = {{409501}},
+            [questKeys.startedBy] = {nil,{409501}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"Collect 'The Dalaran Digest, Vol. 23' and bring it to Owen Thadd in Undercity."},
         },
         [78142] = {
-            [questKeys.startedBy] = {{409562}},
+            [questKeys.startedBy] = {nil,{409562}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"Collect 'Bewitchments and Glamours' and bring it to Owen Thadd in Undercity."},
         },
         [78143] = {
-            [questKeys.startedBy] = {{409692}},
+            [questKeys.startedBy] = {nil,{409692}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"Collect 'Secrets of the Dreamers' located just outside the Wailing Cavern dungeon and bring it to Owen Thadd in Undercity."},
         },
         [78145] = {
-            [questKeys.startedBy] = {{409700}},
+            [questKeys.startedBy] = {nil,{409700}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"Collect 'Arcanic Systems Manual' and bring it to Owen Thadd in Undercity."},
         },
         [78146] = {
-            [questKeys.startedBy] = {{409717}},
+            [questKeys.startedBy] = {nil,{409717}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"Collect 'Goaz Scrolls' and bring it to Owen Thadd in Undercity."},
         },
         [78147] = {
-            [questKeys.startedBy] = {{409735}},
+            [questKeys.startedBy] = {nil,{409735}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"Collect 'Crimes Against Anatomy' and bring it to Owen Thadd in Undercity."},
         },
         [78148] = {
-            [questKeys.startedBy] = {{409731}},
+            [questKeys.startedBy] = {nil,{409731}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"Collect 'Runes of the Sorcerer-Kings' and bring it to Owen Thadd in Undercity."},
         },
         [78149] = {
-            [questKeys.startedBy] = {{409711}},
+            [questKeys.startedBy] = {nil,{409711}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"Collect 'Fury of the Land' and bring it to Owen Thadd in Undercity."},
         },
@@ -2624,7 +2624,7 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
             [questKeys.finishedBy] = {{214070,214096,214098}},
         },
         [79097] = {
-            [questKeys.startedBy] = {{407566}},
+            [questKeys.startedBy] = {nil,{407566}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.objectivesText] = {"Collect 'Baxtan: On Destructive Magics' and bring it to Owen Thadd in Undercity."},
         },
@@ -2648,52 +2648,52 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
 
     local questFixesAlliance = {
         [78124] = {
-            [questKeys.startedBy] = {{409496}},
+            [questKeys.startedBy] = {nil,{409496}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"Collect 'Nar'thalas Almanac, Vol. 74' and bring it to Garion Wendell in Stormwind."},
         },
         [78127] = {
-            [questKeys.startedBy] = {{409501}},
+            [questKeys.startedBy] = {nil,{409501}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"Collect 'The Dalaran Digest, Vol. 23' and bring it to Garion Wendell in Stormwind."},
         },
         [78142] = {
-            [questKeys.startedBy] = {{409562}},
+            [questKeys.startedBy] = {nil,{409562}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"Collect 'Bewitchments and Glamours' and bring it to Garion Wendell in Stormwind."},
         },
         [78143] = {
-            [questKeys.startedBy] = {{409692}},
+            [questKeys.startedBy] = {nil,{409692}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"Collect 'Secrets of the Dreamers' located just outside the Wailing Cavern dungeon and bring it to Garion Wendell in Stormwind."},
         },
         [78145] = {
-            [questKeys.startedBy] = {{409700}},
+            [questKeys.startedBy] = {nil,{409700}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"Collect 'Arcanic Systems Manual' and bring it to Garion Wendell in Stormwind."},
         },
         [78146] = {
-            [questKeys.startedBy] = {{409717}},
+            [questKeys.startedBy] = {nil,{409717}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"Collect 'Goaz Scrolls' and bring it to Garion Wendell in Stormwind."},
         },
         [78147] = {
-            [questKeys.startedBy] = {{409735}},
+            [questKeys.startedBy] = {nil,{409735}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"Collect 'Crimes Against Anatomy' and bring it to Garion Wendell in Stormwind."},
         },
         [78148] = {
-            [questKeys.startedBy] = {{409731}},
+            [questKeys.startedBy] = {nil,{409731}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"Collect 'Runes of the Sorcerer-Kings' and bring it to Garion Wendell in Stormwind."},
         },
         [78149] = {
-            [questKeys.startedBy] = {{409711}},
+            [questKeys.startedBy] = {nil,{409711}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"Collect 'Fury of the Land' and bring it to Garion Wendell in Stormwind."},
         },
         [78150] = {
-            [questKeys.startedBy] = {{211033}},
+            [questKeys.startedBy] = {{211033}}
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"You will need to hand in 10 books to receive the rune, however you can hand 1 in at any time."},
         },
@@ -2710,7 +2710,7 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
             [questKeys.finishedBy] = {{213077,214099,214101}},
         },
         [79097] = {
-            [questKeys.startedBy] = {{407566}},
+            [questKeys.startedBy] = {nil,{407566}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"Collect 'Baxtan: On Destructive Magics' and bring it to Garion Wendell in Stormwind."},
         },

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -309,6 +309,11 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -425170,
             [questKeys.zoneOrSort] = sortKeys.MAGE,
         },
+        [78150] = {
+            [questKeys.questLevel] = -1,
+            [questKeys.requiredSpell] = -425170,
+            [questKeys.zoneOrSort] = sortKeys.MAGE,
+        },
         [78192] = {
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
             [questKeys.objectives] = {{{3733},{3732}}},
@@ -2557,49 +2562,54 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
 
     local questFixesHorde = {
         [78124] = {
-            [questKeys.startedBy] = {{211022},{409496}},
+            [questKeys.startedBy] = {{409496}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
-            [questKeys.objectivesText] = {"Collect 'Nar'thalas Almanac, Vol. 74' and bring it to Owen Thadd in Undercity. After ten books you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Nar'thalas Almanac, Vol. 74' and bring it to Owen Thadd in Undercity."},
         },
         [78127] = {
-            [questKeys.startedBy] = {{211022},{409501}},
+            [questKeys.startedBy] = {{409501}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
-            [questKeys.objectivesText] = {"Collect 'The Dalaran Digest, Vol. 23' and bring it to Owen Thadd in Undercity. After ten books you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'The Dalaran Digest, Vol. 23' and bring it to Owen Thadd in Undercity."},
         },
         [78142] = {
-            [questKeys.startedBy] = {{211022},{409562}},
+            [questKeys.startedBy] = {{409562}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
-            [questKeys.objectivesText] = {"Collect 'Bewitchments and Glamours' and bring it to Owen Thadd in Undercity. After ten books you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Bewitchments and Glamours' and bring it to Owen Thadd in Undercity."},
         },
         [78143] = {
-            [questKeys.startedBy] = {{211022},{409692}},
+            [questKeys.startedBy] = {{409692}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
-            [questKeys.objectivesText] = {"Collect 'Secrets of the Dreamers' located just outside the Wailing Cavern dungeon and bring it to Owen Thadd in Undercity. After ten books you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Secrets of the Dreamers' located just outside the Wailing Cavern dungeon and bring it to Owen Thadd in Undercity."},
         },
         [78145] = {
-            [questKeys.startedBy] = {{211022},{409700}},
+            [questKeys.startedBy] = {{409700}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
-            [questKeys.objectivesText] = {"Collect 'Arcanic Systems Manual' and bring it to Owen Thadd in Undercity. After ten books you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Arcanic Systems Manual' and bring it to Owen Thadd in Undercity."},
         },
         [78146] = {
-            [questKeys.startedBy] = {{211022},{409717}},
+            [questKeys.startedBy] = {{409717}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
-            [questKeys.objectivesText] = {"Collect 'Goaz Scrolls' and bring it to Owen Thadd in Undercity. After ten books you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Goaz Scrolls' and bring it to Owen Thadd in Undercity."},
         },
         [78147] = {
-            [questKeys.startedBy] = {{211022},{409735}},
+            [questKeys.startedBy] = {{409735}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
-            [questKeys.objectivesText] = {"Collect 'Crimes Against Anatomy' and bring it to Owen Thadd in Undercity. After ten books you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Crimes Against Anatomy' and bring it to Owen Thadd in Undercity."},
         },
         [78148] = {
-            [questKeys.startedBy] = {{211022},{409731}},
+            [questKeys.startedBy] = {{409731}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
-            [questKeys.objectivesText] = {"Collect 'Runes of the Sorcerer-Kings' and bring it to Owen Thadd in Undercity. After ten books you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Runes of the Sorcerer-Kings' and bring it to Owen Thadd in Undercity."},
         },
         [78149] = {
-            [questKeys.startedBy] = {{211022},{409711}},
+            [questKeys.startedBy] = {{409711}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
-            [questKeys.objectivesText] = {"Collect 'Fury of the Land' and bring it to Owen Thadd in Undercity. After ten books you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Fury of the Land' and bring it to Owen Thadd in Undercity."},
+        },
+        [78150] = {
+            [questkeys.startedBy] = {{211022}},
+            [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
+            [questKeys.objectivesText] = {"You will need to hand in 10 books to receive the rune, however you can hand 1 in at any time."},
         },
         [78611] = {
             [questKeys.startedBy] = {{214070,214096,214098}},
@@ -2614,9 +2624,9 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
             [questKeys.finishedBy] = {{214070,214096,214098}},
         },
         [79097] = {
-            [questKeys.startedBy] = {{211022},{407566}},
+            [questKeys.startedBy] = {{407566}},
             [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
-            [questKeys.objectivesText] = {"Collect 'Baxtan: On Destructive Magics' and bring it to Owen Thadd in Undercity. After ten books you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Baxtan: On Destructive Magics' and bring it to Owen Thadd in Undercity."},
         },
         [79100] = {
             [questKeys.startedBy] = {{214070,214096,214098}},
@@ -2638,49 +2648,54 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
 
     local questFixesAlliance = {
         [78124] = {
-            [questKeys.startedBy] = {{211033},{409496}},
+            [questKeys.startedBy] = {{409496}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Collect 'Nar'thalas Almanac, Vol. 74' and bring it to Garion Wendell in Stormwind. After ten book turnins you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Nar'thalas Almanac, Vol. 74' and bring it to Garion Wendell in Stormwind."},
         },
         [78127] = {
-            [questKeys.startedBy] = {{211033},{409501}},
+            [questKeys.startedBy] = {{409501}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Collect 'The Dalaran Digest, Vol. 23' and bring it to Garion Wendell in Stormwind. After ten book turnins you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'The Dalaran Digest, Vol. 23' and bring it to Garion Wendell in Stormwind."},
         },
         [78142] = {
-            [questKeys.startedBy] = {{211033},{409562}},
+            [questKeys.startedBy] = {{409562}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Collect 'Bewitchments and Glamours' and bring it to Garion Wendell in Stormwind. After ten book turnins you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Bewitchments and Glamours' and bring it to Garion Wendell in Stormwind."},
         },
         [78143] = {
-            [questKeys.startedBy] = {{211033},{409692}},
+            [questKeys.startedBy] = {{409692}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Collect 'Secrets of the Dreamers' located just outside the Wailing Cavern dungeon and bring it to Garion Wendell in Stormwind. After ten book turnins you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Secrets of the Dreamers' located just outside the Wailing Cavern dungeon and bring it to Garion Wendell in Stormwind."},
         },
         [78145] = {
-            [questKeys.startedBy] = {{211033},{409700}},
+            [questKeys.startedBy] = {{409700}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Collect 'Arcanic Systems Manual' and bring it to Garion Wendell in Stormwind. After ten book turnins you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Arcanic Systems Manual' and bring it to Garion Wendell in Stormwind."},
         },
         [78146] = {
-            [questKeys.startedBy] = {{211033},{409717}},
+            [questKeys.startedBy] = {{409717}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Collect 'Goaz Scrolls' and bring it to Garion Wendell in Stormwind. After ten book turnins you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Goaz Scrolls' and bring it to Garion Wendell in Stormwind."},
         },
         [78147] = {
-            [questKeys.startedBy] = {{211033},{409735}},
+            [questKeys.startedBy] = {{409735}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Collect 'Crimes Against Anatomy' and bring it to Garion Wendell in Stormwind. After ten book turnins you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Crimes Against Anatomy' and bring it to Garion Wendell in Stormwind."},
         },
         [78148] = {
-            [questKeys.startedBy] = {{211033},{409731}},
+            [questKeys.startedBy] = {{409731}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Collect 'Runes of the Sorcerer-Kings' and bring it to Garion Wendell in Stormwind. After ten book turnins you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Runes of the Sorcerer-Kings' and bring it to Garion Wendell in Stormwind."},
         },
         [78149] = {
-            [questKeys.startedBy] = {{211033},{409711}},
+            [questKeys.startedBy] = {{409711}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Collect 'Fury of the Land' and bring it to Garion Wendell in Stormwind. After ten book turnins you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Fury of the Land' and bring it to Garion Wendell in Stormwind."},
+        },
+        [78150] = {
+            [questkeys.startedBy] = {{211033}},
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.objectivesText] = {"You will need to hand in 10 books to receive the rune, however you can hand 1 in at any time."},
         },
         [78611] = {
             [questKeys.startedBy] = {{213077,214099,214101}},
@@ -2695,9 +2710,9 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
             [questKeys.finishedBy] = {{213077,214099,214101}},
         },
         [79097] = {
-            [questKeys.startedBy] = {{211033},{407566}},
+            [questKeys.startedBy] = {{407566}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
-            [questKeys.objectivesText] = {"Collect 'Baxtan: On Destructive Magics' and bring it to Garion Wendell in Stormwind. After ten book turnins you will receive the Icy Veins rune."},
+            [questKeys.objectivesText] = {"Collect 'Baxtan: On Destructive Magics' and bring it to Garion Wendell in Stormwind."},
         },
         [79100] = {
             [questKeys.startedBy] = {{213077,214099,214101}},

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2693,7 +2693,7 @@ function SeasonOfDiscovery:LoadFactionQuestFixes()
             [questKeys.objectivesText] = {"Collect 'Fury of the Land' and bring it to Garion Wendell in Stormwind."},
         },
         [78150] = {
-            [questKeys.startedBy] = {{211033}}
+            [questKeys.startedBy] = {{211033}},
             [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
             [questKeys.objectivesText] = {"You will need to hand in 10 books to receive the rune, however you can hand 1 in at any time."},
         },


### PR DESCRIPTION
## Issue references

Fixes #5468
Linked To #5443 

## Proposed changes

- ADDED: 'Friend of the Library' Mage Rune Quest is now in the QuestDB, and is now accessible to users.
- MODIFIED: Book quests for both Alliance and Horde to have a `finishedBy` set to nil, as we are replacing it with this quest.