### PR TITLE
[quest] Fix BFD Quests Unavailable In Cata

### DIFF
--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1791,6 +1791,7 @@ function QuestieQuestBlacklist:Load()
         [1268] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [1269] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [1273] = QuestieCorrections.CATA_HIDE, -- Replaced by 27261
+        [1275] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [1276] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [1282] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [1284] = QuestieCorrections.CATA_HIDE, -- Removed with cata
@@ -2008,7 +2009,10 @@ function QuestieQuestBlacklist:Load()
         [6202] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6394] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6395] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [6561] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [6562] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6564] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [6565] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6609] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6702] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6703] = QuestieCorrections.CATA_HIDE, -- Removed with cata
@@ -2022,6 +2026,7 @@ function QuestieQuestBlacklist:Load()
         [6711] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6841] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6842] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [6921] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [6981] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [7069] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [7321] = QuestieCorrections.CATA_HIDE, -- Removed with cata


### PR DESCRIPTION
## Issue references

Fixes #6207

## Proposed changes

- Add a fix to Questie corrections for multiple BFD quests to blacklist it in Cata.