### PR TITLE
[quest] ADDED: 'Serendipity' Priest Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -255,6 +255,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90152] = true, -- Hunter Sniper Training Loch Modan
     [90153] = true, -- Hunter Sniper Training The Barrens
     [90154] = true, -- Druid Lacerate Westfall
+    [90160] = true, -- Priest Serendipity
 }
 
 ---@param questId number

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2576,6 +2576,19 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -416049,
             [questKeys.zoneOrSort] = sortKeys.DRUID,
         },
+        [90160] = {
+            [questKeys.name] = "Serendipity",
+            [questKeys.startedBy] = {{211653}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 20,
+            [questKeys.questLevel] = 25,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.PRIEST,
+            [questKeys.objectivesText] = {"Buy the Serendipity rune from Grizzby."},
+            [questKeys.preQuestGroup] = {78265,78266,78267},
+            [questKeys.requiredSpell] = -415995,
+            [questKeys.zoneOrSort] = sortKeys.PRIEST,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5489
Linked To #5443 

## Proposed changes

- ADDED: 'Serendipity' Priest Rune Quest is now in the QuestDB, and should be accessible to users.