### PR TITLE
fix: unblacklist commendation signet quests 10693-10700 for TBC+

### DIFF
--- a/Database/Corrections/QuestieQuestBlacklist.lua
+++ b/Database/Corrections/QuestieQuestBlacklist.lua
@@ -1183,14 +1183,6 @@ function QuestieQuestBlacklist:Load()
         [9750] = true, -- UNUSED Urgent Delivery
         [9767] = true, -- Know Your Enemy
         [10090] = true, -- BETA The Legion's Plans
-        [10693] = true, -- One Commendation Signet
-        [10694] = true, -- Ten Commendation Signets
-        [10695] = true, -- One Commendation Signet
-        [10696] = true, -- Ten Commendation Signets
-        [10697] = true, -- One Commendation Signet
-        [10698] = true, -- Ten Commendation Signets
-        [10699] = true, -- One Commendation Signet
-        [10700] = true, -- Ten Commendation Signets
         [11027] = true, -- NOT IN GAME: Yous Have Da Darkrune? , "replaced" by 11060 (A Crystalforged Darkrune)
 
         [1] = true, -- Unavailable quest "The "Chow" Quest (123)aa"


### PR DESCRIPTION
## Summary
Remove commendation signet quests 10693-10700 from the quest blacklist. These are valid TBC quests that were unconditionally blacklisted with '= true', preventing them from appearing in TBC+.

## Problem
Quests 10693-10700 (One/Ten Commendation Signets for Silvermoon City, Exodar, Officer Dawning, and Officer Khaluun) were blacklisted for all expansions. These quests only exist in the TBC quest database and are not present in Classic/Era at all, so the blacklist entries were both incorrect for TBC+ (where they should be available) and redundant for Era (where they don't exist in the DB).

## Fix
Removed all 8 blacklist entries from QuestieQuestBlacklist.lua.