### PR TITLE
[feature] Show quest name on items starting a quest

### DIFF
--- a/Modules/Tooltips/TooltipHandler.lua
+++ b/Modules/Tooltips/TooltipHandler.lua
@@ -80,12 +80,13 @@ function _QuestieTooltips:AddItemDataToTooltip()
 
         if (not checkedQuestStartItems[itemId]) then
             checkedQuestStartItems[itemId] = true
-            ---@type number
             local itemIdAsNumber = tonumber(itemId)
-            local startQuestId = QuestieDB.QueryItemSingle(itemIdAsNumber, "startQuest")
-            local itemName = QuestieDB.QueryItemSingle(itemIdAsNumber, "name")
-            if startQuestId and startQuestId ~= 0 and itemName then
-                QuestieTooltips:RegisterQuestStartTooltip(startQuestId, itemName, itemIdAsNumber, "i_"..itemId)
+            if itemIdAsNumber then
+                local startQuestId = QuestieDB.QueryItemSingle(itemIdAsNumber, "startQuest")
+                local itemName = QuestieDB.QueryItemSingle(itemIdAsNumber, "name")
+                if startQuestId and startQuestId ~= 0 and itemName then
+                    QuestieTooltips:RegisterQuestStartTooltip(startQuestId, itemName, itemIdAsNumber, "i_"..itemId)
+                end
             end
         end
 


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #7288

## Proposed changes

- Items which start a quest now show the quest they start in the tooltip

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->