### PR TITLE
[quest] Add Warrior's 'Blood Surge' rune

### DIFF
--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -1710,6 +1710,17 @@ function SeasonOfDiscovery:LoadBaseQuests()
             [questKeys.objectivesText] = {"Insert a Grime-Encrusted Salvage into the Salvagematic 9000, and be sure to have thirty silver coins to start the machine."},
             [questKeys.objectives] = {nil,nil,{{213427}}},
         },
+        [79677] = {
+            [questKeys.name] = "A Quick Grocery Run",
+            [questKeys.startedBy] = {{217300}},
+            [questKeys.finishedBy] = {{217300,}},
+            [questKeys.requiredLevel] = 26,
+            [questKeys.questLevel] = 40,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.WARRIOR,
+            [questKeys.objectivesText] = {"Gather the ingredients for Skonk's dish, then bring them to him in Arathi Highlands."},
+            [questKeys.objectives] = {nil,nil,{{213526},{213527},{213528},{213529}}},
+        },
         [79705] = {
             [questKeys.name] = "Salvaging the Salvagematic",
             [questKeys.startedBy] = {{217689}},

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -111,6 +111,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [79242] = 2, -- No Honor Among Thieves
     [79535] = 2, -- Mage Icy Veins/Spell Power
     [79536] = 2, -- Mage Icy Veins/Spell Power
+    [79677] = 2, -- A Quick Grocery Run
     [79947] = 2, -- Mage Icy Veins/Spell Power
     [79948] = 2, -- Mage Icy Veins/Spell Power
     [79949] = 2, -- Mage Icy Veins/Spell Power

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -807,8 +807,8 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.questFlags] = questFlags.RAID,
         },
         [79677] = { -- A Quick Grocery Run
-            [questKeys.startedBy] = {nil,nil,{213422}},
-            [questKeys.zoneOrSort] = zoneIDs.ARATHI_HIGHLANDS,
+            [questKeys.startedBy] = {{2255,2569}},
+            [questKeys.zoneOrSort] = zoneIDs.WARRIOR,
         },
         [79705] = { -- Salvaging the Salvagematic
             [questKeys.finishedBy] = {{217689}},

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -806,6 +806,10 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.zoneOrSort] = zoneIDs.GNOMEREGAN,
             [questKeys.questFlags] = questFlags.RAID,
         },
+        [79677] = { -- A Quick Grocery Run
+            [questKeys.startedBy] = {nil,nil,{213422}},
+            [questKeys.zoneOrSort] = zoneIDs.ARATHI_HIGHLANDS,
+        },
         [79705] = { -- Salvaging the Salvagematic
             [questKeys.finishedBy] = {{217689}},
             [questKeys.zoneOrSort] = zoneIDs.GNOMEREGAN,

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -807,7 +807,7 @@ function SeasonOfDiscovery:LoadQuests()
             [questKeys.questFlags] = questFlags.RAID,
         },
         [79677] = { -- A Quick Grocery Run
-            [questKeys.startedBy] = {{2255,2569}},
+            [questKeys.startedBy] = {{2254,2255,2256,2287,2569,2570,2571}},
             [questKeys.zoneOrSort] = zoneIDs.WARRIOR,
         },
         [79705] = { -- Salvaging the Salvagematic


### PR DESCRIPTION
## Issue references

Fixes #5693 
Linked To #5636 

## Proposed changes

- ADDED: 'Blood Surge' Warrior fake rune quests