### PR TITLE
[quest] ADDED: 'Shared Pain' Teldrassil Priest Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -279,6 +279,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90176] = true, -- Hunter Beast Mastery The Barrens
     [90177] = true, -- Priest Shared Pain Dun Morogh
     [90178] = true, -- Priest Shared Pain Elwynn Forest
+    [90179] = true, -- Priest Shared Pain Teldrassil
 }
 
 ---@param questId number

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2822,6 +2822,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -402854,
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
         },
+        [90179] = {
+            [questKeys.name] = "Shared Pain",
+            [questKeys.startedBy] = {{2038}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 8,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.PRIEST,
+            [questKeys.objectivesText] = {"Kill Lord Melenas to receive the rune."},
+            [questKeys.requiredSpell] = -402854,
+            [questKeys.zoneOrSort] = sortKeys.PRIEST,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5537
Linked To #5443 

## Proposed changes

- ADDED: 'Shared Pain' Teldrassil Priest Fake Rune Quest is now in the QuestDB, and should now be accessible to users.