### PR TITLE
[fix] Custom localization initialization fix

### DIFF
--- a/Modules/QuestieInit.lua
+++ b/Modules/QuestieInit.lua
@@ -148,6 +148,21 @@ QuestieInit.Stages = {}
 QuestieInit.Stages[1] = function() -- run as a coroutine
     Questie:Debug(Questie.DEBUG_CRITICAL, "[QuestieInit:Stage1] Starting the real init.")
 
+    if QUESTIE_LOCALES_OVERRIDE ~= nil then
+        l10n:InitializeLocaleOverride()
+    end
+
+    -- Set proper locale. Either default to client Locale or override based on user.
+    if Questie.db.global.questieLocaleDiff then
+        l10n:SetUILocale(Questie.db.global.questieLocale);
+    else
+        if QUESTIE_LOCALES_OVERRIDE ~= nil then
+            l10n:SetUILocale(QUESTIE_LOCALES_OVERRIDE.locale);
+        else
+            l10n:SetUILocale(GetLocale());
+        end
+    end
+
     local dbCompiled = false
 
     local dbIsCompiled, dbCompiledOnVersion, dbCompiledLang
@@ -375,21 +390,6 @@ function QuestieInit.OnAddonLoaded()
     MinimapIcon:Init()
 
     Questie.SetIcons()
-
-    if QUESTIE_LOCALES_OVERRIDE ~= nil then
-        l10n:InitializeLocaleOverride()
-    end
-
-    -- Set proper locale. Either default to client Locale or override based on user.
-    if Questie.db.global.questieLocaleDiff then
-        l10n:SetUILocale(Questie.db.global.questieLocale);
-    else
-        if QUESTIE_LOCALES_OVERRIDE ~= nil then
-            l10n:SetUILocale(QUESTIE_LOCALES_OVERRIDE.locale);
-        else
-            l10n:SetUILocale(GetLocale());
-        end
-    end
 
     Migration:Migrate()
 


### PR DESCRIPTION
## Issue

When locales initialized on ADDON_LOADED event, QUESTIE_LOCALES_OVERRIDE variable is not set by localization addon, as it is not loaded yet.

## Proposed changes

- Move locale initialization to PLAYER_LOGIN stages. 

It may increase load time only if QUESTIE_LOCALES_OVERRIDE is set and l10n:InitializeLocaleOverride() is called, so seems like no impact for most users with that.