### PR TITLE
[Feature] Improve Journey quest filtering and hidden quest management

### DIFF
--- a/Database/Corrections/Holidays/QuestieEvent.lua
+++ b/Database/Corrections/Holidays/QuestieEvent.lua
@@ -89,6 +89,17 @@ local DMF_CALENDER_ICON_TEXTURES = {
 }
 
 function QuestieEvent.Initialize()
+    -- Always populate event names regardless of showEventQuests setting,
+    -- so that IsEventQuest() works correctly for the Journey hidden section
+    for _, questData in pairs(QuestieEvent.eventQuests) do
+        local questId = questData[2]
+        local hideQuest = questData[5]
+        if (not hideQuest) then
+            _QuestieEvent.eventNamesForQuests[questId] = questData[1]
+            QuestieCorrections.hiddenQuests[questId] = nil
+        end
+    end
+
     if (not Questie.db.profile.showEventQuests) then
         return
     end

--- a/Localization/Translations/Journey/Search.lua
+++ b/Localization/Translations/Journey/Search.lua
@@ -650,6 +650,18 @@ local searchLocales = {
         ["zhCN"] = "掉落该物品的 NPC:",
         ["zhTW"] = "掉落此物品的 NPC:",
     },
+    ["Hide Quest"] = {
+        ["enUS"] = true,
+        ["deDE"] = "Quest verstecken",
+        ["esES"] = "Ocultar misión",
+        ["esMX"] = "Ocultar misión",
+        ["frFR"] = "Cacher la quête",
+        ["koKR"] = "퀘스트 숨기기",
+        ["ptBR"] = "Ocultar missão",
+        ["ruRU"] = "Скрыть задание",
+        ["zhCN"] = "隐藏任务",
+        ["zhTW"] = "隱藏任務",
+    },
 }
 
 for k, v in pairs(searchLocales) do

--- a/Modules/Journey/QuestDetailsFrame.lua
+++ b/Modules/Journey/QuestDetailsFrame.lua
@@ -113,7 +113,7 @@ function _QuestieJourney:DrawQuestDetailsFrame(container, quest)
         container:AddChild(eligibilityTextLabel)
     end
 
-    local hiddenLabel = _QuestieJourney:CreateLabel(Questie:Colorize(l10n("Hide Quest")..l10n(":"), 'yellow'), false)
+    local hiddenLabel = _QuestieJourney:CreateLabel(Questie:Colorize(l10n("Hide Quest")..l10n(": "), 'yellow'), false)
     container:AddChild(hiddenLabel)
     local hiddenCheckbox = AceGUI:Create("CheckBox")
     hiddenCheckbox:SetValue(Questie.db.char.hidden[quest.Id] ~= nil)

--- a/Modules/Journey/QuestDetailsFrame.lua
+++ b/Modules/Journey/QuestDetailsFrame.lua
@@ -18,6 +18,8 @@ local QuestieLib = QuestieLoader:ImportModule("QuestieLib")
 local l10n = QuestieLoader:ImportModule("l10n")
 ---@type QuestieQuest
 local QuestieQuest = QuestieLoader:ImportModule("QuestieQuest")
+---@type QuestieEvent
+local QuestieEvent = QuestieLoader:ImportModule("QuestieEvent")
 
 local AceGUI = LibStub("AceGUI-3.0")
 
@@ -116,7 +118,12 @@ function _QuestieJourney:DrawQuestDetailsFrame(container, quest)
     local hiddenLabel = _QuestieJourney:CreateLabel(Questie:Colorize(l10n("Hide Quest")..l10n(": "), 'yellow'), false)
     container:AddChild(hiddenLabel)
     local hiddenCheckbox = AceGUI:Create("CheckBox")
-    hiddenCheckbox:SetValue(Questie.db.char.hidden[quest.Id] ~= nil)
+    hiddenCheckbox:SetValue(Questie.db.char.hidden[quest.Id] ~= nil or
+        (not Questie.db.profile.showEventQuests and QuestieEvent.IsEventQuest(quest.Id)) or
+        (not Questie.db.profile.showRepeatableQuests and QuestieDB.IsRepeatable(quest.Id)) or
+        (not Questie.db.profile.showPvPQuests and QuestieDB.IsPvPQuest(quest.Id)) or
+        (not Questie.db.profile.showDungeonQuests and QuestieDB.IsDungeonQuest(quest.Id)) or
+        (not Questie.db.profile.showRaidQuests and QuestieDB.IsRaidQuest(quest.Id)))
     hiddenCheckbox:SetWidth(14)
     hiddenCheckbox:SetHeight(14)
     hiddenCheckbox.checkbg:SetSize(14, 14)

