### PR TITLE
Wrap Long Tooltip Text

### DIFF
--- a/Modules/Tooltips/TooltipHandler.lua
+++ b/Modules/Tooltips/TooltipHandler.lua
@@ -34,11 +34,11 @@ function _QuestieTooltips:AddUnitDataToTooltip()
         end
 
         local tooltipData = QuestieTooltips.GetTooltip("m_" .. npcId);
-        if tooltipData then
-            for _, v in pairs (tooltipData) do
-                GameTooltip:AddLine(v)
+            if tooltipData then
+                for _, v in pairs (tooltipData) do
+                    GameTooltip:AddLine(v, nil, nil, nil, true)
+                end
             end
-        end
         QuestieTooltips.lastGametooltipCount = _QuestieTooltips:CountTooltip()
     end
     lastGuid = guid;
@@ -70,11 +70,11 @@ function _QuestieTooltips:AddItemDataToTooltip()
         end
 
         local tooltipData = QuestieTooltips.GetTooltip("i_" .. (itemId or 0));
-        if tooltipData then
-            for _, v in pairs (tooltipData) do
-                self:AddLine(v)
+            if tooltipData then
+                for _, v in pairs (tooltipData) do
+                    self:AddLine(v, nil, nil, nil, true)
+                end
             end
-        end
         QuestieTooltips.lastGametooltipCount = _QuestieTooltips:CountTooltip()
     end
     lastItemId = itemId;
@@ -106,20 +106,19 @@ function _QuestieTooltips.AddObjectDataToTooltip(name, playerZone)
     local alreadyAddedObjectiveLines = {}
     for _, gameObjectId in pairs(lookup) do
         if count > 10 and addedObjects >= 10 then
-            -- only show 10 tooltips
             break
         end
 
         local tooltipData = QuestieTooltips.GetTooltip("o_" .. gameObjectId, playerZone);
-        if tooltipData then
-            for _, line in pairs (tooltipData) do
-                if (not alreadyAddedObjectiveLines[line]) then
-                    alreadyAddedObjectiveLines[line] = true
-                    GameTooltip:AddLine(line)
+            if tooltipData then
+                for _, line in pairs (tooltipData) do
+                    if (not alreadyAddedObjectiveLines[line]) then
+                        alreadyAddedObjectiveLines[line] = true
+                        GameTooltip:AddLine(line, nil, nil, nil, true)
+                    end
                 end
+                addedObjects = addedObjects + 1
             end
-            addedObjects = addedObjects + 1
-        end
     end
     GameTooltip:Show()
     QuestieTooltips.lastGametooltipType = "object";


### PR DESCRIPTION
Will this work? Seems like the game has better support for text wrapping now. It's working in testing.

Turns this

<img width="675" height="147" alt="image" src="https://github.com/user-attachments/assets/8ec4ee60-16c1-48bc-9160-1ec909450680" />

Into this

<img width="341" height="189" alt="image" src="https://github.com/user-attachments/assets/15ce53cc-afe7-4473-a44d-9e09a0ebef28" />