### PR TITLE
[feature] Add option to enable coordinates on Mini World Map

### DIFF
--- a/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
+++ b/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
@@ -298,7 +298,7 @@ function QuestieOptions.tabs.general:Initialize()
                             QuestieOptions:SetProfileValue(info, value)
 
                             if not value then
-                                QuestieCoords.ResetMapText();
+                                QuestieCoords.ResetMiniWorldMapText();
                             end
                         end,
                     },

--- a/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
+++ b/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
@@ -287,6 +287,22 @@ function QuestieOptions.tabs.general:Initialize()
                             end
                         end,
                     },
+                    miniWorldMapCoordinatesEnabled = {
+                        type = "toggle",
+                        order = 5.55,
+                        disabled = function() return not Questie.db.profile.mapCoordinatesEnabled end,
+                        name = function() return l10n('Mini World Map Coord.') end,
+                        desc = function() return l10n("Place the Player's coordinates and Cursor's coordinates on the Mini World Map's title."); end,
+                        get = function(info) return QuestieOptions:GetProfileValue(info); end,
+                        set = function (info, value)
+                            QuestieOptions:SetProfileValue(info, value)
+
+                            if not value then
+                                QuestieCoords.ResetMapText();
+                            end
+                        end,
+                    },			
+					Spacer_Range = QuestieOptionsUtils:Spacer(5.56),
                     mapCoordinatePrecision = {
                         type = "range",
                         order = 5.6,

--- a/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
+++ b/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
@@ -301,8 +301,8 @@ function QuestieOptions.tabs.general:Initialize()
                                 QuestieCoords.ResetMapText();
                             end
                         end,
-                    },			
-					Spacer_Range = QuestieOptionsUtils:Spacer(5.56),
+                    },
+                    Spacer_Range = QuestieOptionsUtils:Spacer(5.56),
                     mapCoordinatePrecision = {
                         type = "range",
                         order = 5.6,

--- a/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
+++ b/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
@@ -297,7 +297,7 @@ function QuestieOptions.tabs.general:Initialize()
                         set = function (info, value)
                             QuestieOptions:SetProfileValue(info, value)
 
-                            if not value then
+                            if (not value) then
                                 QuestieCoords.ResetMiniWorldMapText();
                             end
                         end,

--- a/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
+++ b/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
@@ -269,6 +269,7 @@ function QuestieOptions.tabs.general:Initialize()
 
                             if not value then
                                 QuestieCoords.ResetMapText();
+                                QuestieCoords:ResetMiniWorldMapText();
                             end
                         end,
                     },
@@ -287,22 +288,6 @@ function QuestieOptions.tabs.general:Initialize()
                             end
                         end,
                     },
