### PR TITLE
[feature] Detect character re-creation to reset My Journey data

### DIFF
--- a/Localization/Translations/Journey/MyJourney.lua
+++ b/Localization/Translations/Journey/MyJourney.lua
@@ -338,6 +338,18 @@ local myJourneyLocales = {
         ["zhCN"] = "笔记删除成功",
         ["zhTW"] = "筆記刪除成功",
     },
+    ["Character re-creation detected, resetting Journey data."] = {
+        ["enUS"] = true,
+        ["deDE"] = "Charakter-Neuerstellung erkannt, \"Meine Reise\"-Daten werden zurückgesetzt.",
+        ["esES"] = false,
+        ["esMX"] = false,
+        ["frFR"] = false,
+        ["koKR"] = false,
+        ["ptBR"] = false,
+        ["ruRU"] = false,
+        ["zhCN"] = false,
+        ["zhTW"] = false,
+    }
 }
 
 for k, v in pairs(myJourneyLocales) do

--- a/Modules/Journey/QuestieJourney.lua
+++ b/Modules/Journey/QuestieJourney.lua
@@ -55,6 +55,19 @@ local questCategoryKeys = {
 }
 QuestieJourney.questCategoryKeys = questCategoryKeys
 
+-- Detect character re-creation and ask user about journey reset
+local function checkForCharacterRecreation()
+    local guid = UnitGUID("player") -- this is unique per character
+    if (not Questie.db.char.guid) then
+        -- First login for this character
+        Questie.db.char.guid = guid
+    elseif (Questie.db.char.guid ~= guid) then
+        -- Character re-created, ask user about journey reset
+        Questie:Print(l10n("Character re-creation detected, resetting \"My Journey\" data."))
+        Questie.db.char.journey = {}
+        Questie.db.char.guid = guid
+    end
+end
 
 function QuestieJourney:Initialize()
     local continents = {}
@@ -72,6 +85,8 @@ function QuestieJourney:Initialize()
     end
     coroutine.yield()
     continents[questCategoryKeys.CLASS] = QuestiePlayer:GetLocalizedClassName()
+
+    checkForCharacterRecreation()
 
     coroutine.yield()
     self.continents = continents


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #

## Proposed changes

- When a user re-creates a character with the same name, Questie detects this and resets the "My Journey" data
