### PR TITLE
[db] Add missing NPC drop sources for Long Elegant Feather

### DIFF
--- a/Database/Corrections/classicItemFixes.lua
+++ b/Database/Corrections/classicItemFixes.lua
@@ -270,7 +270,7 @@ function QuestieItemFixes:Load()
             [itemKeys.objectDrops] = {},
         },
         [4589] = { -- Long Elegant Feather
-            [itemKeys.npcDrops] = {2347, 2651, 2657, 2658, 2659},
+            [itemKeys.npcDrops] = {2347, 2473, 2474, 2651, 2657, 2658, 2659, 5300, 6375},
         },
         [4611] = { -- Blue Pearl
             [itemKeys.npcDrops] = {},


### PR DESCRIPTION
## Summary
Fixes #2320

Adds 4 missing NPC drop sources to item 4589 ([Long Elegant Feather](https://www.wowhead.com/classic/item=4589/long-elegant-feather)):
- Granistad (2473)
- Kurdros (2474)
- Frayfeather Hippogryph (5300)
- Thunderhead Hippogryph (6375)

These NPCs were previously listed in the generated drop data but were inadvertently removed by the corrections table override which only listed 5 of the 9 dropping NPCs.

## Test plan
- [x] `busted -p ".test.lua" .` — 719 successes, 0 failures
- [x] `busted -p ".test.lua" ./Database/QuestieDB.test.lua ./Modules/Tooltips/Tooltip.test.lua ./cli/integrationTests/6734.test.lua` — 51 successes, 0 failures
- [x] `luacheck -q Database/Corrections/classicItemFixes.lua` — 0 warnings, 0 errors