### PR TITLE
[quest] Blacklist "Failed Incursion" in Cataclysm

### DIFF
--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -2399,6 +2399,7 @@ function QuestieQuestBlacklist:Load()
         [9662] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [9745] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [9764] = QuestieCorrections.CATA_HIDE, -- Removed with cata
+        [9876] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [10177] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [10352] = QuestieCorrections.CATA_HIDE, -- Removed with cata
         [10354] = QuestieCorrections.CATA_HIDE, -- Removed with cata


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #6247 

## Proposed changes

- Blacklists "Failed Incursion" since it no longer exists in Cataclysm (https://www.wowhead.com/cata/quest=9876/failed-incursion)

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->