### PR TITLE
[Quest] Cata Classic - Fix Greenwarden's Grove quests

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3393,6 +3393,7 @@ function CataQuestFixes.Load()
         [25939] = { -- For Peat's Sake
             [questKeys.preQuestSingle] = {25926},
             [questKeys.nextQuestInChain] = 26196,
+            [questKeys.objectives] = {{{41628,nil,Questie.ICON_TYPE_INTERACT}}},
         },
         [25940] = { -- Last Stand at Whistling Grove
             [questKeys.preQuestSingle] = {25428},

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3378,6 +3378,9 @@ function CataQuestFixes.Load()
             [questKeys.zoneOrSort] = zoneIDs.ORGRIMMAR,
             [questKeys.objectives] = {{{36901,nil,Questie.ICON_TYPE_EVENT}}},
         },
+        [25926] = { -- Mired in Hatred
+            [questKeys.nextQuestInChain] = 25927,
+        },
         [25929] = { -- Sea Legs
             [questKeys.preQuestSingle] = {},
         },
@@ -3386,6 +3389,10 @@ function CataQuestFixes.Load()
         },
         [25936] = { -- Pay It Forward
             [questKeys.objectives] = {{{41672,nil,Questie.ICON_TYPE_EVENT}}},
+        },
+        [25939] = { -- For Peat's Sake
+            [questKeys.preQuestSingle] = {25926},
+            [questKeys.nextQuestInChain] = 26196,
         },
         [25940] = { -- Last Stand at Whistling Grove
             [questKeys.preQuestSingle] = {25428},


### PR DESCRIPTION
Add quest chain tags to Greenwarden's Grove quests and only make "For Peat's Sake" available after completing "Mired in Hatred".

## Proposed changes
- Set _nextQuestInChain_ for relevant quests
- Set _preQuestSingle_ for "For Peat's Sake"
- Change objective icon of "For Peat's Sake" from _SLAY_ to _INTERACT_
  - The objective is to extinguish fires using an item from your inventory, _INTERACT_ seems more appropriate