### PR TITLE
[quest] Fix pre-quests STV (Cata)

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -4106,6 +4106,9 @@ function CataQuestFixes.Load()
         [26337] = { -- Beating the Market
             [questKeys.objectives] = {{{42777}}},
         },
+        [26338] = { -- Population Con-Troll
+            [questKeys.preQuestSingle] = {26299},
+        },
         [26339] = { -- Staging in Brewnall
             [questKeys.preQuestSingle] = {},
             [questKeys.preQuestGroup] = {26331,26333},

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -4124,6 +4124,9 @@ function CataQuestFixes.Load()
         [26350] = { -- Priestess Hu'rala
             [questKeys.preQuestSingle] = {26334},
         },
+        [26352] = { -- Cozzle's Plan
+            [questKeys.preQuestSingle] = {26399},
+        },
         [26353] = { -- Captain Sanders' Hidden Treasure
             [questKeys.startedBy] = {{513,515,126,171,456,127,517,458,391},nil,{1357}},
             [questKeys.finishedBy] = {nil,{35}},


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #6282 
Fixes #6292  
Fixes #6293 

## Proposed changes

- Added pre-quest requirement for Population Con-Troll
- Added pre-quest requirement for Cozzle's Plan
- Added pre-quest requirement for Venture Company Mining


## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->