### PR TITLE
Fix custom localization initialization

### DIFF
--- a/Localization/l10n.lua
+++ b/Localization/l10n.lua
@@ -107,13 +107,10 @@ end
 _InitializeLocaleOverride = function()
     local overridingLocale = QUESTIE_LOCALES_OVERRIDE.locale
     supportedLocals[overridingLocale] = true
-    l10n.itemLookup[overridingLocale] = function() return QUESTIE_LOCALES_OVERRIDE.itemLookup end
-    l10n.questLookup[overridingLocale] = function()
-        -- We don't want to break compatibility with the override addons, so we simply ignore [2] which was the unused quest description
-        return {QUESTIE_LOCALES_OVERRIDE.questLookup[1], QUESTIE_LOCALES_OVERRIDE.questLookup[3]}
-    end
-    l10n.npcNameLookup[overridingLocale] = function() return QUESTIE_LOCALES_OVERRIDE.npcNameLookup end
-    l10n.objectLookup[overridingLocale] = function() return QUESTIE_LOCALES_OVERRIDE.objectLookup end
+    l10n.itemLookup[overridingLocale] = QUESTIE_LOCALES_OVERRIDE.itemLookup
+    l10n.questLookup[overridingLocale] = QUESTIE_LOCALES_OVERRIDE.questLookup
+    l10n.npcNameLookup[overridingLocale] = QUESTIE_LOCALES_OVERRIDE.npcNameLookup
+    l10n.objectLookup[overridingLocale] = QUESTIE_LOCALES_OVERRIDE.objectLookup
 
     for id, _ in pairs(l10n.translations) do
         if QUESTIE_LOCALES_OVERRIDE.translations[id] ~= nil then


### PR DESCRIPTION
## Issue references
I haven't created an issue for that, so I'll describe it briefly here.

Some time ago there was a change to quest lookup structure with description removal, which lead to this commit - https://github.com/Questie/Questie/commit/dd335d357ae4fd1c4d29de99e645c1e2422daacc
I guess instead of returning slice of first and third column it returns table of two rows with ids 1 and 3? I'm not sure about this, but my localization addon doesn't translate quests with old questLookup structure.

Also there was an improvement to startup performance in this commit - https://github.com/Questie/Questie/commit/4271c26df3837287dc1c8e947c9b2b8766350c43
Which at some point (didn't find a commit) had related change in lookup calls - from plain table `l10n.itemLookup[locale]` to function call `l10n.itemLookup[locale]()`, which also changed assignment in _InitializeLocaleOverride to `l10n.questLookup[overridingLocale] = function() return QUESTIE_LOCALES_OVERRIDE.questLookup end` instead of plain table assignment

## Proposed changes

Roll these changes back:
- Remove compatibility code from Questie instead of fixing and supporting it
- Force override addons to use the same structure as in Questie lookup files - no description for quests and return function instead of table
- That also allows external addons to use the same lazy evaluation approach

## Alternative
We could do two things instead:
- Check if `QUESTIE_LOCALES_OVERRIDE` lookup is a table or a function and process it accordingly
- Fix questLookup assignment compatibility for tables - build a slice if it's an old three-column table. I guess that's only possible with iteration through table with rebuilding it to a new one. Something like that:
```
l10n.questLookup[overridingLocale] = function()
    local result = {}
    for id, data in pairs(QUESTIE_LOCALES_OVERRIDE.questLookup) do
        result[id] = {data[1], data[3] or data[2]}
    end
    return result
end

```