### PR TITLE
[quest] Fix 'A Special Surprise' being shown on map before completion of pre-req

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -409,12 +409,6 @@ function CataQuestFixes.Load()
         [12750] = { -- A Special Surprise (Undead)
             [questKeys.preQuestSingle] = {12738}
         },
-        [28649] = { -- A Special Surprise (Worgen)
-            [questKeys.preQuestSingle] = {12738}
-        },
-        [28650] = { -- A Special Surprise (Goblin)
-            [questKeys.preQuestSingle] = {12738}
-        },
         [12821] = { -- Opening the Backdoor
             [questKeys.objectives] = {nil,nil,{{40731}}}
         },
@@ -3840,6 +3834,12 @@ function CataQuestFixes.Load()
         },
         [28635] = { -- A Haunting in Hillsbrad
             [questKeys.triggerEnd] = {"Search Dun Garok for Evidence of a Haunting", {[zoneIDs.HILLSBRAD_FOOTHILLS]={{61.9,84.5}}}},
+        },
+        [28649] = { -- A Special Surprise (Worgen)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [28650] = { -- A Special Surprise (Goblin)
+            [questKeys.preQuestSingle] = {12738}
         },
         [28651] = { -- Novice Elreth
             [questKeys.startedBy] = {{2119,2122,2123,2124,2126,38911}},

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -379,6 +379,42 @@ function CataQuestFixes.Load()
         [12602] = { -- The Alchemist's Apprentice
             [questKeys.startedBy] = {},
         },
+        [12739] = { -- A Special Surprise (Tauren)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [12742] = { -- A Special Surprise (Human)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [12743] = { -- A Special Surprise (Night Elf)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [12744] = { -- A Special Surprise (Dwarf)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [12745] = { -- A Special Surprise (Gnome)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [12746] = { -- A Special Surprise (Draenei)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [12747] = { -- A Special Surprise (Blood Elf)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [12748] = { -- A Special Surprise (Orc)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [12749] = { -- A Special Surprise (Troll)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [12750] = { -- A Special Surprise (Undead)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [28649] = { -- A Special Surprise (Worgen)
+            [questKeys.preQuestSingle] = {12738}
+        },
+        [28650] = { -- A Special Surprise (Goblin)
+            [questKeys.preQuestSingle] = {12738}
+        },
         [12821] = { -- Opening the Backdoor
             [questKeys.objectives] = {nil,nil,{{40731}}}
         },


### PR DESCRIPTION
## Issue references

Fixes #6030 

## Proposed changes

- Adds quest 12738 'A Cry for Vengeance!' as a pre-req for quest(s) 'A Special Surprise' 12739, 12742-12750, 28649-28650.
- **Note:** Quest 'A Special Surprise' is a quest in the Death Knight starter area which has 12 different race-specific versions of the same quest with different quest id's, so there are 12 fixes. Original quests already appear to have correct race requirements, but not the correct pre-req requirements, so **questKeys.requiredRaces** is not included.