### PR TITLE
Feralas quest fix - Darkmist Legacy and Ancient Suffering

### DIFF
--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -15592,6 +15592,14 @@ function CataQuestFixes:LoadFactionFixes()
         [24911] = { -- Tropical Paradise Beckons
             [questKeys.startedBy] = {{38578}},
         },
+        [25422] = { -- The Darkmist Legacy
+            [questKeys.exclusiveTo] = {},
+            [questKeys.preQuestSingle] = {25350},
+        },
+        [25423] = { -- Ancient Suffering
+            [questKeys.exclusiveTo] = {},
+            [questKeys.preQuestSingle] = {25350},
+        },
         [25513] = { -- Thunderdrome: Grudge Match!
             [questKeys.preQuestGroup] = {25065,25095},
         },

--- a/Database/Corrections/cataQuestFixes.lua
+++ b/Database/Corrections/cataQuestFixes.lua
@@ -5548,11 +5548,9 @@ function CataQuestFixes.Load()
             [questKeys.preQuestSingle] = {},
         },
         [25422] = { -- The Darkmist Legacy
-            [questKeys.preQuestSingle] = {25350},
             [questKeys.exclusiveTo] = {},
         },
         [25423] = { -- Ancient Suffering
-            [questKeys.preQuestSingle] = {25350},
             [questKeys.exclusiveTo] = {},
         },
         [25429] = { -- Zukk'ash Infestation


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #

## Proposed changes

- Alliance only quest is marked as prequest for quests available to both factions
- Removing general prequest requirement
- Adding Alliance specific prequest requirement

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->
Confirmed as prequest for Alliance
Confirmed available without prequest on Horde
![image](https://github.com/user-attachments/assets/98d5254c-3605-4d55-885d-df7bf23f2225)
