### PR TITLE
[quest] Fix 'End of the Dark Horde' Unavailable In Era

### DIFF
--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -34,6 +34,7 @@ function QuestieQuestBlacklist:Load()
         [936] = QuestieCorrections.CLASSIC_HIDE + QuestieCorrections.SOD_HIDE,
         [535] = QuestieCorrections.WOTLK_HIDE + QuestieCorrections.CATA_HIDE, -- Valik
         [2000] = true, -- Not in the game - #4487
+        [84377] = QuestieCorrections.CLASSIC_HIDE -- Spillover from SoD
         -- Welcome! quests (Collectors Edition)
         [5805] = true,
         [5841] = true,

--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -34,7 +34,7 @@ function QuestieQuestBlacklist:Load()
         [936] = QuestieCorrections.CLASSIC_HIDE + QuestieCorrections.SOD_HIDE,
         [535] = QuestieCorrections.WOTLK_HIDE + QuestieCorrections.CATA_HIDE, -- Valik
         [2000] = true, -- Not in the game - #4487
-        [84377] = QuestieCorrections.CLASSIC_HIDE -- Spillover from SoD
+        [84377] = QuestieCorrections.CLASSIC_HIDE, -- Spillover from SoD
         -- Welcome! quests (Collectors Edition)
         [5805] = true,
         [5841] = true,


### PR DESCRIPTION
## Issue references

Fixes #6129

## Proposed changes

- Add a fix to Questie corrections for 'End of the Dark Horde' quest to blacklist it in Era, this is SoD spillover.