### PR TITLE
[quest] ADDED: 'Ice Lance' Tirisfal Glades Mage Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -379,6 +379,17 @@ function SeasonOfDiscovery:LoadBaseQuests()
             [questKeys.objectivesText] = {"Kneel in the graveyard to meditate on undeath, then use the rune to learn a new ability. Afterwards, return to Dark Cleric Duesten in the Deathknell chapel."},
             [questKeys.objectives] = {nil,nil,{{205951}}},
         },
+        [77671] = {
+            [questKeys.name] = "Spell Research",
+            [questKeys.startedBy] = {{2124}},
+            [questKeys.finishedBy] = {{2124,}},
+            [questKeys.requiredLevel] = 2,
+            [questKeys.questLevel] = 2,
+            [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
+            [questKeys.requiredClasses] = classIDs.MAGE,
+            [questKeys.objectivesText] = {"Kill Scarlet Initiates to find spell notes and use them to learn a new ability, then return to Isabella in Deathknell."},
+            [questKeys.objectives] = {nil,nil,nil,nil,nil,{{401760}}},
+        },
         [77672] = {
             [questKeys.name] = "The Lost Rune",
             [questKeys.startedBy] = {{2126}},

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -48,6 +48,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [77668] = true, -- Warrior Victory Rush
     [77669] = true, -- Horde Undead Rogue Shadowstrike
     [77670] = true, -- Priest Penance
+    [77671] = true, -- Mage Ice Lance Tirisfal Glades
     [77672] = true, -- Warlock Haunt
     [78088] = true, -- Paladin Divine Storm
     [78089] = true, -- Paladin Divine Storm

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -203,6 +203,11 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
             [questKeys.requiredSpell] = -402862,
         },
+        [77671] = {
+            [questKeys.objectives] = {nil, nil, nil, nil, nil, {{401760, nil, 203751}}},
+            [questKeys.zoneOrSort] = sortKeys.MAGE,
+            [questKeys.requiredSpell] = -401760,
+        },
         [77672] = {
             [questKeys.objectives] = {nil, nil, nil, nil, nil, {{403919, nil, 205230}}},
             [questKeys.zoneOrSort] = sortKeys.WARLOCK,


### PR DESCRIPTION
## Issue references

Fixes #5471
Linked To #5443 

## Proposed changes

- ADDED: 'Ice Lance' Tirisfal Glades Mage Rune Quest is now in the QuestDB, and should be accessible to users. 