### PR TITLE
[quest] 24463 Probing into Ashenvale

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -2521,6 +2521,7 @@ function CataQuestFixes.Load()
         },
         [24463] = { -- Probing into Ashenvale
             [questKeys.preQuestSingle] = {24439},
+            [questKeys.exclusiveTo] = {13612,13866,28493},
         },
         [24467] = { -- Fade to Black
             [questKeys.preQuestSingle] = {14391},


### PR DESCRIPTION
Added 3 quests that make this quest unavailable.

Source: https://www.wowhead.com/cata/quest=24463/probing-into-ashenvale#comments:id=1644184

## Issue references

Fixes #6476 
