### PR TITLE
[quest] Fix 'The Wilds of Feralas' Prerequisite Quest

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -1789,6 +1789,10 @@ function CataQuestFixes.Load()
             [questKeys.preQuestSingle] = {},
             [questKeys.objectives] = {{{36472,nil,Questie.ICON_TYPE_INTERACT}},nil,{{49204}}},
         },
+        [14410] = { -- The Wilds of Feralas
+            [questKeys.preQuestGroup] = {14381,14394},
+            [questKeys.exclusiveTo] = {25447,28511},
+        },
         [14412] = { -- Washed Up
             [questKeys.preQuestSingle] = {14403},
         },


### PR DESCRIPTION
## Issue references

Fixes #6205

## Proposed changes

- Add `preQuestGroup` quests for the 'The Wilds of Feralas' quest.
- Add `exclusiveTo`  quests for the 'The Wilds of Feralas' quest.