### PR TITLE
[quest] Fix 'Rock Lobstrock!' Prerequisite Quest

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -1727,6 +1727,9 @@ function CataQuestFixes.Load()
             [questKeys.preQuestGroup] = {14370,14371},
             [questKeys.objectives] = {{{36297,nil,Questie.ICON_TYPE_TALK}}},
         },
+        [14379] = { -- Rock Lobstrock!
+            [questKeys.preQuestGroup] = {14373,14374},
+        },
         [14382] = { -- Two By Sea
             [questKeys.extraObjectives] = {
                 {nil,Questie.ICON_TYPE_INTERACT,l10n("Use the catapult to board the ship"),0,{{"monster",36283}}},


### PR DESCRIPTION
## Issue references

Fixes #6202

## Proposed changes

- Add `preQuestGroup` to the 'Rock Lobstrock!'' quest.