### PR TITLE
[feature] Add toggle for non quest icons

### DIFF
--- a/Localization/Translations/MinimapIcon/MinimapIcon.lua
+++ b/Localization/Translations/MinimapIcon/MinimapIcon.lua
@@ -26,6 +26,18 @@ local minimapIconLocales = {
         ["zhCN"] = "启动Questie",
         ["zhTW"] = "顯示/隱藏任務位置提示",
     },
+    ["Toggle Non-Quests"] = {
+        ["enUS"] = true,
+        ["deDE"] = false,
+        ["esES"] = false,
+        ["esMX"] = false,
+        ["frFR"] = false,
+        ["koKR"] = false,
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+    },
     ["Toggle My Journey"] = {
         ["enUS"] = true,
         ["deDE"] = "Meine Reise zeigen/verstecken",

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -107,6 +107,30 @@ function QuestieQuest:ToggleNotes(showIcons)
     end
 end
 
+function QuestieQuest:ToggleNonQuestIcons()
+    for typ, frameTypeList in pairs(QuestieMap.manualFrames) do
+        for _, frameList in pairs(frameTypeList) do
+            for _, frameName in ipairs(frameList) do
+                local frame = _G[frameName]
+                if frame then
+                    if Questie.db.profile.hideNonQuestIcons then
+                        frame.shouldBeShowing = frame:IsShown()
+                        frame:Hide()
+                        frame.hidden = true
+                    else
+                        if frame.hidden then
+                            frame.hidden = false
+                            if frame.shouldBeShowing then
+                                frame:SetShown(true)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
 function _QuestieQuest:ShowQuestIcons()
     local trackerHiddenQuests = Questie.db.char.TrackerHiddenQuests
     for questId, frameList in pairs(QuestieMap.questIdFrames) do

--- a/Modules/WorldMapButton/WorldMapButton.lua
+++ b/Modules/WorldMapButton/WorldMapButton.lua
@@ -38,7 +38,10 @@ QuestieWorldMapButtonMixin = {
     OnLoad = function() end,
     OnHide = function() end,
     OnMouseDown = function(_, button)
-        if button == "LeftButton" then
+        if button == "LeftButton" and IsShiftKeyDown() then
+            Questie.db.profile.hideNonQuestIcons = (not Questie.db.profile.hideNonQuestIcons)
+            QuestieQuest:ToggleNonQuestIcons()
+        elseif button == "LeftButton" then
             Questie.db.profile.enabled = (not Questie.db.profile.enabled)
             QuestieQuest:ToggleNotes(Questie.db.profile.enabled)
         elseif button == "RightButton" then
@@ -56,6 +59,7 @@ QuestieWorldMapButtonMixin = {
         GameTooltip:AddLine("Questie ".. QuestieLib:GetAddonVersionString(), 1, 1, 1)
         GameTooltip:AddLine(Questie:Colorize(l10n('Left Click') , 'gray') .. ": ".. l10n('Toggle Questie'))
         GameTooltip:AddLine(Questie:Colorize(l10n('Right Click') , 'gray') .. ": ".. l10n('Toggle Menu'))
+        GameTooltip:AddLine(Questie:Colorize(l10n('Shift + Left Click'), 'gray') .. ": ".. l10n('Toggle Non-Quests'))
         GameTooltip:Show()
     end,
     OnLeave = function() end,


### PR DESCRIPTION
## Issue references

Fixes #7163

## Proposed changes

- Add shortcut on world map to toggle non quest icons for better visibility

## Screenshots
<img width="672" height="583" alt="image" src="https://github.com/user-attachments/assets/0254eb2c-2d46-4f54-ba26-f22e0879f28e" />
<img width="677" height="703" alt="image" src="https://github.com/user-attachments/assets/bbb7792d-4180-4f6e-afe8-90d0e2240c59" />
