### PR TITLE
[Quest] Cata Classic - Fix The Third Fleet quest chain

### DIFF
--- a/Database/Corrections/cataItemFixes.lua
+++ b/Database/Corrections/cataItemFixes.lua
@@ -9,6 +9,9 @@ function CataItemFixes.Load()
     local itemClasses = QuestieDB.itemClasses
 
     return {
+        [2629] = { -- Intrepid Strongbox Key
+            [itemKeys.npcDrops] = {41429},
+        },
         [2859] = { -- Vile Fin Scale
             [itemKeys.npcDrops] = {1541,1543,1544,1545},
         },

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3284,6 +3284,19 @@ function CataQuestFixes.Load()
         [25810] = { -- The Hatchery Must Burn
             [questKeys.startedBy] = {{41003}},
         },
+        [25815] = { -- The Third Fleet
+            [questKeys.nextQuestInChain] = 25816,
+        },
+        [25816] = { -- Cursed To Roam
+            [questKeys.nextQuestInChain] = 25817,
+        },
+        [25817] = { -- The Cursed Crew
+            [questKeys.nextQuestInChain] = 25818,
+        },
+        [25818] = { -- Lifting the Curse
+            [questKeys.nextQuestInChain] = 25819,
+            [questKeys.objectives] = {{{41429,nil,Questie.ICON_TYPE_SLAY}}},
+        },
         [25824] = { -- Debriefing
             [questKeys.objectives] = {{{41340,nil,Questie.ICON_TYPE_TALK}}},
         },

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3295,7 +3295,6 @@ function CataQuestFixes.Load()
         },
         [25818] = { -- Lifting the Curse
             [questKeys.nextQuestInChain] = 25819,
-            [questKeys.objectives] = {{{41429,nil,Questie.ICON_TYPE_SLAY}}},
         },
         [25824] = { -- Debriefing
             [questKeys.objectives] = {{{41340,nil,Questie.ICON_TYPE_TALK}}},


### PR DESCRIPTION
Fix the Menethil Harbor quest chain starting with "The Third Fleet" and ending at "The Eye of Paleth".

## Proposed changes
- Add _nextQuestInChain_ for entire chain
- Fix _npcDrops_ ID on Intrepid Strongbox Key for "Lifting the Curse"