### PR TITLE
[quest] ADDED: 'Ice Lance' Durotar Mage Rune Quest To QuestDB 

### DIFF
--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -236,6 +236,17 @@ function SeasonOfDiscovery:LoadBaseQuests()
             [questKeys.objectivesText] = {"Kneel at the Loa Altar in Sen'jin Village. Commune with the Loa spirit, then use the memory to learn a new ability. Afterwards, return to Ken'jai  in the Valley of Trails."},
             [questKeys.objectives] = {nil,nil,{{205951}}},
         },
+        [77643] = {
+            [questKeys.name] = "Spell Research",
+            [questKeys.startedBy] = {{5884}},
+            [questKeys.finishedBy] = {{5884,}},
+            [questKeys.requiredLevel] = 2,
+            [questKeys.questLevel] = 2,
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.requiredClasses] = classIDs.MAGE,
+            [questKeys.objectivesText] = {"Find the stolen spell notes inside the Burning Blade Coven, then use them to learn a new ability. Afterwards, return to Mai'ah in the Valley of Trails."},
+            [questKeys.objectives] = {nil,nil,nil,nil,nil,{{401760}}},
+        },
         [77648] = {
             [questKeys.name] = "Relics of the Tauren",
             [questKeys.startedBy] = {{3060}},

--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -242,7 +242,7 @@ function SeasonOfDiscovery:LoadBaseQuests()
             [questKeys.finishedBy] = {{5884,}},
             [questKeys.requiredLevel] = 2,
             [questKeys.questLevel] = 2,
-            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
             [questKeys.requiredClasses] = classIDs.MAGE,
             [questKeys.objectivesText] = {"Find the stolen spell notes inside the Burning Blade Coven, then use them to learn a new ability. Afterwards, return to Mai'ah in the Valley of Trails."},
             [questKeys.objectives] = {nil,nil,nil,nil,nil,{{401760}}},

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -35,6 +35,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [77620] = true, -- Mage Ice Lance Elwynn Forest
     [77621] = true, -- Warlock Haunt
     [77642] = true, -- Priest Penance
+    [77643] = true, -- Mage Ice Lance Durotar
     [77648] = true, -- Druid Fury of Stormrage Horde
     [77649] = true, -- Hunter Chimera Shot
     [77651] = true, -- Warrior Victory Rush

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -131,6 +131,11 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
             [questKeys.requiredSpell] = -402862,
         },
+        [77643] = {
+            [questKeys.objectives] = {nil, {{404695}}, nil, nil, nil, {{401760, nil, 203751}}},
+            [questKeys.zoneOrSort] = sortKeys.MAGE,
+            [questKeys.requiredSpell] = -401760,
+        },
         [77648] = {
             [questKeys.objectives] = {nil, nil, nil, nil, nil, {{410061, nil, 208414}}},
             [questKeys.zoneOrSort] = sortKeys.DRUID,


### PR DESCRIPTION
## Issue references

Fixes #5470
Linked To #5443 

## Proposed changes

- ADDED: 'Ice Lance' Durotar Mage Rune Quest is now in the QuestDB, and should be accessible to users. 