### PR TITLE
[quest] ADDED: 'Shared Pain' Durotar Priest Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -279,6 +279,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90176] = true, -- Hunter Beast Mastery The Barrens
     [90177] = true, -- Priest Shared Pain Dun Morogh
     [90178] = true, -- Priest Shared Pain Elwynn Forest
+    [90180] = true, -- Priest Shared Pain Durotar
 }
 
 ---@param questId number

--- a/Database/Corrections/sodNPCFixes.lua
+++ b/Database/Corrections/sodNPCFixes.lua
@@ -12,12 +12,6 @@ function SeasonOfDiscovery:LoadNPCs()
     local waypointPresets = QuestieDB.waypointPresets
 
     return {
-        [13157] = { -- Makasgar
-            [npcKeys.name] = "Makasgar",
-            [npcKeys.spawns] = {
-                [zoneIDs.DUROTAR] = {{62.0, 66.2}},
-            },
-        },
         [202060] = { -- Frozen Murloc
             [npcKeys.spawns] = {
                 [zoneIDs.ELWYNN_FOREST] = {{76.8, 51.4}},

--- a/Database/Corrections/sodNPCFixes.lua
+++ b/Database/Corrections/sodNPCFixes.lua
@@ -12,6 +12,12 @@ function SeasonOfDiscovery:LoadNPCs()
     local waypointPresets = QuestieDB.waypointPresets
 
     return {
+        [13157] = { -- Makasgar
+            [npcKeys.name] = "Makasgar",
+            [npcKeys.spawns] = {
+                [zoneIDs.DUROTAR] = {{62.0, 66.2}},
+            },
+        },
         [202060] = { -- Frozen Murloc
             [npcKeys.spawns] = {
                 [zoneIDs.ELWYNN_FOREST] = {{76.8, 51.4}},

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2822,6 +2822,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -402854,
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
         },
+        [90180] = {
+            [questKeys.name] = "Shared Pain",
+            [questKeys.startedBy] = {{13157,3204}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 13,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.PRIEST,
+            [questKeys.objectivesText] = {"Kill Makasgar or Gazzuz to receive the rune."},
+            [questKeys.requiredSpell] = -402854,
+            [questKeys.zoneOrSort] = sortKeys.PRIEST,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5539 
Linked To #5443 

## Proposed changes

- ADDED: 'Shared Pain' Durotar Priest Fake Rune Quest is now in the QuestDB, and should now be accessible to users.