### PR TITLE
[feature] Add hiding quest tracker during pet battles

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -532,6 +532,7 @@ globals = {
     "C_PaperDollInfo.OffhandHasWeapon",
     "C_PartyInfo.GetActiveCategories",
     "C_PartyInfo.GetInviteConfirmationInvalidQueues",
+    "C_PetBattles",
     "C_PlayerInfo.GetClass",
     "C_PlayerInfo.GetName",
     "C_PlayerInfo.GetRace",

--- a/Localization/Translations/Options/Tracker.lua
+++ b/Localization/Translations/Options/Tracker.lua
@@ -353,6 +353,31 @@ local trackerOptionsLocales = {
         ["zhTW"] = "啟用時，進入地城後會自動將任務清單最小化。",
     },
     ---------------------------------------------------------
+    ["Minimize In Pet Battles"] = {
+        ["enUS"] = true,
+        ["deDE"] = false,
+        ["esES"] = false,
+        ["esMX"] = false,
+        ["frFR"] = false,
+        ["koKR"] = false,
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+    },
+    ["When this is checked, the Questie Tracker will automatically be hidden when entering a pet battle."] = {
+        ["enUS"] = true,
+        ["deDE"] = false,
+        ["esES"] = false,
+        ["esMX"] = false,
+        ["frFR"] = false,
+        ["koKR"] = false,
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+    },
+    ---------------------------------------------------------
     ["Fade Min/Max Buttons"] = {
         ["enUS"] = true,
         ["deDE"] = "Min/Max ausblenden",

--- a/Modules/EventHandler/EventHandler.lua
+++ b/Modules/EventHandler/EventHandler.lua
@@ -190,7 +190,7 @@ function EventHandler:RegisterLateEvents()
     end)
 
     -- Pet Battle Events (MoP and later)
-    if Expansions.Current >= Expansions.MoP and C_PetBattles then
+    if Expansions.Current >= Expansions.MoP then
         Questie:RegisterEvent("PET_BATTLE_OPENING_START", function()
             Questie:Debug(Questie.DEBUG_DEVELOP, "[EVENT] PET_BATTLE_OPENING_START")
             if Questie.db.profile.trackerEnabled then

--- a/Modules/EventHandler/EventHandler.lua
+++ b/Modules/EventHandler/EventHandler.lua
@@ -207,12 +207,12 @@ function EventHandler:RegisterLateEvents()
 
         Questie:RegisterEvent("PET_BATTLE_CLOSE", function()
             Questie:Debug(Questie.DEBUG_DEVELOP, "[EVENT] PET_BATTLE_CLOSE")
-            if Questie.db.profile.trackerEnabled and Questie.db.profile.hideTrackerInPetBattles and trackerMinimizedByPetBattle then
+            if Questie.db.profile.trackerEnabled then
                 trackerMinimizedByPetBattle = false
 
                 QuestieCombatQueue:Queue(function()
                     local baseFrame = TrackerBaseFrame.baseFrame
-                    if baseFrame then
+                    if baseFrame and not baseFrame:IsShown() then
                         baseFrame:Show()
                         QuestieTracker:Update()
                     end

--- a/Modules/EventHandler/EventHandler.lua
+++ b/Modules/EventHandler/EventHandler.lua
@@ -58,7 +58,7 @@ local questAcceptedMessage = string.gsub(ERR_QUEST_ACCEPTED_S, "(%%s)", "(.+)")
 local questCompletedMessage = string.gsub(ERR_QUEST_COMPLETE_S, "(%%s)", "(.+)")
 
 local trackerMinimizedByDungeon = false
-local trackerMinimizedByPetBattle = false
+
 
 --* Calculated in _EventHandler:PlayerLogin()
 ---en/br/es/fr/gb/it/mx: "You are now %s with %s." (e.g. "You are now Honored with Stormwind."), all other languages are very alike
@@ -196,8 +196,6 @@ function EventHandler:RegisterLateEvents()
             if Questie.db.profile.trackerEnabled and Questie.db.profile.hideTrackerInPetBattles then
                 local baseFrame = TrackerBaseFrame.baseFrame
                 if baseFrame and baseFrame:IsShown() then
-                    trackerMinimizedByPetBattle = true
-
                     QuestieCombatQueue:Queue(function()
                         baseFrame:Hide()
                     end)
@@ -208,8 +206,6 @@ function EventHandler:RegisterLateEvents()
         Questie:RegisterEvent("PET_BATTLE_CLOSE", function()
             Questie:Debug(Questie.DEBUG_DEVELOP, "[EVENT] PET_BATTLE_CLOSE")
             if Questie.db.profile.trackerEnabled then
-                trackerMinimizedByPetBattle = false
-
                 QuestieCombatQueue:Queue(function()
                     local baseFrame = TrackerBaseFrame.baseFrame
                     if baseFrame and not baseFrame:IsShown() then

--- a/Modules/EventHandler/EventHandler.lua
+++ b/Modules/EventHandler/EventHandler.lua
@@ -189,11 +189,11 @@ function EventHandler:RegisterLateEvents()
         end
     end)
 
-    -- Pet Battle Events (MoP and later)
+    -- Pet Battle Events (MoP onwards)
     if Expansions.Current >= Expansions.MoP then
         Questie:RegisterEvent("PET_BATTLE_OPENING_START", function()
             Questie:Debug(Questie.DEBUG_DEVELOP, "[EVENT] PET_BATTLE_OPENING_START")
-            if Questie.db.profile.trackerEnabled then
+            if Questie.db.profile.trackerEnabled and Questie.db.profile.hideTrackerInPetBattles then
                 local baseFrame = TrackerBaseFrame.baseFrame
                 if baseFrame and baseFrame:IsShown() then
                     trackerMinimizedByPetBattle = true
@@ -207,7 +207,7 @@ function EventHandler:RegisterLateEvents()
 
         Questie:RegisterEvent("PET_BATTLE_CLOSE", function()
             Questie:Debug(Questie.DEBUG_DEVELOP, "[EVENT] PET_BATTLE_CLOSE")
-            if Questie.db.profile.trackerEnabled and trackerMinimizedByPetBattle then
+            if Questie.db.profile.trackerEnabled and Questie.db.profile.hideTrackerInPetBattles and trackerMinimizedByPetBattle then
                 trackerMinimizedByPetBattle = false
 
                 QuestieCombatQueue:Queue(function()

--- a/Modules/Options/QuestieOptionsDefaults.lua
+++ b/Modules/Options/QuestieOptionsDefaults.lua
@@ -79,6 +79,7 @@ function QuestieOptionsDefaults:Load()
             stickyDurabilityFrame = false,
             hideTrackerInCombat = false,
             hideTrackerInDungeons = true,
+            hideTrackerInPetBattles = true,
             trackerFadeMinMaxButtons = false,
             trackerFadeQuestItemButtons = false,
             trackerBackdropEnabled = false,

--- a/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
+++ b/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
@@ -402,9 +402,32 @@ function QuestieOptions.tabs.tracker:Initialize()
                             end
                         end
                     },
-                    fadeMinMaxButtons = {
+                    minimizeInPetBattles = {
                         type = "toggle",
                         order = 3,
+                        width = 1.5,
+                        name = function() return l10n("Minimize In Pet Battles") end,
+                        desc = function() return l10n("When this is checked, the Questie Tracker will automatically be hidden when entering a pet battle.") end,
+                        disabled = function() return not Questie.db.profile.trackerEnabled end,
+                        get = function() return Questie.db.profile.hideTrackerInPetBattles end,
+                        set = function(_, value)
+                            Questie.db.profile.hideTrackerInPetBattles = value
+                            if C_PetBattles and C_PetBattles.IsInBattle() then
+                                local baseFrame = TrackerBaseFrame.baseFrame
+                                if baseFrame then
+                                    if value then
+                                        baseFrame:Hide()
+                                    else
+                                        baseFrame:Show()
+                                        QuestieTracker:Update()
+                                    end
+                                end
+                            end
+                        end
+                    },
+                    fadeMinMaxButtons = {
+                        type = "toggle",
+                        order = 4,
                         width = 1.5,
                         name = function() return l10n("Fade Min/Max Buttons") end,
                         desc = function() return l10n("When this is checked, the Minimize and Maximize Buttons will fade and become transparent when not in use.") end,
@@ -440,7 +463,7 @@ function QuestieOptions.tabs.tracker:Initialize()
                     },
                     fadeQuestItemButtons = {
                         type = "toggle",
-                        order = 4,
+                        order = 5,
                         width = 1.5,
                         name = function() return l10n("Fade Quest Item Buttons") end,
                         desc = function() return l10n("When this is checked, the Quest Item Buttons will fade and become transparent when not in use.") end,
@@ -476,7 +499,7 @@ function QuestieOptions.tabs.tracker:Initialize()
                     },
                     hideSizer = {
                         type = "toggle",
-                        order = 5,
+                        order = 6,
                         width = 1.5,
                         name = function() return l10n("Hide Tracker Sizer") end,
                         desc = function() return l10n("When this is checked, the Questie Tracker Sizer that appears in the bottom or top right hand corner will be hidden.") end,
@@ -489,7 +512,7 @@ function QuestieOptions.tabs.tracker:Initialize()
                     },
                     lockTracker = {
                         type = "toggle",
-                        order = 6,
+                        order = 7,
                         width = 1.5,
                         name = function() return l10n("Lock Tracker") end,
                         desc = function() return l10n("When this is checked, the Questie Tracker is locked and you need to hold CTRL when you want to move it.") end,
@@ -502,7 +525,7 @@ function QuestieOptions.tabs.tracker:Initialize()
                     },
                     stickyDurabilityFrame = {
                         type = "toggle",
-                        order = 7,
+                        order = 8,
                         width = 1.5,
                         name = function() return l10n("Sticky Durability Frame") end,
                         desc = function() return l10n("When this is checked, the durability frame will be placed on the left or right side of the Questie Tracker depending on where the Tracker is placed on your screen.") end,
@@ -518,7 +541,7 @@ function QuestieOptions.tabs.tracker:Initialize()
                     },
                     stickyVoiceOverFrame = {
                         type = "toggle",
-                        order = 8,
+                        order = 9,
                         width = 1.5,
                         name = function() return l10n("Sticky VoiceOver Frame") end,
                         desc = function() return l10n("When this is checked, the VoiceOver talking head / sound queue frame will be placed on the left or right side of the Questie Tracker depending on where the Tracker is placed on your screen.") end,

--- a/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
+++ b/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
@@ -412,6 +412,17 @@ function QuestieOptions.tabs.tracker:Initialize()
                         get = function() return Questie.db.profile.hideTrackerInPetBattles end,
                         set = function(_, value)
                             Questie.db.profile.hideTrackerInPetBattles = value
+                            if C_PetBattles and C_PetBattles.IsInBattle() then
+                                local baseFrame = TrackerBaseFrame.baseFrame
+                                if baseFrame then
+                                    if value then
+                                        baseFrame:Hide()
+                                    else
+                                        baseFrame:Show()
+                                        QuestieTracker:Update()
+                                    end
+                                end
+                            end
                         end
                     },
                     fadeMinMaxButtons = {

--- a/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
+++ b/Modules/Options/TrackerTab/QuestieOptionsTracker.lua
@@ -412,17 +412,6 @@ function QuestieOptions.tabs.tracker:Initialize()
                         get = function() return Questie.db.profile.hideTrackerInPetBattles end,
                         set = function(_, value)
                             Questie.db.profile.hideTrackerInPetBattles = value
-                            if C_PetBattles and C_PetBattles.IsInBattle() then
-                                local baseFrame = TrackerBaseFrame.baseFrame
-                                if baseFrame then
-                                    if value then
-                                        baseFrame:Hide()
-                                    else
-                                        baseFrame:Show()
-                                        QuestieTracker:Update()
-                                    end
-                                end
-                            end
                         end
                     },
                     fadeMinMaxButtons = {


### PR DESCRIPTION
## Issue references

Fixes #7035

## Proposed changes

- When a user enters a pet battle, the tracker will now be hidden by default as this overlaps UI elements, and is unnecessary to show while in a pet battle.

## Screenshots

<img width="753" height="244" alt="image" src="https://github.com/user-attachments/assets/1477bc86-88dc-42a3-bbc5-92a01fc31863" />
