### PR TITLE
[quest] ADDED: 'Main Gauche' Rogue Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -280,6 +280,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90177] = true, -- Priest Shared Pain Dun Morogh
     [90178] = true, -- Priest Shared Pain Elwynn Forest
     [90179] = true, -- Priest Shared Pain Teldrassil
+    [90184] = true, -- Rogue Main Gauche
 }
 
 ---@param questId number

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2834,6 +2834,19 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -402854,
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
         },
+        [90184] = {
+            [questKeys.name] = "Main Gauche",
+            [questKeys.startedBy] = {{211653}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 20,
+            [questKeys.questLevel] = 25,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.ROGUE,
+            [questKeys.objectivesText] = {"Buy the Main Gauche rune from Grizzby."},
+            [questKeys.preQuestGroup] = {78265,78266,78267},
+            [questKeys.requiredSpell] = -424990,
+            [questKeys.zoneOrSort] = sortKeys.ROGUE,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5555
Linked To #5443 

## Proposed changes

- ADDED: 'Main Gauche' Rogue Fake Rune Quest is now in the QuestDB, and should be accessible to users.