### PR TITLE
[quest] ADDED: 'Lava Burst' Shaman Fake Rune Quest To QuestDB

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -310,6 +310,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [90202] = true, -- Shaman Shamanistic Rage Stonetalon Mountains
     [90203] = true, -- Shaman Way of Earth The Barrens
     [90204] = true, -- Shaman Way of Earth Silverpine Forest
+    [90205] = true, -- Shaman Lava Burst Hillsbrad Foothills
 }
 
 ---@param questId number
@@ -361,6 +362,7 @@ local questsToBlacklistBySoDPhase = {
         [90200] = true, -- Hiding Rogue Mutilate Dun Morogh for now as there are too many icons
         [90201] = true, -- Hiding Rogue Shiv Duskwood for now as there are too many icons
         [90204] = true, -- Hiding Shaman Way of Earth Silverpine Forest for now as there are too many icons
+        [90205] = true, -- Hiding Shaman Lava Burst Hillsbrad Foothills for now as there are too many icons
     },
     [2] = { -- SoD Phase 2 - level cap 40
         [1152] = true, -- Test of Lore; minLevel raised to 26 in P1 for some reason, might be retooled as part of P2?

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -3168,6 +3168,18 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.requiredSpell] = -410107,
             [questKeys.zoneOrSort] = sortKeys.SHAMAN,
         },
+        [90205] = {
+            [questKeys.name] = "Lava Burst",
+            [questKeys.startedBy] = {{2373}},
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 1,
+            [questKeys.questLevel] = 25,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.SHAMAN,
+            [questKeys.objectivesText] = {"Kill Mudsnout Shamans until Kajaric Icon drops, equip it and follow its instructions to receieve the rune."},
+            [questKeys.requiredSpell] = -410095,
+            [questKeys.zoneOrSort] = sortKeys.SHAMAN,
+        },
     }
 end
 


### PR DESCRIPTION
## Issue references

Fixes #5601
Linked To #5443

## Proposed changes

- ADDED: 'Lava Burst' Shaman Fake Rune Quest is now in the QuestDB, and is currently hidden due to Mudsnout Shaman spawns.