### PR TITLE
Add option to change delay before quest sounds

### DIFF
--- a/Localization/Translations/Options/Sounds.lua
+++ b/Localization/Translations/Options/Sounds.lua
@@ -182,10 +182,10 @@ local soundsOptionsLocales = {
         ["esES"] = false,
         ["frFR"] = false,
     },
-    ["Delay (in seconds) between the event and playing the sound."] = {
+    ["Delay (in seconds, default: %s) for playing objective progress and completion sounds. Increase this if you hear double sounds."] = {
         ["ptBR"] = false,
         ["ruRU"] = false,
-        ["deDE"] = "Verzögerung (in Sekunden) zwischen dem Ereignis und dem Abspielen des Sounds.",
+        ["deDE"] = "Verzögerung (in Sekunden, Voreinstellung: %s) beim Abspielen von Quest-Ziel-Fortschritts-Sounds. Diesen Wert erhöhen, falls Sounds doppelt abgespielt werden.",
         ["koKR"] = false,
         ["esMX"] = false,
         ["enUS"] = true,

--- a/Localization/Translations/Options/Sounds.lua
+++ b/Localization/Translations/Options/Sounds.lua
@@ -170,6 +170,30 @@ local soundsOptionsLocales = {
         ["esES"] = "El sonido que escuchas cuando avanzas en un objetivo de misión",
         ["frFR"] = "Le son que vous entendez lorsque vous progressez sur un objectif de quête",
     },
+    ["Sound Delay"] = {
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["deDE"] = "Sound-Verzögerung",
+        ["koKR"] = false,
+        ["esMX"] = false,
+        ["enUS"] = true,
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+        ["esES"] = false,
+        ["frFR"] = false,
+    },
+    ["Delay (in seconds) between the event and playing the sound."] = {
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["deDE"] = "Verzögerung (in Sekunden) zwischen dem Ereignis und dem Abspielen des Sounds.",
+        ["koKR"] = false,
+        ["esMX"] = false,
+        ["enUS"] = true,
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+        ["esES"] = false,
+        ["frFR"] = false,
+    },
 }
 
 for k, v in pairs(soundsOptionsLocales) do

--- a/Localization/Translations/Options/Sounds.lua
+++ b/Localization/Translations/Options/Sounds.lua
@@ -170,10 +170,10 @@ local soundsOptionsLocales = {
         ["esES"] = "El sonido que escuchas cuando avanzas en un objetivo de misión",
         ["frFR"] = "Le son que vous entendez lorsque vous progressez sur un objectif de quête",
     },
-    ["Sound Delay"] = {
+    ["Progress Sound Delay"] = {
         ["ptBR"] = false,
         ["ruRU"] = false,
-        ["deDE"] = "Sound-Verzögerung",
+        ["deDE"] = "Fortschritts-Sound-Verzögerung",
         ["koKR"] = false,
         ["esMX"] = false,
         ["enUS"] = true,

--- a/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
+++ b/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
@@ -613,7 +613,7 @@ function QuestieOptions.tabs.general:Initialize()
                         type = "range",
                         order = 10.0,
                         name = function() return l10n('Progress Sound Delay'); end,
-                        desc = function() return l10n('Delay (in seconds) between the event and playing the sound.'); end,
+                        desc = function() return l10n('Delay (in seconds, default: %s) for playing objective progress and completion sounds. Increase this if you hear double sounds.', optionsDefaults.profile.soundDelay); end,
                         width = 1.4,
                         min = 0.0,
                         max = 1.0,

--- a/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
+++ b/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
@@ -609,6 +609,20 @@ function QuestieOptions.tabs.general:Initialize()
                             Questie.db.profile.objectiveProgressSoundChoiceName = value
                         end,
                     },
+                    soundDelay = {
+                        type = "range",
+                        order = 10.0,
+                        name = function() return l10n('Sound Delay'); end,
+                        desc = function() return l10n('Delay (in seconds) between the event and playing the sound.'); end,
+                        width = 1.4,
+                        min = 0.0,
+                        max = 1.0,
+                        step = 0.01,
+                        get = function(info) return QuestieOptions:GetProfileValue(info); end,
+                        set = function (info, value)
+                            QuestieOptions:SetProfileValue(info, value)
+                        end,
+                    },
                 },
             },
         },

