### PR TITLE
[quest] ADDED: 'Shared Pain' Dun Morogh Priest Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -277,6 +277,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90174] = true, -- Hunter Beast Mastery Loch Modan
     [90175] = true, -- Hunter Beast Mastery Silverpine Forest
     [90176] = true, -- Hunter Beast Mastery The Barrens
+    [90177] = true, -- Priest Shared Pain Dun Morogh
 }
 
 ---@param questId number

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2829,6 +2829,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -410110,
             [questKeys.zoneOrSort] = sortKeys.HUNTER,
         },
+        [90177] = {
+            [questKeys.name] = "Shared Pain",
+            [questKeys.startedBy] = {{6124}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 11,
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.requiredClasses] = classIDs.PRIEST,
+            [questKeys.objectivesText] = {"Kill Captain Beld to receive the rune."},
+            [questKeys.requiredSpell] = -402854,
+            [questKeys.zoneOrSort] = sortKeys.PRIEST,
+        },
     }
 end
 

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2835,7 +2835,7 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 11,
-            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.requiredRaces] = raceIDs.NONE,
             [questKeys.requiredClasses] = classIDs.PRIEST,
             [questKeys.objectivesText] = {"Kill Captain Beld to receive the rune."},
             [questKeys.requiredSpell] = -402854,


### PR DESCRIPTION
## Issue references

Fixes #5532
Linked To #5443 

## Proposed changes

- ADDED: 'Shared Pain' Dun Morogh Priest Fake Rune Quest is now in the QuestDB, and should be accessible to users.