### PR TITLE
Add support for the default quest link format

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1335,6 +1335,7 @@ globals = {
     "GetQuestIndexForWatch",
     "GetQuestItemInfo",
     "GetQuestItemLink",
+    "GetQuestLink",
     "GetQuestLogChoiceInfo",
     "GetQuestLogCompletionText",
     "GetQuestLogIndexByID",

--- a/Modules/FramePool/QuestieFrame.lua
+++ b/Modules/FramePool/QuestieFrame.lua
@@ -174,11 +174,7 @@ function _Qframe:OnClick(button)
         if uiMapId and button == "LeftButton" then
             local frameData = self.data
             if ChatEdit_GetActiveWindow() and frameData.QuestData then
-                if Questie.db.profile.trackerShowQuestLevel then
-                    ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(frameData.QuestData.level, frameData.QuestData.name, frameData.Id))
-                else
-                    ChatEdit_InsertLink("[" .. frameData.QuestData.name .. " (" .. frameData.Id .. ")]")
-                end
+                ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(frameData.QuestData.level, frameData.QuestData.name, frameData.Id))
             else
                 if frameData.Type == "available" and IsShiftKeyDown() then
                     StaticPopupDialogs["QUESTIE_CONFIRMHIDE"]:SetQuest(frameData.Id)

--- a/Modules/Journey/QuestieSearchResults.lua
+++ b/Modules/Journey/QuestieSearchResults.lua
@@ -627,11 +627,7 @@ _HandleOnGroupSelected = function (resultType)
         local questName = QuestieDB.QueryQuestSingle(selectedId, "name")
         local questLevel, _ = QuestieLib.GetTbcLevel(selectedId);
 
-        if Questie.db.profile.trackerShowQuestLevel then
-            ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(questLevel, questName, selectedId))
-        else
-            ChatEdit_InsertLink("[" .. questName .. " (" .. selectedId .. ")]")
-        end
+        ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(questLevel, questName, selectedId))
     end
 
     -- get master frame and create scroll frame inside

--- a/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
+++ b/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
@@ -70,11 +70,7 @@ function _QuestieJourney.questsByZone:ManageTree(container, zoneTree)
 
         -- Add the quest to the open chat window if it was a shift click
         if (IsModifiedClick("CHATLINK") and ChatEdit_GetActiveWindow()) then
-            if Questie.db.profile.trackerShowQuestLevel then
-                ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(quest.level, quest.name, quest.Id))
-            else
-                ChatEdit_InsertLink("[" .. quest.name .. " (" .. quest.Id .. ")]")
-            end
+            ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(quest.level, quest.name, quest.Id))
         end
 
         _QuestieJourney:DrawQuestDetailsFrame(scrollFrame, quest)

