### PR TITLE
[quest] Fix 'Kolkar Leaders' duplicated on map

### DIFF
--- a/Database/Corrections/cataNPCFixes.lua
+++ b/Database/Corrections/cataNPCFixes.lua
@@ -52,6 +52,9 @@ function CataNpcFixes.Load()
             [npcKeys.questEnds] = {749,24459,26179,26180},
             [npcKeys.waypoints] = {},
         },
+        [3389] = { -- Regthar Deathgate
+            [npcKeys.questStarts] = {851,852,855,4021},
+        },
         [3475] = { -- Echeyakee
             [npcKeys.spawns] = {[zoneIDs.THE_BARRENS] = {{56.4,34.9}}},
         },

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -74,7 +74,6 @@ function CataQuestFixes.Load()
         },
         [850] = { -- Kolkar Leaders
             [questKeys.startedBy] = {{34841}},
-            [questKeys.finishedBy] = {{34841}},   
         },
         [869] = { -- To Track a Thief
             [questKeys.triggerEnd] = {"Source of Tracks Discovered",{[zoneIDs.THE_BARRENS] = {{63.5,61.5}}}},

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -72,6 +72,10 @@ function CataQuestFixes.Load()
             [questKeys.exclusiveTo] = {},
             [questKeys.nextQuestInChain] = 871,
         },
+        [850] = { -- Kolkar Leaders
+            [questKeys.startedBy] = {{34841}},
+            [questKeys.finishedBy] = {{34841}},   
+        },
         [869] = { -- To Track a Thief
             [questKeys.triggerEnd] = {"Source of Tracks Discovered",{[zoneIDs.THE_BARRENS] = {{63.5,61.5}}}},
         },


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #6018 

## Proposed changes

- This change updates quest 850 'Kolkar Leaders' to reflect correctly on the map with the change in quest giver starting in Cataclysm.  Removes quest from old quest giver 3389 'Regthar Deathgate'.  Quest starts/ends with new quest giver 34841 Telar Highstrider.