### PR TITLE
[quest] ADDED: 'Flanking Strike' Teldrassil Hunter Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -267,6 +267,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90164] = true, -- Priest Twisted Faith Darkshore
     [90165] = true, -- Priest Twisted Faith The Barrens
     [90166] = true, -- Priest Twisted Faith Silverpine Forest
+    [90168] = true, -- Hunter Flanking Strike Teldrassil
 }
 
 ---@param questId number
@@ -317,6 +318,7 @@ local questsToBlacklistBySoDPhase = {
         [90162] = true, -- Hiding Priest Twisted Faith Loch Modan for now as there are too many icons
         [90164] = true, -- Hiding Priest Twisted Faith Darkshore for now as there are too many icons
         [90165] = true, -- Hiding Priest Twisted Faith The Barrens for now as there are too many icons
+        [90168] = true, -- Hiding Hunter Flanking Strike Teldrassil for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodNPCFixes.lua
+++ b/Database/Corrections/sodNPCFixes.lua
@@ -183,6 +183,11 @@ function SeasonOfDiscovery:LoadNPCs()
                 [zoneIDs.TELDRASSIL] = {{56.6, 57.8}},
             },
         },
+        [209928] = { -- Mowgh
+            [npcKeys.spawns] = {
+                [zoneIDs.TELDRASSIL] = {{48.0, 31.6}},
+            },
+        },
         [210107] = { -- Kackle
             [npcKeys.spawns] = {
                 [zoneIDs.LOCH_MODAN] = {{55.0, 55.4}},

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2713,6 +2713,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -425215,
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
         },
+        [90168] = {
+            [questKeys.name] = "Flanking Strike",
+            [questKeys.startedBy] = {{209928,1997,1995,1996}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 8,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.HUNTER,
+            [questKeys.objectivesText] = {"Kill Strigid Birds for Teldrassil Bird Meat, then use the meat east of the river near The Oracle Glade, to summon Mowgh which you must kill and then loot the rune."},
+            [questKeys.requiredSpell] = -425762,
+            [questKeys.zoneOrSort] = sortKeys.HUNTER,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5509
Linked To #5443 

## Proposed changes

- ADDED: 'Flanking Strike' Teldrassil Hunter Fake Rune Quest is now in the QuestDB, and is currently hidden due to too many icons because of the owls involved in this quest.