### PR TITLE
[feature] Add dungeon names alongside quests

### DIFF
--- a/Database/Zones/zoneDB.lua
+++ b/Database/Zones/zoneDB.lua
@@ -126,7 +126,6 @@ function ZoneDB:GetAreaIdByUiMapId(uiMapId)
     end
 end
 
-
 ---@param areaId AreaId
 ---@return AreaCoordinate?
 function ZoneDB:GetDungeonLocation(areaId)
@@ -137,6 +136,21 @@ function ZoneDB:GetDungeonLocation(areaId)
         local alternativeDungeonAreaId = alternativeDungeonAreaIdToDungeonAreaId[areaId]
         if alternativeDungeonAreaId then
             return dungeons[alternativeDungeonAreaId][4]
+        end
+    end
+    return nil
+end
+
+---@param areaId AreaId
+---@return string?
+function ZoneDB:GetDungeonName(areaId)
+    local dungeon = dungeons[areaId]
+    if dungeon then
+        return dungeon[1]
+    else
+        local alternativeDungeonAreaId = alternativeDungeonAreaIdToDungeonAreaId[areaId]
+        if alternativeDungeonAreaId then
+            return dungeons[alternativeDungeonAreaId][1]
         end
     end
     return nil

--- a/Localization/Translations/TrackerUI.lua
+++ b/Localization/Translations/TrackerUI.lua
@@ -509,6 +509,18 @@ local trackerUILocales = {
         ["zhCN"] = "暴雪计时器启动！",
         ["zhTW"] = "暴雪計時器啟動！",
     },
+    ["Dungeon"] = {
+        ["enUS"] = true,
+        ["deDE"] = false,
+        ["esES"] = false,
+        ["esMX"] = false,
+        ["frFR"] = false,
+        ["koKR"] = false,
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+    },
 }
 
 for k, v in pairs(trackerUILocales) do

--- a/Modules/Tooltips/MapIconTooltip.lua
+++ b/Modules/Tooltips/MapIconTooltip.lua
@@ -21,6 +21,8 @@ local QuestieComms = QuestieLoader:ImportModule("QuestieComms")
 local l10n = QuestieLoader:ImportModule("l10n")
 ---@type QuestXP
 local QuestXP = QuestieLoader:ImportModule("QuestXP")
+---@type ZoneDB
+local ZoneDB = QuestieLoader:ImportModule("ZoneDB")
 
 local HBDPins = LibStub("HereBeDragonsQuestie-Pins-2.0")
 local GetCoinTextureString = C_CurrencyInfo.GetCoinTextureString or GetCoinTextureString
@@ -241,7 +243,16 @@ function MapIconTooltip:Show()
                             self:AddDoubleLine(TRANSPARENT_ICON_TEXTURE .. " " .. questData.title, rewardString, 1, 1, 1, 1, 1, 0);
                         end
                     end
-                end
+                    -- Add dungeon information if this is a dungeon quest
+                    if shift and quest then
+                        local zoneOrSort = quest.zoneOrSort
+                        if zoneOrSort and zoneOrSort > 0 then
+                            local dungeonName = ZoneDB:GetDungeonName(zoneOrSort)
+                            if dungeonName then
+                                self:AddLine("  " .. l10n("Dungeon") .. ": " .. dungeonName, 0.7, 0.7, 0.7)
+                            end
+                        end
+                    end
                 if questData.subData and shift then
                     local dataType = type(questData.subData)
                     if dataType == "table" then
@@ -322,6 +333,18 @@ function MapIconTooltip:Show()
 
             -- Used to get the white color for the quests which don't have anything to collect
             local defaultQuestColor = QuestieLib:GetRGBForObjective({})
+
+            -- Add what dungeon this is in if this is a dungeon quest
+            if shift and quest then
+                local zoneOrSort = quest.zoneOrSort
+                if zoneOrSort and zoneOrSort > 0 then
+                    local dungeonName = ZoneDB:GetDungeonName(zoneOrSort)
+                    if dungeonName then
+                        self:AddLine("   " .. l10n("Dungeon") .. ": " .. dungeonName, 0.7, 0.7, 0.7)
+                    end
+                end
+            end
+
             if shift then
                 local creatureLevels = QuestieDB:GetCreatureLevels(quest) -- Data for min and max level
                 local addedCreatureNames = {}


### PR DESCRIPTION
## Issue references

Fixes #6953

## Proposed changes

- Add ability to see what dungeon is associated with a quest when holding shift and hovering over a quest on the map.

## Screenshots

