### PR TITLE
[quest] ADDED: 'Flanking Strike' Mulgore Hunter Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -269,6 +269,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90166] = true, -- Priest Twisted Faith Silverpine Forest
     [90167] = true, -- Hunter Flanking Strike Dun Morogh
     [90168] = true, -- Hunter Flanking Strike Teldrassil
+    [90171] = true, -- Hunter Flanking Strike Mulgore
 }
 
 ---@param questId number
@@ -321,6 +322,7 @@ local questsToBlacklistBySoDPhase = {
         [90165] = true, -- Hiding Priest Twisted Faith The Barrens for now as there are too many icons
         [90167] = true, -- Hiding Hunter Flanking Strike Dun Morogh for now as there are too many icons
         [90168] = true, -- Hiding Hunter Flanking Strike Teldrassil for now as there are too many icons
+        [90171] = true, -- Hiding Hunter Flanking Strike Mulgore for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodNPCFixes.lua
+++ b/Database/Corrections/sodNPCFixes.lua
@@ -75,6 +75,11 @@ function SeasonOfDiscovery:LoadNPCs()
                 [zoneIDs.STORMWIND_CITY] = {{38.4, 27.4}},
             },
         },
+        [205382] = { -- Mokwa
+            [npcKeys.spawns] = {
+                [zoneIDs.MULGORE] = {{35.8, 57.2}},
+            },
+        },
         [206248] = { -- Wooden Effigy
             [npcKeys.spawns] = {
                 [zoneIDs.TELDRASSIL] = {{66.8, 58}},

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2737,6 +2737,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -425762,
             [questKeys.zoneOrSort] = sortKeys.HUNTER,
         },
+        [90171] = {
+            [questKeys.name] = "Flanking Strike",
+            [questKeys.startedBy] = {{205382,2956,2969,2971,2970,2957}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 8,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.HUNTER,
+            [questKeys.objectivesText] = {"Kill Swoops and Plainstriders for Mulgore Bird Meat, then use the meat east of Bloodhoof Village, to summon Mokwa which you must kill and then loot the rune."},
+            [questKeys.requiredSpell] = -425762,
+            [questKeys.zoneOrSort] = sortKeys.HUNTER,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5517
Linked To #5443 

## Proposed changes

- ADDED: 'Flanking Strike' Mulgore Hunter Fake Rune Quest is now in the QuestDB, and is currently hidden due to too many icons because of the plainstriders and swoops involved in this quest.