### PR TITLE
[quest] Add 25533 Pirate Accuracy Increasing

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3824,6 +3824,9 @@ function CataQuestFixes.Load()
             [questKeys.preQuestSingle] = {25505},
             [questKeys.requiredSourceItems] = {54821},
         },
+        [25533] = { -- Pirate Accuracy Increasing
+            [questKeys.preQuestGroup] = {25516,25518,25526},
+        },
         [25534] = { -- Going Off-Task [Horde]
             [questKeys.exclusiveTo] = {};
         },

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -3825,6 +3825,7 @@ function CataQuestFixes.Load()
             [questKeys.requiredSourceItems] = {54821},
         },
         [25533] = { -- Pirate Accuracy Increasing
+            [questKeys.preQuestSingle] = {},
             [questKeys.preQuestGroup] = {25516,25518,25526},
         },
         [25534] = { -- Going Off-Task [Horde]


### PR DESCRIPTION
Add 3 prerequisite quests that all need to be completed before.

Alliance version still needs to be done.
See here: https://github.com/Questie/Questie/issues/6490