### PR TITLE
[quest] ADDED: 'Beast Mastery' Silverpine Forest Hunter Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -269,6 +269,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90166] = true, -- Priest Twisted Faith Silverpine Forest
     [90167] = true, -- Hunter Flanking Strike Dun Morogh
     [90168] = true, -- Hunter Flanking Strike Teldrassil
+    [90175] = true, -- Hunter Beast Mastery Silverpine Forest
 }
 
 ---@param questId number
@@ -321,6 +322,7 @@ local questsToBlacklistBySoDPhase = {
         [90165] = true, -- Hiding Priest Twisted Faith The Barrens for now as there are too many icons
         [90167] = true, -- Hiding Hunter Flanking Strike Dun Morogh for now as there are too many icons
         [90168] = true, -- Hiding Hunter Flanking Strike Teldrassil for now as there are too many icons
+        [90175] = true, -- Hiding Hunter Beast Mastery Silverpine Forest for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodNPCFixes.lua
+++ b/Database/Corrections/sodNPCFixes.lua
@@ -243,6 +243,11 @@ function SeasonOfDiscovery:LoadNPCs()
                 [zoneIDs.SILVERPINE_FOREST] = {},
             },
         },
+        [211736] = { -- Grizzled Protector
+            [npcKeys.spawns] = {
+                [zoneIDs.SILVERPINE_FOREST] = {},
+            },
+        },
         [211965] = { -- Carrodin
             [npcKeys.spawns] = {
                 [zoneIDs.WETLANDS] = {{46.6, 65.6}},

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2737,6 +2737,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -425762,
             [questKeys.zoneOrSort] = sortKeys.HUNTER,
         },
+        [90175] = {
+            [questKeys.name] = "Beast Mastery",
+            [questKeys.startedBy] = {{1778,211736}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 16,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.HUNTER,
+            [questKeys.objectivesText] = {"Kill Ferocious Grizzled Bears until a Grizzled Protector spawns. Kill it to receive the rune."},
+            [questKeys.requiredSpell] = -410110,
+            [questKeys.zoneOrSort] = sortKeys.HUNTER,
+        },
     }
 end
 

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -113,6 +113,7 @@ local questTagCorrections = {
     [90159] = {1, "Elite"},
     [90163] = {1, "Elite"},
     [90166] = {1, "Elite"},
+    [90175] = {1, "Elite"},
 }
 
 -- race bitmask data, for easy access


### PR DESCRIPTION
## Issue references

Fixes #5526
Linked To #5443 

## Proposed changes

- ADDED: 'Beast Mastery' Silverpine Forest Hunter Fake Rune Quest is now in the QuestDB, and is currently hidden due to the bears spawn points in the quest scattered across the entire zone.