### PR TITLE
[quest] Add 'Return to Vestia' Prerequisite Quest

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -4038,6 +4038,9 @@ function CataQuestFixes.Load()
             [questKeys.requiredRaces] = raceKeys.TAUREN,
             [questKeys.extraObjectives] = {{nil, Questie.ICON_TYPE_TALK, l10n("Talk to Tal"),0,{{"monster",2995}}}},
         },
+        [26401] = { -- Return to Vestia
+            [questKeys.preQuestSingle] = {25368},
+        },
         [26408] = { -- Ashes in Ashenvale
             [questKeys.preQuestSingle] = {13897},
         },


### PR DESCRIPTION
## Issue references

Fixes #6240

## Proposed changes

- Add `preQuestSingle` to the 'Return to Vestia' quest.