### PR TITLE
[quest] Fix pre quest for 'High Priestess Jeklik'

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -4326,6 +4326,9 @@ function CataQuestFixes.Load()
         [26543] = { -- Clammy Hands
             [questKeys.exclusiveTo] = {26572,26557,26556,26588,29349,29345,29354,29346,29348,29317,29320,29361,29319,29322},
         },
+        [26553] = { -- High Priestess Jeklik
+            [questKeys.preQuestSingle] = {26552},
+        },
         [26556] = { -- No Dumping Allowed
             [questKeys.exclusiveTo] = {26572,26543,26557,26588,29349,29345,29354,29346,29348,29317,29320,29361,29319,29322},
             [questKeys.extraObjectives] = {{{[zoneIDs.ORGRIMMAR]={{37.8,81.3}}}, Questie.ICON_TYPE_NODE_FISH, l10n("Fish for Toxic Puddlefish")}},


### PR DESCRIPTION
## Issue references

Fixes #6297

## Proposed changes

- Add `preQuestSingle` to the 'High Priestess Jeklik' quest.