### PR TITLE
[quest] Hide Unavailable Goblin Starter Quests in Cataclysm

### DIFF
--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1563,8 +1563,16 @@ function QuestieQuestBlacklist:Load()
         [24426] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [24427] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [24503] = QuestieCorrections.CATA_HIDE, -- Duplicate of 28414
+        [24860] = QuestieCorrections.CATA_HIDE, -- Not in the game
+        [24935] = QuestieCorrections.CATA_HIDE, -- Not in the game		
+        [24936] = QuestieCorrections.CATA_HIDE, -- Not in the game		
+        [25124] = QuestieCorrections.CATA_HIDE, -- Not in the game
+        [25225] = QuestieCorrections.CATA_HIDE, -- Not in the game
+        [25231] = QuestieCorrections.CATA_HIDE, -- Not in the game		
         [25474] = QuestieCorrections.CATA_HIDE, -- Duplicate of 27729
         [25635] = QuestieCorrections.CATA_HIDE, -- Duplicate of 25583 and 25956
+		[25902] = QuestieCorrections.CATA_HIDE, -- Not in the game
+		[25903] = QuestieCorrections.CATA_HIDE, -- Not in the game		
         [26125] = QuestieCorrections.CATA_HIDE, -- Duplicate of 26124
         [26565] = QuestieCorrections.CATA_HIDE, -- Duplicate of 26588
         [26825] = QuestieCorrections.CATA_HIDE, -- Duplicate of 26826


### PR DESCRIPTION
## Proposed changes

- Remove several Goblin Starting Experience Quests not in game

https://www.wowhead.com/quest=24860/profitable-preservation
https://www.wowhead.com/quest=24935/body-and-soul
https://www.wowhead.com/quest=24936/body-and-soul
https://www.wowhead.com/quest=25124/brute-brutality
https://www.wowhead.com/quest=25225/oil-change
https://www.wowhead.com/quest=25231/southseas-scum
https://www.wowhead.com/quest=25902/your-first-totem
https://www.wowhead.com/quest=25903/its-hot-and-it-might-explode
