### PR TITLE
Remove invalid prequest requirement for "At War with the Scarlet Crusade"

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -206,6 +206,9 @@ function QuestieQuestFixes:Load()
         [420] = {
             [questKeys.exclusiveTo] = {287}, -- senir's observations part 2 becomes unavailable if you have completed frostmane hold
         },
+        [427] = {
+            [questKeys.preQuestSingle] = {},
+        },
         [428] = {
             [questKeys.exclusiveTo] = {429}, -- lost deathstalkers breadcrumb
         },


### PR DESCRIPTION
## Proposed changes

- Remove quest 383 as prerequisite for quest 427. See screenshot I cannot even do quest 383, because I haven't started its pre-quests, but 427 is available.
-

## Screenshots
![Screenshot 2024-02-09 at 00 31 02](https://github.com/Questie/Questie/assets/231804/4b33a471-b775-457a-aa0b-6eb0ce8a63bf)
