### PR TITLE
[quest] Fix 'Altar of Goc' Spawn Location

### DIFF
--- a/Database/Corrections/cataObjectFixes.lua
+++ b/Database/Corrections/cataObjectFixes.lua
@@ -44,6 +44,9 @@ function CataObjectFixes.Load()
         [181781] = { -- Axxarien Crystal
             [objectKeys.name] = "Axxarien Crystal",
         },
+        [185309] = { -- Altar of Goc
+            [objectKeys.spawns] = {[zoneIDs.BLADES_EDGE_MOUNTAINS] = {{64.15,18.5}}},
+        },
         [187922] = { -- Alliance Bonfire - Burning Steppes
             [objectKeys.spawns] = {[zoneIDs.BURNING_STEPPES] = {{68.57,60.2}}},
         },


### PR DESCRIPTION
## Issue references

Fixes #6056

## Proposed changes

- Add a fix to spawn locations for Altar of Goc as part of the Showdown quest.