### PR TITLE
[quest] Fix 'Zukk'ash Infestation' Prerequisite Quest

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -2879,6 +2879,9 @@ function CataQuestFixes.Load()
         [25359] = { -- Toshe's Vengeance
             [questKeys.nextQuestInChain] = 25439,
         },
+        [25367] = { -- Zukk'ash Infestation
+            [questKeys.preQuestSingle] = {25427},
+        },
         [25370] = { -- Inciting the Elements
             [questKeys.preQuestSingle] = {},
             [questKeys.requiredSourceItems] = {53009},


### PR DESCRIPTION
## Issue references

Fixes #6244

## Proposed changes

- Add `preQuestSingle` to the 'Zukk'ash Infestation' quest.