### PR TITLE
[quest] Fix 'Maraudine Prisoner Manifest' startQuest

### DIFF
--- a/Database/Corrections/cataItemFixes.lua
+++ b/Database/Corrections/cataItemFixes.lua
@@ -68,7 +68,7 @@ function CataItemFixes.Load()
             [itemKeys.npcDrops] = {2956,2957},
         },
         [38567] = { -- Maraudine Prisoner Manifest
-            [itemKeys.startQuest] = {},
+            [itemKeys.startQuest] = 14330,
         },
         [39684] = { -- Hair Trigger
             [itemKeys.npcDrops] = {},

--- a/Database/Corrections/cataItemFixes.lua
+++ b/Database/Corrections/cataItemFixes.lua
@@ -67,6 +67,9 @@ function CataItemFixes.Load()
         [33009] = { -- Tender Strider Meat
             [itemKeys.npcDrops] = {2956,2957},
         },
+        [38567] = { -- Maraudine Prisoner Manifest
+            [itemKeys.startQuest] = {},
+        },
         [39684] = { -- Hair Trigger
             [itemKeys.npcDrops] = {},
         },


### PR DESCRIPTION
## Issue references

Fixes #6185

## Proposed changes

- Add a fix to startQuest for the 'Marudine Prisoner Manifest' item to override the autogenerated `itemStartFixes.lua` which is linking to an incorrect quest currently.