### PR TITLE
[quest] ADDED: 'Homunculi' Durotar Priest Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -290,6 +290,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90182] = true, -- Priest Homunculi Dun Morogh
     [90183] = true, -- Priest Homunculi Elwynn Forest
     [90184] = true, -- Priest Homunculi Teldrassil
+    [90185] = true, -- Priest Homunculi Durotar
 }
 
 ---@param questId number
@@ -335,6 +336,7 @@ local questsToBlacklistBySoDPhase = {
         [90182] = true, -- Hiding Priest Homunculi Dun Morogh for now as there are too many icons
         [90183] = true, -- Hiding Priest Homunculi Elwynn Forest for now as there are too many icons
         [90184] = true, -- Hiding Priest Homunculi Teldrassil for now as there are too many icons
+        [90185] = true, -- Hiding Priest Homunculi Durotar for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2925,6 +2925,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -402852,
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
         },
+        [90185] = {
+            [questKeys.name] = "Homunculi",
+            [questKeys.startedBy] = {{3206}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 8,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.PRIEST,
+            [questKeys.objectivesText] = {"Kill Voodoo Trolls to receive the rune."},
+            [questKeys.requiredSpell] = -402852,
+            [questKeys.zoneOrSort] = sortKeys.PRIEST,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5557
Linked To #5443 

## Proposed changes

- ADDED: 'Homunculi' Durotar Priest Fake Rune Quest is now in the QuestDB, and is currently hidden due to too many icons from the Voodoo Trolls.