### PR TITLE
Fix for non-string calls to GetTooltip

### DIFF
--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -201,6 +201,11 @@ function QuestieTooltips.GetTooltip(key)
         return nil -- temporary disable tooltips in raids, we should make a proper fix
     end
 
+    -- Something calls this method with table, perhaps a bad interaction with Plater? /tanoh 2024-08-29
+    if type(key) ~= "string" then
+        return nil
+    end
+
     local isObjectTooltip = key:sub(1, 2) == "o_"
     if isObjectTooltip then
         local objectIsInCurrentZone = false


### PR DESCRIPTION
## Proposed changes

Make sure `GetTooltip` argument is a string before trying to call `sub` on it. Looks like it is due to interaction with Plater that is causing it. I always get this error whenever a hostile nameplate is shown. This fix fixes it by making sure that the argument is a string.

You could argue that Plater should be fixed as well, which might be true but Questie shouldn't break either if sent arguments it can't handle.

## Screenshots
![image](https://github.com/user-attachments/assets/4e8bbda6-cb86-4164-bacf-5fd2e0e47677)
