### PR TITLE
[quest] ADDED: 'Flanking Strike' Dun Morogh Hunter Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -267,6 +267,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90164] = true, -- Priest Twisted Faith Darkshore
     [90165] = true, -- Priest Twisted Faith The Barrens
     [90166] = true, -- Priest Twisted Faith Silverpine Forest
+    [90167] = true, -- Hunter Flanking Strike Dun Morogh
 }
 
 ---@param questId number
@@ -317,6 +318,7 @@ local questsToBlacklistBySoDPhase = {
         [90162] = true, -- Hiding Priest Twisted Faith Loch Modan for now as there are too many icons
         [90164] = true, -- Hiding Priest Twisted Faith Darkshore for now as there are too many icons
         [90165] = true, -- Hiding Priest Twisted Faith The Barrens for now as there are too many icons
+        [90167] = true, -- Hiding Hunter Flanking Strike Dun Morogh for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodNPCFixes.lua
+++ b/Database/Corrections/sodNPCFixes.lua
@@ -147,6 +147,11 @@ function SeasonOfDiscovery:LoadNPCs()
                 [zoneIDs.ELWYNN_FOREST] = {{25.4, 43.6}},
             },
         },
+        [208812] = { -- Jorul
+            [npcKeys.spawns] = {
+                [zoneIDs.DUN_MOROGH] = {{37.8, 42.4}},
+            },
+        },
         [208919] = { -- Blueheart
             [npcKeys.spawns] = {
                 [zoneIDs.TIRISFAL_GLADES] = {{61.6, 51.4}},

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2713,6 +2713,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -425215,
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
         },
+        [90167] = {
+            [questKeys.name] = "Flanking Strike",
+            [questKeys.startedBy] = {{208812,208638,1125,1126,1127,1689}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 7,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.HUNTER,
+            [questKeys.objectivesText] = {"Kill Boars for Dun Morogh Pig Meat, then use the meat east of the lake near Brewnall Village, to summon Jorul which you must kill and then loot the rune."},
+            [questKeys.requiredSpell] = -425762,
+            [questKeys.zoneOrSort] = sortKeys.HUNTER,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5507
Linked To #5443 

## Proposed changes

- ADDED: 'Flanking Strike' Dun Morogh Hunter Fake Rune Quest is now in the QuestDB, and is currently hidden due to too many icons because of the boars involved in this quest.