### PR TITLE
[quest] ADDED: 'Ice Lance' Dun Morogh Mage Rune Quest

### DIFF
--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -357,6 +357,17 @@ function SeasonOfDiscovery:LoadBaseQuests()
             [questKeys.objectivesText] = {"Recover the rune from the group of Troggs, southwest of Anvilmar, and use it to learn a new ability. Then, return to Alamar Grimm in Anvilmar."},
             [questKeys.objectives] = nil,
         },
+        [77667] = {
+            [questKeys.name] = "Spell Research",
+            [questKeys.startedBy] = {{944}},
+            [questKeys.finishedBy] = {{944,}},
+            [questKeys.requiredLevel] = 2,
+            [questKeys.questLevel] = 2,
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.requiredClasses] = classIDs.MAGE,
+            [questKeys.objectivesText] = {"Find the stolen spell notes at the trogg camp to the southwest of Anvilmar, then use them to learn a new ability. Afterwards, return to Marryk Nurribit in Anvilmar."},
+            [questKeys.objectives] = {nil,nil,nil,nil,nil,{{401760}}},
+        },
         [77668] = {
             [questKeys.name] = "The Lost Rune",
             [questKeys.startedBy] = {{2119}},

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -47,6 +47,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [77661] = true, -- Priest Penance
     [77666] = true, -- Warlock Haunt
     [77668] = true, -- Warrior Victory Rush
+    [77667] = true, -- Mage Ice Lance Dun Morogh
     [77669] = true, -- Horde Undead Rogue Shadowstrike
     [77670] = true, -- Priest Penance
     [77671] = true, -- Mage Ice Lance Tirisfal Glades

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -191,6 +191,11 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.zoneOrSort] = sortKeys.WARLOCK,
             [questKeys.requiredSpell] = -403919,
         },
+        [77667] = {
+            [questKeys.objectives] = {nil, {{405633}}, nil, nil, nil, {{401760, nil, 203751}}},
+            [questKeys.zoneOrSort] = sortKeys.MAGE,
+            [questKeys.requiredSpell] = -401760,
+        },
         [77668] = {
             [questKeys.objectives] = {nil, nil, nil, nil, nil, {{403470, nil, 204806}}},
             [questKeys.requiredRaces] = raceIDs.UNDEAD,


### PR DESCRIPTION
## Issue references

Fixes #5472
Linked To #5443 

## Proposed changes

- ADDED: 'Ice Lance' Dun Morogh Mage Rune Quest is now in the QuestDB, and should be accessible to users. 