### PR TITLE
[fix] Fix enable icons on map/options not being intertwined

### DIFF
--- a/Modules/Options/QuestieOptions.lua
+++ b/Modules/Options/QuestieOptions.lua
@@ -16,6 +16,7 @@ QuestieOptions.tabs = { ... }
 QuestieConfigFrame = nil
 
 local AceGUI = LibStub("AceGUI-3.0")
+---@type AceConfigDialog-3.0
 local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 
 -- Forward declaration

--- a/Modules/Options/QuestieOptions.lua
+++ b/Modules/Options/QuestieOptions.lua
@@ -80,7 +80,8 @@ end
 function QuestieOptions:ToggleConfigWindow()
     if not QuestieConfigFrame:IsShown() then
         PlaySound(882)
-        -- AceConfigDialog:Open("Questie", QuestieConfigFrame)
+        local AceConfigDialog = LibStub("AceConfigDialog-3.0")
+        AceConfigDialog:Open("Questie", QuestieConfigFrame)
         QuestieConfigFrame:Show()
     else
         QuestieConfigFrame:Hide()

--- a/Modules/Options/QuestieOptions.lua
+++ b/Modules/Options/QuestieOptions.lua
@@ -82,7 +82,6 @@ function QuestieOptions:ToggleConfigWindow()
     if not QuestieConfigFrame:IsShown() then
         PlaySound(882)
         AceConfigDialog:Open("Questie", QuestieConfigFrame)
-        QuestieConfigFrame:Show()
     else
         QuestieConfigFrame:Hide()
     end

--- a/Modules/Options/QuestieOptions.lua
+++ b/Modules/Options/QuestieOptions.lua
@@ -80,7 +80,6 @@ end
 function QuestieOptions:ToggleConfigWindow()
     if not QuestieConfigFrame:IsShown() then
         PlaySound(882)
-        local AceConfigDialog = LibStub("AceConfigDialog-3.0")
         AceConfigDialog:Open("Questie", QuestieConfigFrame)
         QuestieConfigFrame:Show()
     else

--- a/Modules/WorldMapButton/WorldMapButton.lua
+++ b/Modules/WorldMapButton/WorldMapButton.lua
@@ -59,6 +59,12 @@ QuestieWorldMapButtonMixin = {
             if GameTooltip:IsShown() and GameTooltip:GetOwner() == mapButton then
                 UpdateTooltip(mapButton)
             end
+            -- Refresh options UI if open to reflect new state
+            local QuestieOptions = QuestieLoader:ImportModule("QuestieOptions")
+            local AceConfigDialog = LibStub("AceConfigDialog-3.0")
+            if _G.QuestieConfigFrame and _G.QuestieConfigFrame:IsShown() then
+                AceConfigDialog:Open("Questie", _G.QuestieConfigFrame)
+            end
         elseif button == "RightButton" then
             if QuestieMenu.IsOpen() then
                 QuestieMenu:Hide()

--- a/Modules/WorldMapButton/WorldMapButton.lua
+++ b/Modules/WorldMapButton/WorldMapButton.lua
@@ -13,6 +13,11 @@ local QuestieMenu = QuestieLoader:ImportModule("QuestieMenu")
 
 local KButtons = LibStub("Krowi_WorldMapButtons-1.4")
 
+---@type QuestieOptions
+local QuestieOptions = QuestieLoader:ImportModule("QuestieOptions")
+---@type AceConfigDialog
+local AceConfigDialog = LibStub("AceConfigDialog-3.0")
+
 local mapButton
 
 function WorldMapButton.Initialize()
@@ -60,8 +65,6 @@ QuestieWorldMapButtonMixin = {
                 UpdateTooltip(mapButton)
             end
             -- Refresh options UI if open to reflect new state
-            local QuestieOptions = QuestieLoader:ImportModule("QuestieOptions")
-            local AceConfigDialog = LibStub("AceConfigDialog-3.0")
             if _G.QuestieConfigFrame and _G.QuestieConfigFrame:IsShown() then
                 AceConfigDialog:Open("Questie", _G.QuestieConfigFrame)
             end

--- a/Modules/WorldMapButton/WorldMapButton.lua
+++ b/Modules/WorldMapButton/WorldMapButton.lua
@@ -13,8 +13,6 @@ local QuestieMenu = QuestieLoader:ImportModule("QuestieMenu")
 
 local KButtons = LibStub("Krowi_WorldMapButtons-1.4")
 
----@type QuestieOptions
-local QuestieOptions = QuestieLoader:ImportModule("QuestieOptions")
 ---@type AceConfigDialog
 local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 

--- a/Modules/WorldMapButton/WorldMapButton.lua
+++ b/Modules/WorldMapButton/WorldMapButton.lua
@@ -13,7 +13,7 @@ local QuestieMenu = QuestieLoader:ImportModule("QuestieMenu")
 
 local KButtons = LibStub("Krowi_WorldMapButtons-1.4")
 
----@type AceConfigDialog
+---@type AceConfigDialog-3.0
 local AceConfigDialog = LibStub("AceConfigDialog-3.0")
 
 local mapButton


### PR DESCRIPTION
## Issue references

Fixes #3129

## Proposed changes
The GUI option for Enable Icons and the world map "Show Questie" are the same now. Before they were not causing sync issues where enabling the option on the world map would not change the GUI option.

## Screenshots

https://github.com/user-attachments/assets/4e592f40-6036-4c18-8b82-25e90139384d



