### PR TITLE
[quest] Hide "Heeding the Call" in Cataclysm

### DIFF
--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1512,6 +1512,7 @@ function QuestieQuestBlacklist:Load()
         [1431] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [5121] = QuestieCorrections.CATA_HIDE, -- Replaced by 28470
         [5123] = QuestieCorrections.CATA_HIDE, -- Replaced by 28471
+        [5926] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6564] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6981] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [7492] = QuestieCorrections.CATA_HIDE, -- Removed with cata

--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1512,7 +1512,12 @@ function QuestieQuestBlacklist:Load()
         [1431] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [5121] = QuestieCorrections.CATA_HIDE, -- Replaced by 28470
         [5123] = QuestieCorrections.CATA_HIDE, -- Replaced by 28471
+        [5923] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [5924] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [5925] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [5926] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [5927] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [5928] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6564] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6981] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [7492] = QuestieCorrections.CATA_HIDE, -- Removed with cata


### PR DESCRIPTION
## Proposed changes

- This hides the druid quest "Heeding the Call" in Cata as it has been removed: https://www.wowhead.com/cata/quest=5924/heeding-the-call