### PR TITLE
[quest] Fix 'Get Me Out of Here' triggerEnd

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -248,6 +248,9 @@ function CataQuestFixes.Load()
         [6031] = { -- Runecloth
             [questKeys.reputationReward] = {{factionIDs.TIMBERMAW_HOLD,8}},
         },
+        [6132] = { -- Get Me Out of Here!
+            [questKeys.triggerEnd] = {"Escort Melizza Brimbuzzle", {[zoneIDs.DESOLACE]={{39.84,61.49}}}},
+        },
         [6322] = { -- Michael Garrett
             [questKeys.requiredRaces] = raceKeys.UNDEAD,
         },


### PR DESCRIPTION
## Issue references

Fixes #6189

## Proposed changes

- Add a fix to include `triggerEnd` for 'Get Me Out of Here!' as done in 'Goggle Boggle' & 'Death from Below'.