### PR TITLE
[quest] ADDED: 'Void Plague' Elwynn Forest Priest Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -255,6 +255,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90152] = true, -- Hunter Sniper Training Loch Modan
     [90153] = true, -- Hunter Sniper Training The Barrens
     [90154] = true, -- Druid Lacerate Westfall
+    [90156] = true, -- Priest Void Plague Elwynn Forest
 }
 
 ---@param questId number

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2576,6 +2576,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -416049,
             [questKeys.zoneOrSort] = sortKeys.DRUID,
         },
+        [90156] = {
+            [questKeys.name] = "Void Plague",
+            [questKeys.startedBy] = {{327}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 8,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.PRIEST,
+            [questKeys.objectivesText] = {"Kill Goldtooth and loot the rune."},
+            [questKeys.requiredSpell] = -425216,
+            [questKeys.zoneOrSort] = sortKeys.PRIEST,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5479
Linked To #5443 

## Proposed changes

- ADDED: 'Void Plague' Elwynn Forest Priest Fake Rune Quest is now in the QuestDB, and should be accessible to users. 