### PR TITLE
[quest] MODIFIED: requiredRaces & Classes for quests

### DIFF
--- a/Database/Corrections/classicQuestFixes.lua
+++ b/Database/Corrections/classicQuestFixes.lua
@@ -1892,6 +1892,13 @@ function QuestieQuestFixes:Load()
         [5262] = {
             [questKeys.startedBy] = {{10813},nil,{13250}},
         },
+        [5283] = {
+            [questKeys.requiredRaces] = raceIDs.HUMAN + raceIDs.DWARF + raceIDs.NIGHT_ELF,
+            [questKeys.requiredClasses] = classIDs.WARRIOR + classIDs.PALADIN,
+        },
+        [5284] = {
+            [questKeys.requiredRaces] = raceIDs.HUMAN + raceIDs.DWARF + raceIDs.NIGHT_ELF,
+        },
         [5305]  ={
             [questKeys.exclusiveTo] = {8869},
             [questKeys.requiredSpecialization] = specKeys.BLACKSMITHING_WEAPON,


### PR DESCRIPTION
## Issue references

#5802 

## Proposed changes

- ADDED: `requiredRaces` & `requiredClasses` overrides to 'The Way Of the Armorsmith' & The 'Way of the Weaponsmith' to show only on correct races