### PR TITLE
[quest] ADDED: 'Between the Eyes' Orgrimmar Rogue Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -290,6 +290,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90182] = true, -- Priest Homunculi Dun Morogh
     [90183] = true, -- Priest Homunculi Elwynn Forest
     [90184] = true, -- Priest Homunculi Teldrassil
+    [90195] = true, -- Rogue Between the Eyes Orgrimmar
 }
 
 ---@param questId number

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -2928,6 +2928,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -402852,
             [questKeys.zoneOrSort] = sortKeys.PRIEST,
         },
+        [90195] = {
+            [questKeys.name] = "Between the Eyes",
+            [questKeys.startedBy] = {nil,{404830}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 10,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.ROGUE,
+            [questKeys.objectivesText] = {"Loot the Dusty Chest and receive the rune."},
+            [questKeys.requiredSpell] = -400081,
+            [questKeys.zoneOrSort] = sortKeys.ROGUE,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5580

## Proposed changes

- ADDED: 'Between the Eyes' Orgrimmar Rogue Fake Rune Quest is now in the QuestDB, and is accessible to users.