--- a/Modules/QuestLinks/ChatFilter.lua
+++ b/Modules/QuestLinks/ChatFilter.lua
@@ -67,9 +67,9 @@ ChatFilter.Filter = function(chatFrame, _, msg, playerName, languageName, channe
                     end
 
                     if questLevel then
-                        msg = string.gsub(msg, "%[%["..questLevel.."%] "..questName.." %("..sqid.."%)%]", questLink)
+                        msg = string.gsub(k, "%[%["..questLevel.."%] "..questName.." %("..sqid.."%)%]", questLink)
                     else
-                        msg = string.gsub(msg, "%["..questName.." %("..sqid.."%)%]", questLink)
+                        msg = string.gsub(k, "%["..questName.." %("..sqid.."%)%]", questLink)
                     end
                 end
             end

--- a/Modules/QuestLinks/ChatFilter.lua
+++ b/Modules/QuestLinks/ChatFilter.lua
@@ -67,9 +67,9 @@ ChatFilter.Filter = function(chatFrame, _, msg, playerName, languageName, channe
                     end
 
                     if questLevel then
-                        msg = string.gsub(k, "%[%["..questLevel.."%] "..questName.." %("..sqid.."%)%]", questLink)
+                        msg = string.gsub(msg, "%[%["..questLevel.."%] "..questName.." %("..sqid.."%)%]", questLink)
                     else
-                        msg = string.gsub(k, "%["..questName.." %("..sqid.."%)%]", questLink)
+                        msg = string.gsub(msg, "%["..questName.." %("..sqid.."%)%]", questLink)
                     end
                 end
             end

--- a/Modules/QuestLinks/Hooks.lua
+++ b/Modules/QuestLinks/Hooks.lua
@@ -27,8 +27,8 @@ function Hooks:HookQuestLogTitle()
         end
 
         if (IsModifiedClick("CHATLINK") and ChatEdit_GetActiveWindow()) then
-            local questId = GetQuestIDFromLogIndex(questLogLineIndex)
-            ChatEdit_InsertLink("[" .. string.gsub(self:GetText(), " *(.*)", "%1") .. " (" .. questId .. ")]")
+            local title, level, _, _, _, _, _, questId = GetQuestLogTitle(questLogLineIndex)
+            ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(level, title, questId))
         else
             -- only call if we actually want to fix this quest (normal quests already call AQW_insert)
             if Questie.db.profile.trackerEnabled and GetNumQuestLeaderBoards(questLogLineIndex) == 0 and (not IsQuestWatched(questLogLineIndex)) then

--- a/Modules/QuestLinks/Hooks.lua
+++ b/Modules/QuestLinks/Hooks.lua
@@ -5,6 +5,8 @@ local Hooks = QuestieLoader:CreateModule("Hooks")
 
 ---@type QuestieTracker
 local QuestieTracker = QuestieLoader:ImportModule("QuestieTracker")
+---@type QuestieLink
+local QuestieLink = QuestieLoader:ImportModule("QuestieLink")
 
 
 function Hooks:HookQuestLogTitle()

--- a/Modules/QuestLinks/Link.lua
+++ b/Modules/QuestLinks/Link.lua
@@ -65,7 +65,14 @@ end
 
 ---@return string
 function QuestieLink:GetQuestLinkString(questLevel, questName, questId)
-    return "[["..tostring(questLevel).."] "..questName.." ("..tostring(questId)..")]"
+    local questLink = GetQuestLink and GetQuestLink(questId)
+    local questString = "["..questName.." ("..tostring(questId)..")]"
+
+    if Questie.db.profile.trackerShowQuestLevel then
+        questString = questString:gsub("%[", "[["..tostring(questLevel).."] ")
+    end
+
+    return questLink and questLink:gsub("%[(.-)%]", questString) or questString
 end
 
 ---@return string
@@ -361,7 +368,7 @@ hooksecurefunc("ChatFrame_OnHyperlinkShow", function(...)
                 local msg = ChatFrame1EditBox:GetText()
                 if msg then
                     ChatFrame1EditBox:SetText("")
-                    ChatEdit_InsertLink(string.gsub(msg, "%|Hquestie:" .. questId .. ":.*%|h", "%[%[" .. quest.level .. "%] " .. quest.name .. " %(" .. questId .. "%)%]"))
+                    ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(quest.level, quest.name, questId))
                 end
             end
         end

--- a/Modules/QuestLinks/Link.lua
+++ b/Modules/QuestLinks/Link.lua
@@ -65,14 +65,20 @@ end
 
 ---@return string
 function QuestieLink:GetQuestLinkString(questLevel, questName, questId)
-    local questLink = GetQuestLink and GetQuestLink(questId)
     local questString = "["..questName.." ("..tostring(questId)..")]"
 
     if Questie.db.profile.trackerShowQuestLevel then
         questString = questString:gsub("%[", "[["..tostring(questLevel).."] ")
     end
 
-    return questLink and questLink:gsub("%[(.-)%]", questString) or questString
+    if GetQuestLink then
+        local questLink = GetQuestLink(questId)
+        if questLink then
+            return questLink:gsub("%[(.-)%]", questString)
+        end
+    end
+
+    return questString
 end
 
 ---@return string

--- a/Modules/Tracker/TrackerLinePool.lua
+++ b/Modules/Tracker/TrackerLinePool.lua
@@ -760,11 +760,7 @@ TrackerLinePool.OnClickQuest = function(self, button)
         end
     elseif TrackerUtils:IsBindTrue(Questie.db.profile.trackerbindUntrack, button) then
         if (IsModifiedClick("CHATLINK") and ChatEdit_GetActiveWindow()) then
-            if Questie.db.profile.trackerShowQuestLevel then
-                ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(self.Quest.level, self.Quest.name, self.Quest.Id))
-            else
-                ChatEdit_InsertLink("[" .. self.Quest.name .. " (" .. self.Quest.Id .. ")]")
-            end
+            ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(self.Quest.level, self.Quest.name, self.Quest.Id))
         else
             QuestieTracker:UntrackQuestId(self.Quest.Id)
             local questLogFrame = QuestLogExFrame or ClassicQuestLog or QuestLogFrame

--- a/Modules/Tracker/TrackerMenu.lua
+++ b/Modules/Tracker/TrackerMenu.lua
@@ -204,17 +204,9 @@ TrackerMenu.addLinkToChatOption = function(menu, quest)
             LibDropDown:CloseDropDownMenus()
 
             if (not ChatFrame1EditBox:IsVisible()) then
-                if Questie.db.profile.trackerShowQuestLevel then
-                    ChatFrame_OpenChat(QuestieLink:GetQuestLinkString(quest.level, quest.name, quest.Id))
-                else
-                    ChatFrame_OpenChat("[" .. quest.name .. " (" .. quest.Id .. ")]")
-                end
+                ChatFrame_OpenChat(QuestieLink:GetQuestLinkString(quest.level, quest.name, quest.Id))
             else
-                if Questie.db.profile.trackerShowQuestLevel then
-                    ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(quest.level, quest.name, quest.Id))
-                else
-                    ChatEdit_InsertLink("[" .. quest.name .. " (" .. quest.Id .. ")]")
-                end
+                ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(quest.level, quest.name, quest.Id))
             end
         end
     })


### PR DESCRIPTION
Questie is using its own quest link format, which differs from the default format introduced in patch 3.4.0. This fix allows players who don't have Questie installed to interact with quest links generated by Questie.