### PR TITLE
[quest] ADDED: Fake Object IDs For Buried Treasure

### DIFF
--- a/Database/Corrections/sodObjectFixes.lua
+++ b/Database/Corrections/sodObjectFixes.lua
@@ -10,13 +10,9 @@ function SeasonOfDiscovery:LoadObjects()
     local zoneIDs = ZoneDB.zoneIDs
 
     return {
-        [386675] = {
+        [386675] = { -- Dun Morogh Buried Treasure
             [objectKeys.spawns] = {
                 [1] = {{46.96,43.73}},
-                [12] = {{80.3, 79.1}},
-                [14] = {{62.1, 94.8}},
-                [85] = {{52.9, 54}},
-                [141] = {{55.3, 90.8}},
             },
         },
         [386691] = {
@@ -231,6 +227,28 @@ function SeasonOfDiscovery:LoadObjects()
             [objectKeys.zoneID] = zoneIDs.LOCH_MODAN,
             [objectKeys.spawns] = {
                 [zoneIDs.ASHENVALE] = {{36.4,19.6}},
+            },
+        },
+
+        -- Fake Rune Objects
+        [900000] = {
+            [objectKeys.spawns] = { -- Elwynn Forest Buried Treasure
+                [12] = {{80.3, 79.1}},
+            },
+        },
+        [900001] = {
+            [objectKeys.spawns] = { -- Durotar Buried Treasure
+                [14] = {{62.1, 94.8}},
+            },
+        },
+        [900002] = {
+            [objectKeys.spawns] = { -- Tirisfal Glades Buried Treasure
+                [85] = {{52.9, 54}},
+            },
+        },
+        [900003] = {
+            [objectKeys.spawns] = { -- Teldrassil Buried Treasure
+                [141] = {{55.3, 90.8}},
             },
         },
     }

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2331,7 +2331,7 @@ function SeasonOfDiscovery:LoadQuests()
         },
         [90134] = {
             [questKeys.name] = "Quick Draw",
-            [questKeys.startedBy] = {nil,{386675}},
+            [questKeys.startedBy] = {nil,{900000}},
             [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 5,
@@ -2343,7 +2343,7 @@ function SeasonOfDiscovery:LoadQuests()
         },
         [90135] = {
             [questKeys.name] = "Quick Draw",
-            [questKeys.startedBy] = {nil,{386675}},
+            [questKeys.startedBy] = {nil,{900003}},
             [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 5,
@@ -2355,7 +2355,7 @@ function SeasonOfDiscovery:LoadQuests()
         },
         [90136] = {
             [questKeys.name] = "Quick Draw",
-            [questKeys.startedBy] = {nil,{386675}},
+            [questKeys.startedBy] = {nil,{900001}},
             [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 5,
@@ -2367,7 +2367,7 @@ function SeasonOfDiscovery:LoadQuests()
         },
         [90137] = {
             [questKeys.name] = "Quick Draw",
-            [questKeys.startedBy] = {nil,{386675}},
+            [questKeys.startedBy] = {nil,{900002}},
             [questKeys.finishedBy] = nil,
             [questKeys.requiredLevel] = 1,
             [questKeys.questLevel] = 5,


### PR DESCRIPTION
## Issue references

Fixes #5567 

## Proposed changes

- ADDED: Fake object IDs for each buried treasure to match the objectivesText in each quest.