### PR TITLE
[quest] ADDED: 'Shared Pain' Elwynn Forest Priest Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -277,6 +277,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90174] = true, -- Hunter Beast Mastery Loch Modan
     [90175] = true, -- Hunter Beast Mastery Silverpine Forest
     [90176] = true, -- Hunter Beast Mastery The Barrens
+    [90178] = true, -- Priest Shared Pain Elwynn Forest
 }
 
 ---@param questId number
@@ -317,6 +318,7 @@ local questsToBlacklistBySoDPhase = {
         [90169] = true, -- Hiding Priest Power Word: Barrier Redridge Mountains for now as there are too many icons
         [90173] = true, -- Hiding Hunter Beast Mastery Darkshore for now as there are too many icons
         [90175] = true, -- Hiding Hunter Beast Mastery Silverpine Forest for now as there are too many icons
+        [90178] = true, -- Hiding Priest Shared Pain Elwynn Forest for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2829,6 +2829,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -410110,
             [questKeys.zoneOrSort] = sortKeys.HUNTER,
         },
+        [90178] = {
+            [questKeys.name] = "Shared Pain",
+            [questKeys.startedBy] = {{40}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 6,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.PRIEST,
+            [questKeys.objectivesText] = {"Kill Kobold Miners to receive the rune."},
+            [questKeys.requiredSpell] = -402854,
+            [questKeys.zoneOrSort] = sortKeys.PRIEST,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5534
Linked To #5443 

## Proposed changes

- ADDED: 'Shared Pain' Elwynn Forest Priest Fake Rune Quest is now in the QuestDB, and is currently hidden due to too many icons associated from the kobolds required.