### PR TITLE
Support XPerl Target for Target Frame Icon.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2812,6 +2812,7 @@ globals = {
     "TomTom",
     "LibStub",
     "SUFUnittarget",
+    "XPerl_Target",
     "ElvUF_Target",
     "AzeriteUnitFrameTarget",
     "GwTargetUnitFrame",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2761,6 +2761,7 @@
         "TomTom",
         "LibStub",
         "SUFUnittarget",
+        "XPerl_Target",
         "ElvUF_Target",
         "AzeriteUnitFrameTarget",
         "PitBull4_Frames_Target",

--- a/Modules/QuestieNameplate.lua
+++ b/Modules/QuestieNameplate.lua
@@ -240,6 +240,8 @@ function _QuestieNameplate.GetTargetFrameIconFrame()
     elseif SUFUnittarget then
         targetFrame = SUFUnittarget
         frame:SetFrameLevel(SUFUnittarget:GetFrameLevel() + 1)
+    elseif XPerl_Target then
+        targetFrame = XPerl_Target
     end
 
     frame:SetParent(targetFrame)


### PR DESCRIPTION
Support target frame from XPerl addon (https://github.com/Resike/Z-Perl, https://www.curseforge.com/wow/addons/zperl) for Target Frame Icon option.