### PR TITLE
[quest] Roll the Bones - removed unnecessary prequest

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -2844,7 +2844,7 @@ function CataQuestFixes.Load()
         },
         [24730] = { -- Roll the Bones
             [questKeys.preQuestSingle] = {},
-        }
+        },
         [24733] = { -- The Bait for Lar'korwi
             [questKeys.requiredSourceItems] = {11569,11570},
         },

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -2788,6 +2788,9 @@ function CataQuestFixes.Load()
         [24691] = { -- Peculiar Delicacies
             [questKeys.preQuestSingle] = {24690},
         },
+        [24698] = { -- Adventures in Archaeology
+            [questKeys.nextQuestInChain] = 24730,
+        },
         [24702] = { -- Here Lies Dadanga
             [questKeys.specialFlags] = specialFlags.REPEATABLE,
         },
@@ -2839,6 +2842,9 @@ function CataQuestFixes.Load()
             [questKeys.preQuestSingle] = {24695},
             [questKeys.specialFlags] = specialFlags.REPEATABLE,
         },
+        [24730] = { -- Roll the Bones
+            [questKeys.preQuestSingle] = {},
+        }
         [24733] = { -- The Bait for Lar'korwi
             [questKeys.requiredSourceItems] = {11569,11570},
         },


### PR DESCRIPTION
Made the former prerequisiste quest a breadcrumb quest instead.

## Issue references

Fixes #6507 