### PR TITLE
[quest] ADDED: 'Shared Pain' Tirisfal Glades Priest Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -279,6 +279,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90176] = true, -- Hunter Beast Mastery The Barrens
     [90177] = true, -- Priest Shared Pain Dun Morogh
     [90178] = true, -- Priest Shared Pain Elwynn Forest
+    [90181] = true, -- Priest Shared Pain Tirisfal Glades
 }
 
 ---@param questId number
@@ -320,6 +321,7 @@ local questsToBlacklistBySoDPhase = {
         [90173] = true, -- Hiding Hunter Beast Mastery Darkshore for now as there are too many icons
         [90175] = true, -- Hiding Hunter Beast Mastery Silverpine Forest for now as there are too many icons
         [90178] = true, -- Hiding Priest Shared Pain Elwynn Forest for now as there are too many icons
+        [90181] = true, -- Hiding Priest Shared Pain Tirisfal Glades for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2822,6 +2822,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -402854,
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
         },
+        [90181] = {
+            [questKeys.name] = "Shared Pain",
+            [questKeys.startedBy] = {{1934}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 6,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.PRIEST,
+            [questKeys.objectivesText] = {"Kill Tirisfal Farmers to receive the rune."},
+            [questKeys.requiredSpell] = -402854,
+            [questKeys.zoneOrSort] = sortKeys.PRIEST,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5541 
Linked To #5443 

## Proposed changes

- ADDED: 'Shared Pain' Tirisfal Glades Priest Fake Rune Quest is now in the QuestDB, and should now be accessible to users.