### PR TITLE
fix: unblacklist commendation signet quests 10693-10700 for TBC+

### DIFF
--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1183,14 +1183,14 @@ function QuestieQuestBlacklist:Load()
         [9750] = true, -- UNUSED Urgent Delivery
         [9767] = true, -- Know Your Enemy
         [10090] = true, -- BETA The Legion's Plans
-        [10693] = true, -- One Commendation Signet
-        [10694] = true, -- Ten Commendation Signets
-        [10695] = true, -- One Commendation Signet
-        [10696] = true, -- Ten Commendation Signets
-        [10697] = true, -- One Commendation Signet
-        [10698] = true, -- Ten Commendation Signets
-        [10699] = true, -- One Commendation Signet
-        [10700] = true, -- Ten Commendation Signets
+        [10693] = Expansions.Current == Expansions.Era, -- One Commendation Signet (Silvermoon City Commendation Officer)
+        [10694] = Expansions.Current == Expansions.Era, -- Ten Commendation Signets (Silvermoon City Commendation Officer)
+        [10695] = Expansions.Current == Expansions.Era, -- One Commendation Signet (Exodar Commendation Officer)
+        [10696] = Expansions.Current == Expansions.Era, -- Ten Commendation Signets (Exodar Commendation Officer)
+        [10697] = Expansions.Current == Expansions.Era, -- One Commendation Signet (Officer Dawning)
+        [10698] = Expansions.Current == Expansions.Era, -- Ten Commendation Signets (Officer Dawning)
+        [10699] = Expansions.Current == Expansions.Era, -- One Commendation Signet (Officer Khaluun)
+        [10700] = Expansions.Current == Expansions.Era, -- Ten Commendation Signets (Officer Khaluun)
         [11027] = true, -- NOT IN GAME: Yous Have Da Darkrune? , "replaced" by 11060 (A Crystalforged Darkrune)
 
         [1] = true, -- Unavailable quest "The "Chow" Quest (123)aa"

--- a/Database/Corrections/tbcNPCFixes.lua
+++ b/Database/Corrections/tbcNPCFixes.lua
@@ -1707,6 +1707,20 @@ function QuestieTBCNpcFixes:Load()
             [npcKeys.questStarts] = {63866},
             [npcKeys.questEnds] = {64319},
         },
+        [21968] = { -- Silvermoon City Commendation Officer
+            [npcKeys.questEnds] = {10693,10694},
+        },
+        [21969] = { -- Exodar Commendation Officer
+            [npcKeys.zoneID] = zoneIDs.THE_EXODAR,
+            [npcKeys.spawns] = {[zoneIDs.THE_EXODAR] = {{61.63,78.37}}},
+            [npcKeys.questEnds] = {10695,10696},
+        },
+        [21970] = { -- Officer Dawning
+            [npcKeys.questEnds] = {10697,10698},
+        },
+        [21971] = { -- Officer Khaluun
+            [npcKeys.questEnds] = {10699,10700},
+        },
     }
 end
 

--- a/Database/Corrections/tbcQuestFixes.lua
+++ b/Database/Corrections/tbcQuestFixes.lua
@@ -3042,6 +3042,46 @@ function QuestieTBCQuestFixes:Load()
         [10687] = {
             [questKeys.preQuestSingle] = {10552},
         },
+        [10693] = { -- One Commendation Signet (Silvermoon City Commendation Officer)
+            [questKeys.finishedBy] = {{21968}},
+            [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
+            [questKeys.reputationReward] = {{factionIDs.SILVERMOON_CITY,5}},
+        },
+        [10694] = { -- Ten Commendation Signets (Silvermoon City Commendation Officer)
+            [questKeys.finishedBy] = {{21968}},
+            [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
+            [questKeys.reputationReward] = {{factionIDs.SILVERMOON_CITY,150}},
+        },
+        [10695] = { -- One Commendation Signet (Exodar Commendation Officer)
+            [questKeys.finishedBy] = {{21969}},
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.reputationReward] = {{factionIDs.EXODAR,5}},
+        },
+        [10696] = { -- Ten Commendation Signets (Exodar Commendation Officer)
+            [questKeys.finishedBy] = {{21969}},
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.reputationReward] = {{factionIDs.EXODAR,150}},
+        },
+        [10697] = { -- One Commendation Signet (Officer Dawning)
+            [questKeys.finishedBy] = {{21970}},
+            [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
+            [questKeys.reputationReward] = {{factionIDs.SILVERMOON_CITY,5}},
+        },
+        [10698] = { -- Ten Commendation Signets (Officer Dawning)
+            [questKeys.finishedBy] = {{21970}},
+            [questKeys.requiredRaces] = raceIDs.ALL_HORDE,
+            [questKeys.reputationReward] = {{factionIDs.SILVERMOON_CITY,150}},
+        },
+        [10699] = { -- One Commendation Signet (Officer Khaluun)
+            [questKeys.finishedBy] = {{21971}},
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.reputationReward] = {{factionIDs.EXODAR,5}},
+        },
+        [10700] = { -- Ten Commendation Signets (Officer Khaluun)
+            [questKeys.finishedBy] = {{21971}},
+            [questKeys.requiredRaces] = raceIDs.ALL_ALLIANCE,
+            [questKeys.reputationReward] = {{factionIDs.EXODAR,150}},
+        },
         [10707] = {
             [questKeys.extraObjectives] = {{nil, Questie.ICON_TYPE_EVENT, l10n("Kill the 3 Shadowmoon Soulstealers to force Shadowlord Deathwail to land"), 0, {{"object", 185125}}}},
         },


### PR DESCRIPTION
Fixes #7419 - Quest 10696 not found in database

## Problem
Quests 10693-10700 (Commendation Signet turn-in quests) were unconditionally blacklisted in \QuestieQuestBlacklist.lua\, causing the error *'Quest 10696 not found in database'* when a TBC player interacts with one of these quests.

These are valid TBC quests for turning in Alliance/Horde Commendation Signets to Silvermoon/Exodar officers for city reputation. They should only be blacklisted in Classic Era (where the NPCs don't exist).

## Changes
### QuestieQuestBlacklist.lua
- Changed blacklist for quests 10693-10700 from \= true\ (unconditional) to \= Expansions.Current == Expansions.Era\ (Era-only)

### tbcQuestFixes.lua
- Added corrections for all 8 quests:
  - \inishedBy\  correct commendation officer NPC (21968-21971)
  - \equiredRaces\  \ALL_HORDE\ for Silvermoon quests, \ALL_ALLIANCE\ for Exodar quests
  - \eputationReward\  5 rep for single signet, 150 rep for ten signets (values from Wotlk data)

### tbcNPCFixes.lua
- Added \questEnds\ to all 4 commendation officers (21968-21971)
- Added spawn location for NPC 21969 (Exodar Commendation Officer) which was missing

## Quest/NPC Mapping
| Quest | Name | NPC | Faction |
|-------|------|-----|---------|
| 10693 | One Commendation Signet | 21968 (Silvermoon City Commendation Officer) | Horde |
| 10694 | Ten Commendation Signets | 21968 | Horde |
| 10695 | One Commendation Signet | 21969 (Exodar Commendation Officer) | Alliance |
| 10696 | Ten Commendation Signets | 21969 | Alliance |
| 10697 | One Commendation Signet | 21970 (Officer Dawning) | Horde |
| 10698 | Ten Commendation Signets | 21970 | Horde |
| 10699 | One Commendation Signet | 21971 (Officer Khaluun) | Alliance |
| 10700 | Ten Commendation Signets | 21971 | Alliance |