### PR TITLE
[Quest] Cata Classic - Fix pre-quest requirement for Claws from the Deep and Reclaiming Goods

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3278,6 +3278,12 @@ function CataQuestFixes.Load()
         [25799] = { -- Defend the Drill
             [questKeys.triggerEnd] = {"Oil Drilling Rig defended",[zoneIDs.THOUSAND_NEEDLES]={{85.9,44.6},{90.2,50.7},{87.2,49.5},{88.3,44.4}}},
         },
+        [25801] = { -- Claws from the Deep
+            [questKeys.preQuestSingle] = {25800},
+        },
+        [25802] = { -- Reclaiming Goods
+            [questKeys.preQuestSingle] = {25800},
+        },
         [25807] = { -- An Ancient Reborn
             [questKeys.objectives] = {{{41300,nil,Questie.ICON_TYPE_EVENT}}},
         },


### PR DESCRIPTION
Another Menethil Harbor quest fix, "Claws from the Deep" and "Reclaiming Goods" only become available after completing "When Life Gives You Crabs".

## Proposed changes

- Set _preQuestSingle_ for "Claws from the Deep" and "Reclaiming Goods"