### PR TITLE
Update MinimapIcon.lua

### DIFF
--- a/Modules/MinimapIcon.lua
+++ b/Modules/MinimapIcon.lua
@@ -35,18 +35,19 @@ function _MinimapIcon:CreateDataBrokerObject()
 
         OnClick = _MinimapIcon.OnClick,
 
+        ---@param tooltip any
         OnTooltipShow = function (tooltip)
-            tooltip:AddDoubleLine("Questie", Questie:Colorize(QuestieLib:GetAddonVersionString(),'gray'), 1, 0.82, 0, 1, 1, 1)
+            tooltip:AddDoubleLine(Questie:Colorize("Questie", 'gold'), Questie:Colorize(QuestieLib:GetAddonVersionString(), 'gray'))
             tooltip:AddLine(" ")
-            tooltip:AddDoubleLine(Questie:Colorize(l10n('Left Click'), 'lightBlue'), (Questie:Colorize(l10n('Toggle My Journey'), 'white')))
-            tooltip:AddDoubleLine(Questie:Colorize(l10n('Right Click'), 'lightBlue'), (Questie:Colorize(l10n('Toggle Menu'), 'white')))
+            tooltip:AddDoubleLine(Questie:Colorize(l10n('Left Click'), 'lightBlue'), Questie:Colorize(l10n('Toggle My Journey'), 'white'))
+            tooltip:AddDoubleLine(Questie:Colorize(l10n('Right Click'), 'lightBlue'), Questie:Colorize(l10n('Toggle Menu'), 'white'))
             tooltip:AddLine(" ")
-            tooltip:AddDoubleLine(Questie:Colorize(l10n('Shift + Left Click'), 'lightBlue'), (Questie:Colorize(l10n('Questie Options'), 'white')))
+            tooltip:AddDoubleLine(Questie:Colorize(l10n('Shift + Left Click'), 'lightBlue'), Questie:Colorize(l10n('Questie Options'), 'white'))
             tooltip:AddLine(" ")
-            tooltip:AddDoubleLine(Questie:Colorize(l10n('Ctrl + Left Click'), 'lightBlue'), (Questie:Colorize(l10n('Reload Questie'), 'white')))
-            tooltip:AddDoubleLine(Questie:Colorize(l10n('Ctrl + Right Click'), 'lightBlue'), (Questie:Colorize(l10n('Hide Minimap Button'), 'white')))
+            tooltip:AddDoubleLine(Questie:Colorize(l10n('Ctrl + Left Click'), 'lightBlue'), Questie:Colorize(l10n('Reload Questie'), 'white'))
+            tooltip:AddDoubleLine(Questie:Colorize(l10n('Ctrl + Right Click'), 'lightBlue'), Questie:Colorize(l10n('Hide Minimap Button'), 'white'))
             tooltip:AddLine(" ")
-            tooltip:AddDoubleLine(Questie:Colorize(l10n('Ctrl + Shift + Left Click'), 'lightBlue'), (Questie:Colorize(l10n('Toggle Questie'), 'white')))
+            tooltip:AddDoubleLine(Questie:Colorize(l10n('Ctrl + Shift + Left Click'), 'lightBlue'), Questie:Colorize(l10n('Toggle Questie'), 'white'))
         end,
     })
 

--- a/Questie.lua
+++ b/Questie.lua
@@ -74,7 +74,7 @@ function Questie:Colorize(str, color)
     elseif color == "blue" then
         c = "|cFF0000FF";
     elseif color == "lightBlue" then
-        c = "|cB900FFFF";
+        c = "|cFF00BBFF";
     elseif color == "reputationBlue" then
         c = "|cFF8080ff";
     elseif color == "repeatableBlue" then


### PR DESCRIPTION
Small UX changes to Questie Minimap Tooltip.

<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #

## Proposed changes

-
-

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->

<img width="277" height="236" alt="image" src="https://github.com/user-attachments/assets/b43a292b-0316-48e5-8e8c-5a990776b075" />

vs

<img width="248" height="185" alt="image" src="https://github.com/user-attachments/assets/5aace8da-4b8e-4ab4-a76a-f9a367944a74" />

Would love to have like an "informationBlue" variable (the 'lightBlue' is very neon), but I know you guys hate changes. (=

I'd use like #00BBFF though. 

The reason for this change is just to break up the block of hard to read text.

By adding blue, you're giving some visual anchors. Buy adding a few spacer lines you're making each section more usable.