--- a/Modules/Journey/QuestDetailsFrame.lua
+++ b/Modules/Journey/QuestDetailsFrame.lua
@@ -125,31 +125,35 @@ function _QuestieJourney:DrawQuestDetailsFrame(container, quest)
     hiddenCheckbox.check:SetSize(14, 14)
     hiddenCheckbox.check:SetPoint("TOPLEFT", hiddenCheckbox.frame, "TOPLEFT", 0, 0)
     hiddenCheckbox:SetCallback("OnValueChanged", function(frame)
-        if Questie.db.char.hidden[quest.Id] ~= nil then
-            frame:SetValue(false)
-            QuestieQuest:UnhideQuest(quest.Id)
-        else
-            frame:SetValue(true)
-            QuestieQuest:HideQuest(quest.Id)
-        end
+        xpcall(function()
+            if Questie.db.char.hidden[quest.Id] ~= nil then
+                frame:SetValue(false)
+                QuestieQuest:UnhideQuest(quest.Id)
+            else
+                frame:SetValue(true)
+                QuestieQuest:HideQuest(quest.Id)
+            end
+        end, CallErrorHandler)
     end)
     hiddenCheckbox:SetCallback("OnEnter", function()
+        xpcall(function()
         if GameTooltip:IsShown() then return end
-        GameTooltip:SetOwner(hiddenCheckbox.frame, "ANCHOR_CURSOR")
-        GameTooltip:AddLine(l10n("Quest is hidden"))
-        GameTooltip:AddLine(l10n("\nIf checked, hides the quest from the map, even if it is active.\n\nHiding a quest is also possible by Shift-clicking it on the map."), 1, 1, 1, true)
-        GameTooltip:SetFrameStrata("TOOLTIP")
-        GameTooltip:Show()
+            GameTooltip:SetOwner(hiddenCheckbox.frame, "ANCHOR_CURSOR")
+            GameTooltip:SetFrameStrata("TOOLTIP")
+            GameTooltip:Show()
+        end, CallErrorHandler)
     end)
     hiddenCheckbox:SetCallback("OnLeave", function()
-        if GameTooltip:IsShown() then
-            GameTooltip:Hide()
-        end
+        xpcall(function()
+            if GameTooltip:IsShown() then
+                GameTooltip:Hide()
+            end
+        end, CallErrorHandler)
     end)
     container:AddChild(hiddenCheckbox)
     hiddenCheckbox.frame:SetScript("OnUpdate", function(self)
         self:ClearAllPoints()
-        self:SetPoint("LEFT", hiddenLabel.frame, "LEFT", hiddenLabel.label:GetStringWidth() + 1, (hiddenLabel.frame:GetHeight() - 14) / 2)
+        self:SetPoint("LEFT", hiddenLabel.frame, "LEFT", hiddenLabel.label:GetStringWidth(), (hiddenLabel.frame:GetHeight() - 14) / 2)
         self:SetScript("OnUpdate", nil)
     end)
 

--- a/Modules/Journey/QuestDetailsFrame.lua
+++ b/Modules/Journey/QuestDetailsFrame.lua
@@ -117,23 +117,18 @@ function _QuestieJourney:DrawQuestDetailsFrame(container, quest)
     container:AddChild(hiddenLabel)
     local hiddenCheckbox = AceGUI:Create("CheckBox")
     hiddenCheckbox:SetValue(Questie.db.char.hidden[quest.Id] ~= nil)
-    hiddenCheckbox:SetFullWidth(false)
     hiddenCheckbox:SetWidth(14)
     hiddenCheckbox:SetHeight(14)
     hiddenCheckbox.checkbg:SetSize(14, 14)
     hiddenCheckbox.checkbg:SetPoint("TOPLEFT", hiddenCheckbox.frame, "TOPLEFT", 0, 0)
     hiddenCheckbox.check:SetSize(14, 14)
     hiddenCheckbox.check:SetPoint("TOPLEFT", hiddenCheckbox.frame, "TOPLEFT", 0, 0)
