### PR TITLE
Feature: Re-click Questie icon to close dropdown menu

### DIFF
--- a/Libs/LibUIDropDownMenu/LibUIDropDownMenu.lua
+++ b/Libs/LibUIDropDownMenu/LibUIDropDownMenu.lua
@@ -118,6 +118,10 @@ function lib:UIDropDownMenu_InitializeHelper(frame)
     frame:SetHeight(L_UIDROPDOWNMENUQUESTIE_BUTTON_HEIGHT * 2);
 end
 
+function lib:getOpen() 
+    return L_UIDROPDOWNMENUQUESTIE_OPEN_MENU
+end
+
 function lib:UIDropDownMenuButton_ShouldShowIconTooltip(self)
     if self.Icon and (self.iconTooltipTitle or self.iconTooltipText) and (self.icon or self.mouseOverIcon) then
         return GetMouseFocus() == self.Icon;

--- a/Libs/LibUIDropDownMenu/LibUIDropDownMenu.lua
+++ b/Libs/LibUIDropDownMenu/LibUIDropDownMenu.lua
@@ -118,8 +118,9 @@ function lib:UIDropDownMenu_InitializeHelper(frame)
     frame:SetHeight(L_UIDROPDOWNMENUQUESTIE_BUTTON_HEIGHT * 2);
 end
 
+--Questie addition, to know when menus are showing
 function lib:getOpen() 
-    return L_UIDROPDOWNMENUQUESTIE_OPEN_MENU
+    return L_UIDROPDOWNMENUQUESTIE_OPEN_MENU ~= nil
 end
 
 function lib:UIDropDownMenuButton_ShouldShowIconTooltip(self)

--- a/Modules/MinimapIcon.lua
+++ b/Modules/MinimapIcon.lua
@@ -36,8 +36,11 @@ function _MinimapIcon:CreateDataBrokerObject()
             if (not Questie.started) then
                 return
             end
-
-            if button == "LeftButton" and not QuestieMenu:isOpen() then
+            if button == "LeftButton" then
+                if QuestieMenu.IsOpen() then
+                    QuestieMenu:Hide()
+                    return
+                end
                 if IsShiftKeyDown() and IsControlKeyDown() then
                     Questie.db.profile.enabled = (not Questie.db.profile.enabled)
                     QuestieQuest:ToggleNotes(Questie.db.profile.enabled)
@@ -55,10 +58,7 @@ function _MinimapIcon:CreateDataBrokerObject()
                 if QuestieJourney:IsShown() then
                     QuestieJourney.ToggleJourneyWindow();
                 end
-
                 return;
-            elseif button == "LeftButton" and QuestieMenu:isOpen() then
-                QuestieMenu:Hide()
             elseif button == "RightButton" then
                 if (not IsModifierKeyDown()) then
                     -- CLose config window if it's open to avoid desyncing the Checkbox

--- a/Modules/MinimapIcon.lua
+++ b/Modules/MinimapIcon.lua
@@ -37,7 +37,7 @@ function _MinimapIcon:CreateDataBrokerObject()
                 return
             end
 
-            if button == "LeftButton" then
+            if button == "LeftButton" and not QuestieMenu:isOpen() then
                 if IsShiftKeyDown() and IsControlKeyDown() then
                     Questie.db.profile.enabled = (not Questie.db.profile.enabled)
                     QuestieQuest:ToggleNotes(Questie.db.profile.enabled)
@@ -57,6 +57,8 @@ function _MinimapIcon:CreateDataBrokerObject()
                 end
 
                 return;
+            elseif button == "LeftButton" and QuestieMenu:isOpen() then
+                QuestieMenu:Hide()
             elseif button == "RightButton" then
                 if (not IsModifierKeyDown()) then
                     -- CLose config window if it's open to avoid desyncing the Checkbox

--- a/Modules/QuestieMenu/QuestieMenu.lua
+++ b/Modules/QuestieMenu/QuestieMenu.lua
@@ -336,16 +336,15 @@ function QuestieMenu:Show(hideDelay)
         end})
         tinsert(menuTable, { text= l10n('Reload UI'), func=function() ReloadUI() end})
     end
-    
     tinsert(menuTable, {text= l10n('Cancel'), func=function() end})
     LibDropDown:EasyMenu(menuTable, QuestieMenu.menu, "cursor", -80, -15, "MENU", hideDelay or 2)
 end
 
 function QuestieMenu:Hide()
