### PR TITLE
[quest] Fix "Conscript of the Horde" exclusivity

### DIFF
--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1503,6 +1503,7 @@ function QuestieQuestBlacklist:Load()
         [819] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [830] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [832] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [842] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [882] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [883] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [884] = QuestieCorrections.CATA_HIDE, -- Removed with cata

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -64,6 +64,9 @@ function CataQuestFixes.Load()
         [824] = { -- Je'neu of the Earthen Ring
             [questKeys.finishedBy] = {{12736}},
         },
+        [840] = { -- Conscript of the Horde
+            [questKeys.exclusiveTo] = {},
+        },
         [869] = { -- To Track a Thief
             [questKeys.triggerEnd] = {"Source of Tracks Discovered",{[zoneIDs.THE_BARRENS] = {{63.5,61.5}}}},
         },
@@ -3265,6 +3268,9 @@ function CataQuestFixes.Load()
         },
         [28488] = { -- Beneath the Surface
             [questKeys.exclusiveTo] = {26710,27048},
+        },
+        [28494] = { -- Warchief's Command: Northern Barrens!
+            [questKeys.exclusiveTo] = {26642},
         },
         [28501] = { -- The Defense of Nahom
             [questKeys.objectives] = {{{49228}}},

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -66,12 +66,20 @@ function CataQuestFixes.Load()
         },
         [840] = { -- Conscript of the Horde
             [questKeys.exclusiveTo] = {},
+            [questKeys.nextQuestInChain] = 871,
         },
         [869] = { -- To Track a Thief
             [questKeys.triggerEnd] = {"Source of Tracks Discovered",{[zoneIDs.THE_BARRENS] = {{63.5,61.5}}}},
         },
         [870] = { -- The Forgotten Pools
             [questKeys.triggerEnd] = {"Explore the waters of the Forgotten Pools",{[zoneIDs.THE_BARRENS] = {{37.1,45.4}}}},
+        },
+        [871] = { -- In Defense of Far Watch
+            [questKeys.preQuestSingle] = {840, 26642, 28494},
+            [questKeys.nextQuestInChain] = 872,
+        },
+        [872] = { -- The Far Watch Offensive
+            [questKeys.preQuestSingle] = {871},
         },
         [918] = { -- Timberling Seeds
             [questKeys.preQuestSingle] = {997},
@@ -2367,6 +2375,7 @@ function CataQuestFixes.Load()
         },
         [26642] = { -- Preserving the Barrens
             [questKeys.exclusiveTo] = {28494},
+            [questKeys.nextQuestInChain] = 871,
         },
         [26645] = { -- The Night Watch
             [questKeys.preQuestSingle] = {26618},
@@ -3271,6 +3280,7 @@ function CataQuestFixes.Load()
         },
         [28494] = { -- Warchief's Command: Northern Barrens!
             [questKeys.exclusiveTo] = {26642},
+            [questKeys.nextQuestInChain] = 871,
         },
         [28501] = { -- The Defense of Nahom
             [questKeys.objectives] = {{{49228}}},


### PR DESCRIPTION
## Proposed changes

- This fixes the exclusivity of the "Conscript of the Horde" quest. This quest can be picked up with either "Preserving the Barrens" or "Warchief's Command: Northern Barrens!", but not both. (the latter two are still exclusive to each other)
- Updates the breadcrumbs between these quests for the entire chain
- Removes an old quest that was previously referenced in the chain, but has been removed from Cata

## Screenshots
Here's a screenshot where I have both of these in my quest log showing that this is possible!

![WoWScrnShot_052524_165237](https://github.com/Questie/Questie/assets/122651505/647b3da0-f2fb-4d40-b5d3-544167ef7cf3)