### PR TITLE
Fix required reputation for quest "The Dread Citadel" to be neutral instead of honored

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -3713,6 +3713,9 @@ function QuestieQuestFixes:Load()
         [9120] = {
             [questKeys.startedBy] = {{15990},nil,{22520}},
         },
+        [9121] = {
+            [questKeys.requiredMinRep] = {529,0},
+        },
         [9124] = {
             [questKeys.requiredMinRep] = {529,3000},
         },


### PR DESCRIPTION
## Proposed changes

The required reputation for Argent Dawn is neutral and not honored for this quest. The quest objective is still being honored, but the quest can be accepted already with neutral. Maybe even unfriendly, but I cannot find that out.
Screenshots attached that show the quest with my char being neutral.

## Screenshots

<img width="1675" alt="Screenshot 2024-01-23 at 00 47 56" src="https://github.com/Questie/Questie/assets/231804/41681f9c-6d19-4631-8a2c-021b7229656f">

<img width="1734" alt="Screenshot 2024-01-23 at 00 48 03" src="https://github.com/Questie/Questie/assets/231804/27527821-ebe0-40ed-9731-844e1165653c">