-        LibDropDown:HideDropDownMenu(1)
+    LibDropDown:CloseDropDownMenus()    
 end
 
-function QuestieMenu:isOpen() 
+function QuestieMenu.IsOpen() 
    return LibDropDown:getOpen()
 end
 

--- a/Modules/QuestieMenu/QuestieMenu.lua
+++ b/Modules/QuestieMenu/QuestieMenu.lua
@@ -336,9 +336,17 @@ function QuestieMenu:Show(hideDelay)
         end})
         tinsert(menuTable, { text= l10n('Reload UI'), func=function() ReloadUI() end})
     end
-
+    
     tinsert(menuTable, {text= l10n('Cancel'), func=function() end})
     LibDropDown:EasyMenu(menuTable, QuestieMenu.menu, "cursor", -80, -15, "MENU", hideDelay or 2)
+end
+
+function QuestieMenu:Hide()
+        LibDropDown:HideDropDownMenu(1)
+end
+
+function QuestieMenu:isOpen() 
+   return LibDropDown:getOpen()
 end
 
 function QuestieMenu:ShowTownsfolk(hideDelay)

--- a/Modules/WorldMapButton/WorldMapButton.lua
+++ b/Modules/WorldMapButton/WorldMapButton.lua
@@ -39,10 +39,12 @@ QuestieWorldMapButtonMixin = {
         if button == "LeftButton" then
             Questie.db.profile.enabled = (not Questie.db.profile.enabled)
             QuestieQuest:ToggleNotes(Questie.db.profile.enabled)
-        elseif button == "RightButton" and not QuestieMenu.IsOpen() then
-            QuestieMenu:Show()
-        elseif  button == "RightButton" and QuestieMenu.IsOpen() then 
-            QuestieMenu:Hide()
+        elseif button == "RightButton" then
+            if QuestieMenu.IsOpen() then
+                QuestieMenu:Hide()
+            else
+                QuestieMenu:Show()
+            end
         end
     end,
     OnMouseUp = function() end,

--- a/Modules/WorldMapButton/WorldMapButton.lua
+++ b/Modules/WorldMapButton/WorldMapButton.lua
@@ -39,9 +39,9 @@ QuestieWorldMapButtonMixin = {
         if button == "LeftButton" then
             Questie.db.profile.enabled = (not Questie.db.profile.enabled)
             QuestieQuest:ToggleNotes(Questie.db.profile.enabled)
-        elseif button == "RightButton" and not QuestieMenu:isOpen() then
+        elseif button == "RightButton" and not QuestieMenu.IsOpen() then
             QuestieMenu:Show()
-        elseif  button == "RightButton" and QuestieMenu:isOpen() then 
+        elseif  button == "RightButton" and QuestieMenu.IsOpen() then 
             QuestieMenu:Hide()
         end
     end,

--- a/Modules/WorldMapButton/WorldMapButton.lua
+++ b/Modules/WorldMapButton/WorldMapButton.lua
@@ -39,8 +39,10 @@ QuestieWorldMapButtonMixin = {
         if button == "LeftButton" then
             Questie.db.profile.enabled = (not Questie.db.profile.enabled)
             QuestieQuest:ToggleNotes(Questie.db.profile.enabled)
-        elseif button == "RightButton" then
+        elseif button == "RightButton" and not QuestieMenu:isOpen() then
             QuestieMenu:Show()
+        elseif  button == "RightButton" and QuestieMenu:isOpen() then 
+            QuestieMenu:Hide()
         end
     end,
     OnMouseUp = function() end,


### PR DESCRIPTION
re-clicking the minimap icon with left click closes the dropdown menu, and re-clicking the icon with right click in the worldmap will close the dropdown menu as well

<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #6180

## Proposed changes

-Left clicking the Questie minimap icon will close the dropdown menu if its open
-Right clicking the Questie icon in the world map window will close the dropdown menu if its open
-This feature will work in classic and SOD, I will need to update the library to get it working in CATA 

## Screenshots

https://github.com/user-attachments/assets/033d18fa-1122-49b1-b7c5-e7b1672b8c6a


https://github.com/user-attachments/assets/187d3130-31e1-43a5-a228-cdb56b5ec72f



<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->