### PR TITLE
[quest] ADDED: 'Beast Mastery' Loch Modan Hunter Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -269,6 +269,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90166] = true, -- Priest Twisted Faith Silverpine Forest
     [90167] = true, -- Hunter Flanking Strike Dun Morogh
     [90168] = true, -- Hunter Flanking Strike Teldrassil
+    [90174] = true, -- Hunter Beast Mastery Loch Modan
 }
 
 ---@param questId number

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2737,6 +2737,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -425762,
             [questKeys.zoneOrSort] = sortKeys.HUNTER,
         },
+        [90174] = {
+            [questKeys.name] = "Beast Mastery",
+            [questKeys.startedBy] = {{1187},{407918}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 14,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.HUNTER,
+            [questKeys.objectivesText] = {"Loot the Empty Trophy Display next to Daryl the Youngling to receive the rune."},
+            [questKeys.requiredSpell] = -410110,
+            [questKeys.zoneOrSort] = sortKeys.HUNTER,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5524
Linked To #5443 

## Proposed changes

- ADDED: 'Beast Mastery' Loch Modan Hunter Fake Rune Quest is now in the QuestDB, and should now be accessible to users.