-    hiddenCheckbox:SetCallback("OnValueChanged", function(frame)
-        xpcall(function()
-            if Questie.db.char.hidden[quest.Id] ~= nil then
-                frame:SetValue(false)
-                QuestieQuest:UnhideQuest(quest.Id)
-            else
-                frame:SetValue(true)
-                QuestieQuest:HideQuest(quest.Id)
-            end
-        end, CallErrorHandler)
+    hiddenCheckbox:SetCallback("OnValueChanged", function()
+        if Questie.db.char.hidden[quest.Id] ~= nil then
+            QuestieQuest:UnhideQuest(quest.Id)
+        else
+            QuestieQuest:HideQuest(quest.Id)
+        end
     end)
     container:AddChild(hiddenCheckbox)
     hiddenCheckbox.frame:SetScript("OnUpdate", function(self)

--- a/Modules/Journey/QuestDetailsFrame.lua
+++ b/Modules/Journey/QuestDetailsFrame.lua
@@ -135,21 +135,6 @@ function _QuestieJourney:DrawQuestDetailsFrame(container, quest)
             end
         end, CallErrorHandler)
     end)
-    hiddenCheckbox:SetCallback("OnEnter", function()
-        xpcall(function()
-        if GameTooltip:IsShown() then return end
-            GameTooltip:SetOwner(hiddenCheckbox.frame, "ANCHOR_CURSOR")
-            GameTooltip:SetFrameStrata("TOOLTIP")
-            GameTooltip:Show()
-        end, CallErrorHandler)
-    end)
-    hiddenCheckbox:SetCallback("OnLeave", function()
-        xpcall(function()
-            if GameTooltip:IsShown() then
-                GameTooltip:Hide()
-            end
-        end, CallErrorHandler)
-    end)
     container:AddChild(hiddenCheckbox)
     hiddenCheckbox.frame:SetScript("OnUpdate", function(self)
         self:ClearAllPoints()

--- a/Modules/Journey/QuestDetailsFrame.lua
+++ b/Modules/Journey/QuestDetailsFrame.lua
@@ -16,6 +16,8 @@ local TrackerUtils = QuestieLoader:ImportModule("TrackerUtils")
 local QuestieLib = QuestieLoader:ImportModule("QuestieLib")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
+---@type QuestieQuest
+local QuestieQuest = QuestieLoader:ImportModule("QuestieQuest")
 
 local AceGUI = LibStub("AceGUI-3.0")
 
@@ -110,6 +112,46 @@ function _QuestieJourney:DrawQuestDetailsFrame(container, quest)
         local eligibilityTextLabel = _QuestieJourney:CreateLabel(Questie:Colorize(l10n("Doable") .. l10n(": "), 'yellow') .. eligibilityText, true)
         container:AddChild(eligibilityTextLabel)
     end
+
+    local hiddenLabel = _QuestieJourney:CreateLabel(Questie:Colorize(l10n("Hide Quest")..l10n(":"), 'yellow'), false)
+    container:AddChild(hiddenLabel)
+    local hiddenCheckbox = AceGUI:Create("CheckBox")
+    hiddenCheckbox:SetValue(Questie.db.char.hidden[quest.Id] ~= nil)
+    hiddenCheckbox:SetFullWidth(false)
+    hiddenCheckbox:SetWidth(14)
+    hiddenCheckbox:SetHeight(14)
+    hiddenCheckbox.checkbg:SetSize(14, 14)
+    hiddenCheckbox.checkbg:SetPoint("TOPLEFT", hiddenCheckbox.frame, "TOPLEFT", 0, 0)
+    hiddenCheckbox.check:SetSize(14, 14)
+    hiddenCheckbox.check:SetPoint("TOPLEFT", hiddenCheckbox.frame, "TOPLEFT", 0, 0)
+    hiddenCheckbox:SetCallback("OnValueChanged", function(frame)
+        if Questie.db.char.hidden[quest.Id] ~= nil then
+            frame:SetValue(false)
+            QuestieQuest:UnhideQuest(quest.Id)
+        else
+            frame:SetValue(true)
+            QuestieQuest:HideQuest(quest.Id)
+        end
+    end)
+    hiddenCheckbox:SetCallback("OnEnter", function()
+        if GameTooltip:IsShown() then return end
+        GameTooltip:SetOwner(hiddenCheckbox.frame, "ANCHOR_CURSOR")
+        GameTooltip:AddLine(l10n("Quest is hidden"))
+        GameTooltip:AddLine(l10n("\nIf checked, hides the quest from the map, even if it is active.\n\nHiding a quest is also possible by Shift-clicking it on the map."), 1, 1, 1, true)
+        GameTooltip:SetFrameStrata("TOOLTIP")
+        GameTooltip:Show()
+    end)
+    hiddenCheckbox:SetCallback("OnLeave", function()
+        if GameTooltip:IsShown() then
+            GameTooltip:Hide()
+        end
+    end)
+    container:AddChild(hiddenCheckbox)
+    hiddenCheckbox.frame:SetScript("OnUpdate", function(self)
+        self:ClearAllPoints()
+        self:SetPoint("LEFT", hiddenLabel.frame, "LEFT", hiddenLabel.label:GetStringWidth() + 1, (hiddenLabel.frame:GetHeight() - 14) / 2)
+        self:SetScript("OnUpdate", nil)
+    end)
 
     QuestieJourneyUtils:Spacer(container)
 

--- a/Modules/Journey/QuestieSearchResults.lua
+++ b/Modules/Journey/QuestieSearchResults.lua
@@ -13,6 +13,8 @@ local QuestieSearch = QuestieLoader:ImportModule("QuestieSearch")
 local QuestieMap = QuestieLoader:ImportModule("QuestieMap")
 ---@type QuestieDB
 local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
+---@type QuestieEvent
+local QuestieEvent = QuestieLoader:ImportModule("QuestieEvent")
 ---@type QuestieCorrections
 local QuestieCorrections = QuestieLoader:ImportModule("QuestieCorrections")
 ---@type QuestieLib
@@ -222,12 +224,17 @@ function QuestieSearchResults:QuestDetailsFrame(details, id)
 
     -- hidden by Questie
     local hiddenQuests = AceGUI:Create("CheckBox")
-    hiddenQuests:SetValue(QuestieCorrections.hiddenQuests[id])
     hiddenQuests:SetLabel(l10n("Hidden by Questie"))
     hiddenQuests:SetDisabled(true)
     -- reduce offset to next checkbox
     hiddenQuests:SetHeight(16)
     hiddenQuests:SetFullWidth(true);
+    hiddenQuests:SetValue(QuestieCorrections.hiddenQuests[id] or
+        (not Questie.db.profile.showEventQuests and QuestieEvent.IsEventQuest(id)) or
+        (not Questie.db.profile.showRepeatableQuests and QuestieDB.IsRepeatable(id)) or
+        (not Questie.db.profile.showPvPQuests and QuestieDB.IsPvPQuest(id)) or
+        (not Questie.db.profile.showDungeonQuests and QuestieDB.IsDungeonQuest(id)) or
+        (not Questie.db.profile.showRaidQuests and QuestieDB.IsRaidQuest(id)))
     details:AddChild(hiddenQuests)
 
     -- hidden by user

--- a/Modules/Journey/tabs/QuestsByFaction/QuestsByFactions.lua
+++ b/Modules/Journey/tabs/QuestsByFaction/QuestsByFactions.lua
@@ -480,7 +480,7 @@ function _QuestieJourney.questsByFaction:CollectFactionQuests(factionId)
             temp.text = questName
 
             -- Manually hidden quests: only show in Hidden Quests section, skip categorization
-            if Questie.db.char.hidden[questId] then
+            if Questie.db.char.hidden and Questie.db.char.hidden[questId] then
                 if not factionTree[7] then
                     factionTree[7] = {
                         value = "h",

--- a/Modules/Journey/tabs/QuestsByFaction/QuestsByFactions.lua
+++ b/Modules/Journey/tabs/QuestsByFaction/QuestsByFactions.lua
@@ -479,8 +479,13 @@ function _QuestieJourney.questsByFaction:CollectFactionQuests(factionId)
 
             temp.text = questName
 
-            -- Manually hidden quests: only show in Hidden Quests section, skip categorization
-            if Questie.db.char.hidden and Questie.db.char.hidden[questId] then
+            -- Manually hidden quests and option-filtered quests: only show in Hidden Quests section
+            if (Questie.db.char.hidden and Questie.db.char.hidden[questId]) or
+               (not Questie.db.profile.showEventQuests and QuestieEvent.IsEventQuest(questId)) or
+               (not Questie.db.profile.showRepeatableQuests and QuestieDB.IsRepeatable(questId)) or
+               (not Questie.db.profile.showPvPQuests and QuestieDB.IsPvPQuest(questId)) or
+               (not Questie.db.profile.showDungeonQuests and QuestieDB.IsDungeonQuest(questId)) or
+               (not Questie.db.profile.showRaidQuests and QuestieDB.IsRaidQuest(questId)) then
                 if not factionTree[7] then
                     factionTree[7] = {
                         value = "h",

--- a/Modules/Journey/tabs/QuestsByFaction/QuestsByFactions.lua
+++ b/Modules/Journey/tabs/QuestsByFaction/QuestsByFactions.lua
@@ -479,17 +479,29 @@ function _QuestieJourney.questsByFaction:CollectFactionQuests(factionId)
 
             temp.text = questName
 
-            local breadcrumbForQuestId = QuestieDB.QueryQuest(questId,{"breadcrumbForQuestId"})[1] or {}
-            local eligibilityText, _, returnReason = QuestieDB.IsDoableVerbose(questId, false, true, true)
+            -- Manually hidden quests: only show in Hidden Quests section, skip categorization
+            if Questie.db.char.hidden[questId] then
+                if not factionTree[7] then
+                    factionTree[7] = {
+                        value = "h",
+                        text = l10n("Hidden Quests"),
+                        children = {},
+                    }
+                end
+                tinsert(factionTree[7].children, temp)
+                hiddenCounter = hiddenCounter + 1
+            else
+                local breadcrumbForQuestId = QuestieDB.QueryQuest(questId,{"breadcrumbForQuestId"})[1] or {}
+                local eligibilityText, _, returnReason = QuestieDB.IsDoableVerbose(questId, false, true, true)
 
-            -- Breadcrumb quests
-            if breadcrumbForQuestId and breadcrumbForQuestId ~= 0 then
-                tinsert(factionTree[1].children, temp)
-                breadcrumbCounter = breadcrumbCounter + 1
-            end
+                -- Breadcrumb quests
+                if breadcrumbForQuestId and breadcrumbForQuestId ~= 0 then
+                    tinsert(factionTree[1].children, temp)
+                    breadcrumbCounter = breadcrumbCounter + 1
+                end
 
-            -- Filtering logic. If changing anything here, also change in QuestsByZone.lua
-            if returnReason then
+                -- Filtering logic. If changing anything here, also change in QuestsByZone.lua
+                if returnReason then
                 if returnReason == DoableStates.AVAILABLE then -- available quests
                     if QuestieDB.IsRepeatable(questId) then
                         tinsert(factionTree[3].children, temp)
@@ -709,19 +721,7 @@ function _QuestieJourney.questsByFaction:CollectFactionQuests(factionId)
                         prequestMissingCounter = prequestMissingCounter + 1
                     end
                 end
-            end
-
-            -- show manually hidden quests
-            if Questie.db.char.hidden[questId] then
-                if not factionTree[7] then
-                    factionTree[7] = {
-                        value = "h",
-                        text = l10n("Hidden Quests"),
-                        children = {},
-                    }
                 end
-                tinsert(factionTree[7].children, temp)
-                hiddenCounter = hiddenCounter + 1
             end
             temp = {}
         end

--- a/Modules/Journey/tabs/QuestsByFaction/QuestsByFactions.lua
+++ b/Modules/Journey/tabs/QuestsByFaction/QuestsByFactions.lua
@@ -479,34 +479,17 @@ function _QuestieJourney.questsByFaction:CollectFactionQuests(factionId)
 
             temp.text = questName
 
-            -- Manually hidden quests and option-filtered quests: only show in Hidden Quests section
-            if (Questie.db.char.hidden and Questie.db.char.hidden[questId]) or
-               (not Questie.db.profile.showEventQuests and QuestieEvent.IsEventQuest(questId)) or
-               (not Questie.db.profile.showRepeatableQuests and QuestieDB.IsRepeatable(questId)) or
-               (not Questie.db.profile.showPvPQuests and QuestieDB.IsPvPQuest(questId)) or
-               (not Questie.db.profile.showDungeonQuests and QuestieDB.IsDungeonQuest(questId)) or
-               (not Questie.db.profile.showRaidQuests and QuestieDB.IsRaidQuest(questId)) then
-                if not factionTree[7] then
-                    factionTree[7] = {
-                        value = "h",
-                        text = l10n("Hidden Quests"),
-                        children = {},
-                    }
-                end
-                tinsert(factionTree[7].children, temp)
-                hiddenCounter = hiddenCounter + 1
-            else
-                local breadcrumbForQuestId = QuestieDB.QueryQuest(questId,{"breadcrumbForQuestId"})[1] or {}
-                local eligibilityText, _, returnReason = QuestieDB.IsDoableVerbose(questId, false, true, true)
+            local breadcrumbForQuestId = QuestieDB.QueryQuest(questId,{"breadcrumbForQuestId"})[1] or {}
+            local eligibilityText, _, returnReason = QuestieDB.IsDoableVerbose(questId, false, true, true)
 
-                -- Breadcrumb quests
-                if breadcrumbForQuestId and breadcrumbForQuestId ~= 0 then
-                    tinsert(factionTree[1].children, temp)
-                    breadcrumbCounter = breadcrumbCounter + 1
-                end
+            -- Breadcrumb quests
+            if breadcrumbForQuestId and breadcrumbForQuestId ~= 0 then
+                tinsert(factionTree[1].children, temp)
+                breadcrumbCounter = breadcrumbCounter + 1
+            end
 
-                -- Filtering logic. If changing anything here, also change in QuestsByZone.lua
-                if returnReason then
+            -- Filtering logic. If changing anything here, also change in QuestsByZone.lua
+            if returnReason then
                 if returnReason == DoableStates.AVAILABLE then -- available quests
                     if QuestieDB.IsRepeatable(questId) then
                         tinsert(factionTree[3].children, temp)
@@ -726,7 +709,24 @@ function _QuestieJourney.questsByFaction:CollectFactionQuests(factionId)
                         prequestMissingCounter = prequestMissingCounter + 1
                     end
                 end
+            end
+
+            -- show hidden and option-filtered quests
+            if (Questie.db.char.hidden and Questie.db.char.hidden[questId]) or
+               (not Questie.db.profile.showEventQuests and QuestieEvent.IsEventQuest(questId)) or
+               (not Questie.db.profile.showRepeatableQuests and QuestieDB.IsRepeatable(questId)) or
+               (not Questie.db.profile.showPvPQuests and QuestieDB.IsPvPQuest(questId)) or
+               (not Questie.db.profile.showDungeonQuests and QuestieDB.IsDungeonQuest(questId)) or
+               (not Questie.db.profile.showRaidQuests and QuestieDB.IsRaidQuest(questId)) then
+                if not factionTree[7] then
+                    factionTree[7] = {
+                        value = "h",
+                        text = l10n("Hidden Quests"),
+                        children = {},
+                    }
                 end
+                tinsert(factionTree[7].children, temp)
+                hiddenCounter = hiddenCounter + 1
             end
             temp = {}
         end

--- a/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
+++ b/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
@@ -237,34 +237,17 @@ function _QuestieJourney.questsByZone:CategorizeQuests(quests)
             temp.value = questId
             temp.text = QuestieLib:GetColoredQuestName(questId, Questie.db.profile.enableTooltipsQuestLevel, false)
 
-            -- Manually hidden quests and option-filtered quests: only show in Hidden Quests section
-            if (Questie.db.char.hidden and Questie.db.char.hidden[questId]) or
-               (not Questie.db.profile.showEventQuests and QuestieEvent.IsEventQuest(questId)) or
-               (not Questie.db.profile.showRepeatableQuests and QuestieDB.IsRepeatable(questId)) or
-               (not Questie.db.profile.showPvPQuests and QuestieDB.IsPvPQuest(questId)) or
-               (not Questie.db.profile.showDungeonQuests and QuestieDB.IsDungeonQuest(questId)) or
-               (not Questie.db.profile.showRaidQuests and QuestieDB.IsRaidQuest(questId)) then
-                if not zoneTree[7] then
-                    zoneTree[7] = {
-                        value = "h",
-                        text = l10n("Hidden Quests"),
-                        children = {},
-                    }
-                end
-                tinsert(zoneTree[7].children, temp)
-                hiddenCounter = hiddenCounter + 1
-            else
-                local breadcrumbForQuestId = QuestieDB.QueryQuest(questId,{"breadcrumbForQuestId"})[1] or {}
-                local eligibilityText, _, returnReason = QuestieDB.IsDoableVerbose(questId, false, true, true)
+            local breadcrumbForQuestId = QuestieDB.QueryQuest(questId,{"breadcrumbForQuestId"})[1] or {}
+            local eligibilityText, _, returnReason = QuestieDB.IsDoableVerbose(questId, false, true, true)
 
-                -- Breadcrumb quests
-                if breadcrumbForQuestId and breadcrumbForQuestId ~= 0 then
-                    tinsert(zoneTree[1].children, temp)
-                    breadcrumbCounter = breadcrumbCounter + 1
-                end
+            -- Breadcrumb quests
+            if breadcrumbForQuestId and breadcrumbForQuestId ~= 0 then
+                tinsert(zoneTree[1].children, temp)
+                breadcrumbCounter = breadcrumbCounter + 1
+            end
 
-                -- Filtering logic. If changing anything here, also change in QuestsByFaction.lua
-                if returnReason then
+            -- Filtering logic. If changing anything here, also change in QuestsByFaction.lua
+            if returnReason then
                 if returnReason == DoableStates.AVAILABLE then -- available quests
                     if QuestieDB.IsRepeatable(questId) then
                         tinsert(zoneTree[3].children, temp)
@@ -484,7 +467,24 @@ function _QuestieJourney.questsByZone:CategorizeQuests(quests)
                         prequestMissingCounter = prequestMissingCounter + 1
                     end
                 end
+            end
+
+            -- show hidden and option-filtered quests
+            if (Questie.db.char.hidden and Questie.db.char.hidden[questId]) or
+               (not Questie.db.profile.showEventQuests and QuestieEvent.IsEventQuest(questId)) or
+               (not Questie.db.profile.showRepeatableQuests and QuestieDB.IsRepeatable(questId)) or
+               (not Questie.db.profile.showPvPQuests and QuestieDB.IsPvPQuest(questId)) or
+               (not Questie.db.profile.showDungeonQuests and QuestieDB.IsDungeonQuest(questId)) or
+               (not Questie.db.profile.showRaidQuests and QuestieDB.IsRaidQuest(questId)) then
+                if not zoneTree[7] then
+                    zoneTree[7] = {
+                        value = "h",
+                        text = l10n("Hidden Quests"),
+                        children = {},
+                    }
                 end
+                tinsert(zoneTree[7].children, temp)
+                hiddenCounter = hiddenCounter + 1
             end
             temp = {}
         end

--- a/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
+++ b/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
@@ -238,7 +238,7 @@ function _QuestieJourney.questsByZone:CategorizeQuests(quests)
             temp.text = QuestieLib:GetColoredQuestName(questId, Questie.db.profile.enableTooltipsQuestLevel, false)
 
             -- Manually hidden quests: only show in Hidden Quests section, skip categorization
-            if Questie.db.char.hidden and Questie.db.char.hidden[questId] then 
+            if Questie.db.char.hidden and Questie.db.char.hidden[questId] then
                 if not zoneTree[7] then
                     zoneTree[7] = {
                         value = "h",

--- a/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
+++ b/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
@@ -237,17 +237,29 @@ function _QuestieJourney.questsByZone:CategorizeQuests(quests)
             temp.value = questId
             temp.text = QuestieLib:GetColoredQuestName(questId, Questie.db.profile.enableTooltipsQuestLevel, false)
 
-            local breadcrumbForQuestId = QuestieDB.QueryQuest(questId,{"breadcrumbForQuestId"})[1] or {}
-            local eligibilityText, _, returnReason = QuestieDB.IsDoableVerbose(questId, false, true, true)
+            -- Manually hidden quests: only show in Hidden Quests section, skip categorization
+            if Questie.db.char.hidden[questId] then
+                if not zoneTree[7] then
+                    zoneTree[7] = {
+                        value = "h",
+                        text = l10n("Hidden Quests"),
+                        children = {},
+                    }
+                end
+                tinsert(zoneTree[7].children, temp)
+                hiddenCounter = hiddenCounter + 1
+            else
+                local breadcrumbForQuestId = QuestieDB.QueryQuest(questId,{"breadcrumbForQuestId"})[1] or {}
+                local eligibilityText, _, returnReason = QuestieDB.IsDoableVerbose(questId, false, true, true)
 
-            -- Breadcrumb quests
-            if breadcrumbForQuestId and breadcrumbForQuestId ~= 0 then
-                tinsert(zoneTree[1].children, temp)
-                breadcrumbCounter = breadcrumbCounter + 1
-            end
+                -- Breadcrumb quests
+                if breadcrumbForQuestId and breadcrumbForQuestId ~= 0 then
+                    tinsert(zoneTree[1].children, temp)
+                    breadcrumbCounter = breadcrumbCounter + 1
+                end
 
-            -- Filtering logic. If changing anything here, also change in QuestsByFaction.lua
-            if returnReason then
+                -- Filtering logic. If changing anything here, also change in QuestsByFaction.lua
+                if returnReason then
                 if returnReason == DoableStates.AVAILABLE then -- available quests
                     if QuestieDB.IsRepeatable(questId) then
                         tinsert(zoneTree[3].children, temp)
@@ -467,19 +479,7 @@ function _QuestieJourney.questsByZone:CategorizeQuests(quests)
                         prequestMissingCounter = prequestMissingCounter + 1
                     end
                 end
-            end
-
-            -- show manually hidden quests
-            if Questie.db.char.hidden[questId] then
-                if not zoneTree[7] then
-                    zoneTree[7] = {
-                        value = "h",
-                        text = l10n("Hidden Quests"),
-                        children = {},
-                    }
                 end
-                tinsert(zoneTree[7].children, temp)
-                hiddenCounter = hiddenCounter + 1
             end
             temp = {}
         end

--- a/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
+++ b/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
@@ -237,8 +237,13 @@ function _QuestieJourney.questsByZone:CategorizeQuests(quests)
             temp.value = questId
             temp.text = QuestieLib:GetColoredQuestName(questId, Questie.db.profile.enableTooltipsQuestLevel, false)
 
-            -- Manually hidden quests: only show in Hidden Quests section, skip categorization
-            if Questie.db.char.hidden and Questie.db.char.hidden[questId] then
+            -- Manually hidden quests and option-filtered quests: only show in Hidden Quests section
+            if (Questie.db.char.hidden and Questie.db.char.hidden[questId]) or
+               (not Questie.db.profile.showEventQuests and QuestieEvent.IsEventQuest(questId)) or
+               (not Questie.db.profile.showRepeatableQuests and QuestieDB.IsRepeatable(questId)) or
+               (not Questie.db.profile.showPvPQuests and QuestieDB.IsPvPQuest(questId)) or
+               (not Questie.db.profile.showDungeonQuests and QuestieDB.IsDungeonQuest(questId)) or
+               (not Questie.db.profile.showRaidQuests and QuestieDB.IsRaidQuest(questId)) then
                 if not zoneTree[7] then
                     zoneTree[7] = {
                         value = "h",

--- a/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
+++ b/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
@@ -238,7 +238,7 @@ function _QuestieJourney.questsByZone:CategorizeQuests(quests)
             temp.text = QuestieLib:GetColoredQuestName(questId, Questie.db.profile.enableTooltipsQuestLevel, false)
 
             -- Manually hidden quests: only show in Hidden Quests section, skip categorization
-            if Questie.db.char.hidden[questId] then
+            if Questie.db.char.hidden and Questie.db.char.hidden[questId] then 
                 if not zoneTree[7] then
                     zoneTree[7] = {
                         value = "h",


### PR DESCRIPTION
This PR addresses several of the requests made in #7391. The primary features requested
~~1. Hiding quests in the journey would remove them from their respective section (available, repeatable, etc.)~~ **Overruled as an unwanted feature by an internal discussion by the Questie dev team**
2. The option that hides the icons in the GUI option also hides the respective category in the journey
3. A hide quest button available in the Quest by Zone section

## Issues
Fixes #7391 

## Screenshots
Before:
<img width="739" height="1045" alt="image" src="https://github.com/user-attachments/assets/f12fc079-8dd2-4a5e-a9f2-dc7122bf1914" />

After:
<img width="710" height="903" alt="image" src="https://github.com/user-attachments/assets/a4024eb8-e60a-4462-865f-3e4302ff3f1b" />
<img width="978" height="428" alt="image" src="https://github.com/user-attachments/assets/c705fab5-4fca-43d9-827b-ebdf419a7fc4" />
<img width="728" height="830" alt="image" src="https://github.com/user-attachments/assets/a47040fa-f8db-4e50-bc1a-0e84afb0860e" />
<img width="1368" height="285" alt="image" src="https://github.com/user-attachments/assets/e1eb6930-953b-4159-8b01-e7e3e9889f31" />
<img width="1373" height="451" alt="image" src="https://github.com/user-attachments/assets/c7e35b37-6a3c-424d-9d3d-d3afc77b3201" />



