### PR TITLE
[quest] Fix 'The Ultrasafe Personnel Launcher' triggerEnd

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3281,6 +3281,7 @@ function CataQuestFixes.Load()
         },
         [25839] = { -- The Ultrasafe Personnel Launcher
             [questKeys.triggerEnd] = {"Use the Ultrasafe Personnel Launcher to deploy to Frostmane Retreat.", {[zoneIDs.DUN_MOROGH] = {{56.85,46.65}}}},
+            [questKeys.objectives] = {{{41398,nil,Questie.ICON_TYPE_INTERACT}}},
         },
         [25843] = { -- Tortolla's Revenge
             [questKeys.preQuestSingle] = {25372},

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3279,6 +3279,9 @@ function CataQuestFixes.Load()
             [questKeys.preQuestSingle] = {},
             [questKeys.preQuestGroup] = {25520,25807},
         },
+        [25839] = { -- The Ultrasafe Personnel Launcher
+            [questKeys.triggerEnd] = {"Use the Ultrasafe Personnel Launcher to deploy to Frostmane Retreat.", {[zoneIDs.DUN_MOROGH] = {{56.85,46.65}}}},
+        },
         [25843] = { -- Tortolla's Revenge
             [questKeys.preQuestSingle] = {25372},
             [questKeys.nextQuestInChain] = 25904,

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3280,7 +3280,6 @@ function CataQuestFixes.Load()
             [questKeys.preQuestGroup] = {25520,25807},
         },
         [25839] = { -- The Ultrasafe Personnel Launcher
-            [questKeys.triggerEnd] = {"Use the Ultrasafe Personnel Launcher to deploy to Frostmane Retreat.", {[zoneIDs.DUN_MOROGH] = {{56.85,46.65}}}},
             [questKeys.objectives] = {{{41398,nil,Questie.ICON_TYPE_INTERACT}}},
         },
         [25843] = { -- Tortolla's Revenge


### PR DESCRIPTION
## Issue references

Fixes #6102

## Proposed changes

- Add a fix to include `triggerEnd` for 'The Ultrasafe Personnel Launcher' as done in 'Missing In Action' & 'Supplies to Auberdine'.