--- a/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
+++ b/Modules/Options/GeneralTab/QuestieOptionsGeneral.lua
@@ -612,7 +612,7 @@ function QuestieOptions.tabs.general:Initialize()
                     soundDelay = {
                         type = "range",
                         order = 10.0,
-                        name = function() return l10n('Sound Delay'); end,
+                        name = function() return l10n('Progress Sound Delay'); end,
                         desc = function() return l10n('Delay (in seconds) between the event and playing the sound.'); end,
                         width = 1.4,
                         min = 0.0,

--- a/Modules/Options/QuestieOptionsDefaults.lua
+++ b/Modules/Options/QuestieOptionsDefaults.lua
@@ -144,6 +144,7 @@ function QuestieOptionsDefaults:Load()
             ldbDisplayText = "Questie",
             enableQuestFrameIcons = true,
             loadCustomSounds = false,
+            soundDelay = 0.5,
             soundOnQuestComplete = false,
             questCompleteSoundChoiceName = "QuestDefault",
             soundOnObjectiveComplete = false,

--- a/Modules/Sounds.lua
+++ b/Modules/Sounds.lua
@@ -4,8 +4,8 @@ local Sounds = QuestieLoader:CreateModule("Sounds")
 local LSM30 = LibStub("LibSharedMedia-3.0")
 
 local soundTable
-local shouldPlayObjectiveSound = false
 local shouldPlayObjectiveProgress = false
+local shouldPlayObjectiveComplete = false
 
 function Sounds.PlayObjectiveProgress()
     if (not Questie.db.profile.soundOnObjectiveProgress) then
@@ -14,7 +14,7 @@ function Sounds.PlayObjectiveProgress()
 
     if (not shouldPlayObjectiveProgress) then
         shouldPlayObjectiveProgress = true
-        C_Timer.After(0.5, function ()
+        C_Timer.After(Questie.db.profile.soundDelay, function ()
             if shouldPlayObjectiveProgress then
                 PlaySoundFile(Sounds.GetSelectedSoundFile(Questie.db.profile.objectiveProgressSoundChoiceName), "Master")
                 shouldPlayObjectiveProgress = false
@@ -28,12 +28,12 @@ function Sounds.PlayObjectiveComplete()
         return
     end
 
-    if (not shouldPlayObjectiveSound) then
-        shouldPlayObjectiveSound = true
-        C_Timer.After(0.5, function ()
-            if shouldPlayObjectiveSound then
+    if (not shouldPlayObjectiveComplete) then
+        shouldPlayObjectiveComplete = true
+        C_Timer.After(Questie.db.profile.soundDelay, function ()
+            if shouldPlayObjectiveComplete then
                 PlaySoundFile(Sounds.GetSelectedSoundFile(Questie.db.profile.objectiveCompleteSoundChoiceName), "Master")
-                shouldPlayObjectiveSound = false
+                shouldPlayObjectiveComplete = false
             end
         end)
     end
@@ -44,9 +44,11 @@ function Sounds.PlayQuestComplete()
         return
     end
 
-    shouldPlayObjectiveSound = false
     shouldPlayObjectiveProgress = false
-    PlaySoundFile(Sounds.GetSelectedSoundFile(Questie.db.profile.questCompleteSoundChoiceName), "Master")
+    shouldPlayObjectiveComplete = false
+    C_Timer.After(Questie.db.profile.soundDelay, function ()
+        PlaySoundFile(Sounds.GetSelectedSoundFile(Questie.db.profile.questCompleteSoundChoiceName), "Master")
+    end)
 end
 
 function Sounds.GetSelectedSoundFile(typeSelected)

--- a/Modules/Sounds.lua
+++ b/Modules/Sounds.lua
@@ -46,9 +46,7 @@ function Sounds.PlayQuestComplete()
 
     shouldPlayObjectiveProgress = false
     shouldPlayObjectiveComplete = false
-    C_Timer.After(Questie.db.profile.soundDelay, function ()
-        PlaySoundFile(Sounds.GetSelectedSoundFile(Questie.db.profile.questCompleteSoundChoiceName), "Master")
-    end)
+    PlaySoundFile(Sounds.GetSelectedSoundFile(Questie.db.profile.questCompleteSoundChoiceName), "Master")
 end
 
 function Sounds.GetSelectedSoundFile(typeSelected)


### PR DESCRIPTION
Currently, most quest sounds (objective progress, objective completion) are played with a delay of 0.5 seconds after the actual event. This delay does not feel great for short progress sounds which play noticeably after the on-screen message appears.

This PR adds an option slider to configure a custom delay time for quest sounds. Default is 0.5, as before.

![image](https://github.com/user-attachments/assets/98c4fc22-8ffd-4333-a47e-5ca9cd120e83)