### PR TITLE
Update WorldMapButton.lua

### DIFF
--- a/Modules/WorldMapButton/WorldMapButton.lua
+++ b/Modules/WorldMapButton/WorldMapButton.lua
@@ -52,7 +52,8 @@ QuestieWorldMapButtonMixin = {
     OnMouseUp = function() end,
     OnEnter = function(self)
         local tooltip = GameTooltip
-        tooltip:SetOwner(self, "ANCHOR_BOTTOMLEFT")
+        tooltip:SetOwner(self, "ANCHOR_NONE");
+        tooltip:SetPoint("TOPRIGHT", self, "BOTTOMRIGHT", 0, 0);
         tooltip:AddDoubleLine(Questie:Colorize("Questie", 'gold'), Questie:Colorize(QuestieLib:GetAddonVersionString(), 'gray'))
         tooltip:AddLine(" ")
         tooltip:AddDoubleLine(Questie:Colorize(l10n('Left Click'), 'lightBlue'), Questie:Colorize(l10n('Toggle Questie'), 'white'))


### PR DESCRIPTION
Updating World Map Button to Match Minimap Button.

Map Button Tooltip

<img width="319" height="155" alt="image" src="https://github.com/user-attachments/assets/e9d672e6-557c-4402-95dd-b10bfac26741" />

Minimap Button Tooltip

<img width="372" height="276" alt="image" src="https://github.com/user-attachments/assets/1919f86f-59f7-4f3e-8c25-bc56c923e87a" />
