### PR TITLE
[quest] Blacklisted First Aid Trauma Quests & Bumped Phase Number

### DIFF
--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -8,7 +8,7 @@ local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
 ---@type QuestieQuestBlacklist
 local QuestieQuestBlacklist = QuestieLoader:ImportModule("QuestieQuestBlacklist")
 
-SeasonOfDiscovery.currentPhase = 1 -- TODO: Use API function which hopefully will come in the future
+SeasonOfDiscovery.currentPhase = 2 -- TODO: Use API function which hopefully will come in the future
 
 
 
@@ -348,7 +348,9 @@ local questsToBlacklistBySoDPhase = {
         [8171] = true, -- The Battle for Arathi Basin!
         [8168] = true, -- The Battle for Arathi Basin!
     },
-    [3] = { -- SoD Phase 3 - level cap 50
+    [3] = { -- SoD Phase 3 - level cap 50#
+        [6623] = true, -- Horde Trauma
+        [6625] = true, -- Alliance Trauma
     },
     [4] = { -- SoD Phase 4 - level cap 60
         -- These might not be re-added at level 60

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -348,7 +348,7 @@ local questsToBlacklistBySoDPhase = {
         [8171] = true, -- The Battle for Arathi Basin!
         [8168] = true, -- The Battle for Arathi Basin!
     },
-    [3] = { -- SoD Phase 3 - level cap 50#
+    [3] = { -- SoD Phase 3 - level cap 50
         [6623] = true, -- Horde Trauma
         [6625] = true, -- Alliance Trauma
     },

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -8,7 +8,7 @@ local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
 ---@type QuestieQuestBlacklist
 local QuestieQuestBlacklist = QuestieLoader:ImportModule("QuestieQuestBlacklist")
 
-SeasonOfDiscovery.currentPhase = 2 -- TODO: Use API function which hopefully will come in the future
+SeasonOfDiscovery.currentPhase = 1 -- TODO: Use API function which hopefully will come in the future
 
 
 


### PR DESCRIPTION
## Issue references

Fixes #5666

## Proposed changes

- ADDED: 'Alliance Trauma' & 'Horde Trauma' First Aid 300 Quests To Blacklist For P2.
- MODIFIED: Bumped Current Phase Of SoD To 2.