### PR TITLE
[db] Amulet of Allistarj / Grol - fix drop issues

### DIFF
--- a/Database/Corrections/QuestieNPCBlacklist.lua
+++ b/Database/Corrections/QuestieNPCBlacklist.lua
@@ -6,6 +6,8 @@ local QuestieCorrections = QuestieLoader:ImportModule("QuestieCorrections")
 ---@return table<NpcId, boolean>
 function QuestieNPCBlacklist:Load()
     return {
+        [3032] =  QuestieCorrections.CATA_HIDE, -- Beram Skychaser
+        [7666] =  QuestieCorrections.CATA_HIDE, -- Archmage Allistarj
         [8001] = true,
         [13151] = QuestieCorrections.CLASSIC_HIDE, -- Syndicate Master Ryson
         [13153] = QuestieCorrections.CLASSIC_HIDE, -- Commander Mulfort
@@ -18,7 +20,6 @@ function QuestieNPCBlacklist:Load()
         [15799] = QuestieCorrections.CLASSIC_HIDE, -- Colossus Researcher Eazel (AQ Opening event)
         [17544] = true, -- M'uru in Silvermoon City removed starting with SWP patch
         [21155] = true, -- Bloodelf War Effort Recruiter
-        [178420] =  QuestieCorrections.WOTLK_HIDE + QuestieCorrections.CATA_HIDE, -- removed in WotLK
-        [3032] =  QuestieCorrections.CATA_HIDE, -- removed in Cata
+        [178420] =  QuestieCorrections.WOTLK_HIDE + QuestieCorrections.CATA_HIDE,        
     }
 end

--- a/Database/Corrections/cataItemFixes.lua
+++ b/Database/Corrections/cataItemFixes.lua
@@ -61,6 +61,9 @@ function CataItemFixes.Load()
         [10458] = { -- Prayer to Elune
             [itemKeys.npcDrops] = {},
         },
+        [10754] = { -- The Amulet of Sevine
+            [itemKeys.npcDrops] = {41265},
+        },
         [11114] = { -- Dinosaur Bone
             [itemKeys.npcDrops] = {6501,6502,6503,6504,9162,9163,9164},
         },

--- a/Database/Corrections/cataItemFixes.lua
+++ b/Database/Corrections/cataItemFixes.lua
@@ -61,6 +61,9 @@ function CataItemFixes.Load()
         [10458] = { -- Prayer to Elune
             [itemKeys.npcDrops] = {},
         },
+        [10753] = { -- Amulet of Grol
+            [itemKeys.npcDrops] = {41267},
+        },
         [10754] = { -- Amulet of Sevine
             [itemKeys.npcDrops] = {41265},
         },

--- a/Database/Corrections/cataItemFixes.lua
+++ b/Database/Corrections/cataItemFixes.lua
@@ -61,8 +61,11 @@ function CataItemFixes.Load()
         [10458] = { -- Prayer to Elune
             [itemKeys.npcDrops] = {},
         },
-        [10754] = { -- The Amulet of Sevine
+        [10754] = { -- Amulet of Sevine
             [itemKeys.npcDrops] = {41265},
+        },
+        [10755] = { -- Amulet of Allistarj
+            [itemKeys.npcDrops] = {},
         },
         [11114] = { -- Dinosaur Bone
             [itemKeys.npcDrops] = {6501,6502,6503,6504,9162,9163,9164},


### PR DESCRIPTION
Amulet of Allistarj drops from https://www.wowhead.com/cata/object=203229/allistarjian-vault now.
Amulet of Grol drops from https://www.wowhead.com/cata/npc=41267/spirit-of-grol instead of https://www.wowhead.com/cata/npc=7665/grol-the-destroyer