### PR TITLE
[quest] Blacklist "The Key To Freedom" in Cataclysm Classic

### DIFF
--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1888,6 +1888,7 @@ function QuestieQuestBlacklist:Load()
         [4421] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [4441] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [4442] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+	[4451] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [4505] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [4506] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [4641] = QuestieCorrections.CATA_HIDE, -- Removed with cata

--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1888,7 +1888,7 @@ function QuestieQuestBlacklist:Load()
         [4421] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [4441] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [4442] = QuestieCorrections.CATA_HIDE, -- Removed with cata
-	[4451] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [4451] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [4505] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [4506] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [4641] = QuestieCorrections.CATA_HIDE, -- Removed with cata


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #6086 

## Proposed changes

- Blacklists quest 4451 (The Key To Freedom) because it is no longer available

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->

![image](https://github.com/Questie/Questie/assets/11901488/fc4b913b-b8af-49b7-b1cf-eef702372b08)