### PR TITLE
[quest] Add Rogue's 'The Eye of Bhossca' rune

### DIFF
--- a/Database/Corrections/Automatic/sodBaseQuests.lua
+++ b/Database/Corrections/Automatic/sodBaseQuests.lua
@@ -1017,6 +1017,17 @@ function SeasonOfDiscovery:LoadBaseQuests()
             [questKeys.objectivesText] = {"Do you have something for me?"},
             [questKeys.objectives] = {nil,nil,{{211365}}},
         },
+        [78676] = {
+            [questKeys.name] = "The Eye of Bhossca",
+            [questKeys.startedBy] = nil,
+            [questKeys.finishedBy] = nil,
+            [questKeys.requiredLevel] = 30,
+            [questKeys.questLevel] = 35,
+            [questKeys.requiredRaces] = raceIDs.NONE,
+            [questKeys.requiredClasses] = classIDs.ROGUE,
+            [questKeys.objectivesText] = {"Find The Eye of Bhossca inside of the Scarlet Monastery. Then, return it to C's dead drop near Pyrewood Village. You must complete the job alone."},
+            [questKeys.objectives] = {nil,nil,{{210953}}},
+        },
         [78680] = {
             [questKeys.name] = "Rumors Abound",
             [questKeys.startedBy] = {{6247}},

--- a/Database/Corrections/SeasonOfDiscovery.lua
+++ b/Database/Corrections/SeasonOfDiscovery.lua
@@ -90,6 +90,7 @@ local runeQuestsInSoD = {-- List quests here to have them flagged as Rune quests
     [78537] = 1, -- Shaman Earth Shield Part 2
     [78561] = 1, -- Shaman Earth Shield Part 3
     [78575] = 1, -- Shaman Earth Shield Part 4
+    [78676] = 2, -- The Eye of Bhossca
     [78680] = 1, -- Warlock Metamorphosis Part 2
     [78681] = 1, -- Warlock Metamorphosis Part 3
     [78684] = 1, -- Warlock Metamorphosis Part 4

--- a/Database/Corrections/sodQuestFixes.lua
+++ b/Database/Corrections/sodQuestFixes.lua
@@ -464,6 +464,11 @@ function SeasonOfDiscovery:LoadQuests()
         [78612] = { -- A Full Shipment
             [questKeys.specialFlags] = specialFlags.REPEATABLE,
         },
+        [78676] = { -- The Eye of Bhossca
+            [questKeys.startedBy] = {nil,{410369}},
+            [questKeys.finishedBy] = {nil,{410369}},
+            [questKeys.zoneOrSort] = sortKeys.ROGUE,
+        },
         [78680] = { -- Rumors Abound
             [questKeys.requiredClasses] = classIDs.WARLOCK,
             [questKeys.zoneOrSort] = sortKeys.WARLOCK,


### PR DESCRIPTION
## Issue references

Fixes #5695
Linked To #5636 

## Proposed changes

- ADDED: 'The Eye of Bhossca' Rogue fake rune quests