### PR TITLE
[Quest] Cata Classic - Remove pre-quest restriction from The Twilight's Hammer Revealed

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3668,6 +3668,9 @@ function CataQuestFixes.Load()
             [questKeys.extraObjectives] = {{nil, Questie.ICON_TYPE_EVENT, l10n("Three Hammerhead Oil and two Remora Oil"), 0, {{"object", 203461}}}},
             [questKeys.requiredSourceItems] = {56833},
         },
+        [26127] = { -- The Twilight's Hammer Revealed
+            [questKeys.preQuestSingle] = {},
+        },
         [26133] = { -- Fiends from the Netherworld
             [questKeys.preQuestSingle] = {26111},
         },
@@ -3917,6 +3920,9 @@ function CataQuestFixes.Load()
         [26326] = { -- The Very Earth Beneath Our Feet
             [questKeys.preQuestSingle] = {},
             [questKeys.preQuestGroup] = {26876,27938},
+        },
+        [26327] = { -- Anvilmar the Hero
+            [questKeys.nextQuestInChain] = 26127,
         },
         [26329] = { -- One More Thing
             [questKeys.zoneOrSort] = zoneIDs.CHILL_BREEZE_VALLEY,


### PR DESCRIPTION
"Anvilmar the Hero" is an optional quest for "The Twilight's Hammer Revealed", even though the NPCs are right next to eachother.

## Proposed changes
- Remove _preQuestSingle_ from "The Twilight's Hammer Revealed"
- Set "The Twilight's Hammer Revealed" as _nextQuestInChain_ for "Anvilmar the Hero"