-                    miniWorldMapCoordinatesEnabled = {
-                        type = "toggle",
-                        order = 5.55,
-                        disabled = function() return not Questie.db.profile.mapCoordinatesEnabled end,
-                        name = function() return l10n('Mini World Map Coord.') end,
-                        desc = function() return l10n("Place the Player's coordinates and Cursor's coordinates on the Mini World Map's title."); end,
-                        get = function(info) return QuestieOptions:GetProfileValue(info); end,
-                        set = function (info, value)
-                            QuestieOptions:SetProfileValue(info, value)
-
-                            if (not value) then
-                                QuestieCoords.ResetMiniWorldMapText();
-                            end
-                        end,
-                    },
-                    Spacer_Range = QuestieOptionsUtils:Spacer(5.56),
                     mapCoordinatePrecision = {
                         type = "range",
                         order = 5.6,

--- a/Modules/Options/QuestieOptionsDefaults.lua
+++ b/Modules/Options/QuestieOptionsDefaults.lua
@@ -26,7 +26,7 @@ function QuestieOptionsDefaults:Load()
             nameplateEnabled = true,
             minimapCoordinatesEnabled = false,
             mapCoordinatesEnabled = true,
-			miniWorldMapCoordinatesEnabled = false,
+            miniWorldMapCoordinatesEnabled = false,
             mapCoordinatePrecision = 1,
             dbmHUDEnable = false,
             dbmHUDShowAlert = true,

--- a/Modules/Options/QuestieOptionsDefaults.lua
+++ b/Modules/Options/QuestieOptionsDefaults.lua
@@ -26,7 +26,6 @@ function QuestieOptionsDefaults:Load()
             nameplateEnabled = true,
             minimapCoordinatesEnabled = false,
             mapCoordinatesEnabled = true,
-            miniWorldMapCoordinatesEnabled = false,
             mapCoordinatePrecision = 1,
             dbmHUDEnable = false,
             dbmHUDShowAlert = true,

--- a/Modules/Options/QuestieOptionsDefaults.lua
+++ b/Modules/Options/QuestieOptionsDefaults.lua
@@ -26,6 +26,7 @@ function QuestieOptionsDefaults:Load()
             nameplateEnabled = true,
             minimapCoordinatesEnabled = false,
             mapCoordinatesEnabled = true,
+			miniWorldMapCoordinatesEnabled = false,
             mapCoordinatePrecision = 1,
             dbmHUDEnable = false,
             dbmHUDShowAlert = true,

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -136,7 +136,7 @@ end
 
 function QuestieCoords.ResetMiniWorldMapText()
     local currentMapId = WorldMapFrame:GetMapID();
-    if(currentMapId) then
+    if currentMapId then
         local info = C_Map.GetMapInfo(currentMapId);
         if(info) then
             GetMiniWorldMapTitleText():SetText(info.name);

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -30,7 +30,7 @@ end
 local function GetMiniWorldMapTitleText()
     local regions = {WorldMapFrame.MiniBorderFrame:GetRegions()}
     for i = 1, #regions do
-        if (regions[i].SetText) then
+        if regions[i].SetText then
             return regions[i]
         end
     end

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -138,7 +138,7 @@ function QuestieCoords.ResetMiniWorldMapText()
     local currentMapId = WorldMapFrame:GetMapID();
     if currentMapId then
         local info = C_Map.GetMapInfo(currentMapId);
-        if(info) then
+        if info then
             GetMiniWorldMapTitleText():SetText(info.name);
         end
     end

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -91,7 +91,7 @@ function QuestieCoords:WriteCoords()
         mapTitleText:SetText(worldmapCoordsText)
         if(Questie.db.profile.miniWorldMapCoordinatesEnabled) then
             local miniWorldMapTitleText = GetMiniWorldMapTitleText()
-            if(miniWorldMapTitleText) then
+            if miniWorldMapTitleText then
                 miniWorldMapTitleText:SetText(worldmapCoordsText)
             end
         end

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -89,11 +89,11 @@ function QuestieCoords:WriteCoords()
         worldmapCoordsText = worldmapCoordsText.."|  Player: "..format(precision.. " X , ".. precision .." Y", posX, posY);
         -- Add text to world map
         mapTitleText:SetText(worldmapCoordsText)
-        if Questie.db.profile.miniWorldMapCoordinatesEnabled then
-            local miniWorldMapTitleText = GetMiniWorldMapTitleText()
-            if miniWorldMapTitleText then
-                miniWorldMapTitleText:SetText(worldmapCoordsText)
-            end
+
+        -- Adding text to mini world map
+        local miniWorldMapTitleText = GetMiniWorldMapTitleText()
+        if miniWorldMapTitleText then
+            miniWorldMapTitleText:SetText(worldmapCoordsText)
         end
     end
 end
@@ -134,7 +134,7 @@ function QuestieCoords:ResetMapText()
     GetMapTitleText():SetText(WORLD_MAP);
 end
 
-function QuestieCoords.ResetMiniWorldMapText()
+function QuestieCoords:ResetMiniWorldMapText()
     local currentMapId = WorldMapFrame:GetMapID();
     if currentMapId then
         local info = C_Map.GetMapInfo(currentMapId);

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -28,12 +28,12 @@ local function GetMapTitleText()
 end
 
 local function GetMiniWorldMapTitleText()
-	local regions = {WorldMapFrame.MiniBorderFrame:GetRegions()}
-	for i = 1, #regions do
-		if (regions[i].SetText) then
-			return regions[i]
-		end
-	end
+    local regions = {WorldMapFrame.MiniBorderFrame:GetRegions()}
+    for i = 1, #regions do
+        if (regions[i].SetText) then
+            return regions[i]
+        end
+    end
 end
 
 function QuestieCoords:WriteCoords()
@@ -89,12 +89,12 @@ function QuestieCoords:WriteCoords()
         worldmapCoordsText = worldmapCoordsText.."|  Player: "..format(precision.. " X , ".. precision .." Y", posX, posY);
         -- Add text to world map
         mapTitleText:SetText(worldmapCoordsText)
-		if(Questie.db.profile.miniWorldMapCoordinatesEnabled) then
-			local miniWorldMapTitleText = GetMiniWorldMapTitleText()
-			if(miniWorldMapTitleText) then
-				miniWorldMapTitleText:SetText(worldmapCoordsText)
-			end
-		end
+        if(Questie.db.profile.miniWorldMapCoordinatesEnabled) then
+            local miniWorldMapTitleText = GetMiniWorldMapTitleText()
+            if(miniWorldMapTitleText) then
+                miniWorldMapTitleText:SetText(worldmapCoordsText)
+            end
+        end
     end
 end
 
@@ -132,5 +132,5 @@ end
 
 function QuestieCoords:ResetMapText()
     GetMapTitleText():SetText(WORLD_MAP);
-	GetMiniWorldMapTitleText():SetText(WORLD_MAP);
+    GetMiniWorldMapTitleText():SetText(WORLD_MAP);
 end

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -89,7 +89,7 @@ function QuestieCoords:WriteCoords()
         worldmapCoordsText = worldmapCoordsText.."|  Player: "..format(precision.. " X , ".. precision .." Y", posX, posY);
         -- Add text to world map
         mapTitleText:SetText(worldmapCoordsText)
-        if(Questie.db.profile.miniWorldMapCoordinatesEnabled) then
+        if Questie.db.profile.miniWorldMapCoordinatesEnabled then
             local miniWorldMapTitleText = GetMiniWorldMapTitleText()
             if miniWorldMapTitleText then
                 miniWorldMapTitleText:SetText(worldmapCoordsText)

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -132,5 +132,14 @@ end
 
 function QuestieCoords:ResetMapText()
     GetMapTitleText():SetText(WORLD_MAP);
-	GetMiniWorldMapTitleText():SetText(GetZoneText());
+end
+
+function QuestieCoords:ResetMiniWorldMapText()
+    local currentMapId = WorldMapFrame:GetMapID();
+    if(currentMapId) then
+        local info = C_Map.GetMapInfo(currentMapId);
+        if(info) then
+            GetMiniWorldMapTitleText():SetText(info.name);
+        end
+    end
 end

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -132,5 +132,5 @@ end
 
 function QuestieCoords:ResetMapText()
     GetMapTitleText():SetText(WORLD_MAP);
-    GetMiniWorldMapTitleText():SetText(WORLD_MAP);
+	GetMiniWorldMapTitleText():SetText(GetZoneText());
 end

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -27,6 +27,15 @@ local function GetMapTitleText()
     end
 end
 
+local function GetMiniWorldMapTitleText()
+	local regions = {WorldMapFrame.MiniBorderFrame:GetRegions()}
+	for i = 1, #regions do
+		if (regions[i].SetText) then
+			return regions[i]
+		end
+	end
+end
+
 function QuestieCoords:WriteCoords()
     if not ((Questie.db.profile.mapCoordinatesEnabled and WorldMapFrame:IsVisible()) or (Questie.db.profile.minimapCoordinatesEnabled and Minimap:IsVisible())) then
         return -- no need to write coords
@@ -80,6 +89,12 @@ function QuestieCoords:WriteCoords()
         worldmapCoordsText = worldmapCoordsText.."|  Player: "..format(precision.. " X , ".. precision .." Y", posX, posY);
         -- Add text to world map
         mapTitleText:SetText(worldmapCoordsText)
+		if(Questie.db.profile.miniWorldMapCoordinatesEnabled) then
+			local miniWorldMapTitleText = GetMiniWorldMapTitleText()
+			if(miniWorldMapTitleText) then
+				miniWorldMapTitleText:SetText(worldmapCoordsText)
+			end
+		end
     end
 end
 
@@ -117,4 +132,5 @@ end
 
 function QuestieCoords:ResetMapText()
     GetMapTitleText():SetText(WORLD_MAP);
+	GetMiniWorldMapTitleText():SetText(WORLD_MAP);
 end

--- a/Modules/QuestieCoordinates.lua
+++ b/Modules/QuestieCoordinates.lua
@@ -134,7 +134,7 @@ function QuestieCoords:ResetMapText()
     GetMapTitleText():SetText(WORLD_MAP);
 end
 
-function QuestieCoords:ResetMiniWorldMapText()
+function QuestieCoords.ResetMiniWorldMapText()
     local currentMapId = WorldMapFrame:GetMapID();
     if(currentMapId) then
         local info = C_Map.GetMapInfo(currentMapId);


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Proposed changes

- Add an option to enable map coordinates on Mini World Map's title, similar to how it works currently on full sized World Map. 

## Known issues

- There is a small issue of "Show Mini World Map Coordinates" not fitting existing option structure, so I had to trim it manually to "Mini World Map Coord.".
- Map's original title shows up for a moment when changing zones and when you open a map after closing it with any other zone being selected that is not your current one. This is most likely because Blizzard UI changing title to match currently selected zone before WriteCoords has a chance to be run due to it having relatively low update interval. I don't think this is a major issue, but I understand if pull request will be rejected because of it.

## Screenshots
![image](https://github.com/Questie/Questie/assets/53978306/20904f42-8e72-431b-aecc-b88448d1c1f2)
![image](https://github.com/Questie/Questie/assets/53978306/a06bbbe7-3e88-4454-8a53-95c201a205da)
![image](https://github.com/Questie/Questie/assets/53978306/2c236566-d477-4e92-8e0b-de9f14d86e0c)

