### PR TITLE
[fix]fix titan human bonus reputation

### DIFF
--- a/Modules/QuestieReputation.lua
+++ b/Modules/QuestieReputation.lua
@@ -279,7 +279,7 @@ _GetRewardMultiplier = function()
     local multiplier = 1 + buffMultiplier
 
     if playerIsHuman then
-        multiplier = multiplier + 0.1 -- 10% bonus reputation from Human Racial
+        multiplier = multiplier + (Questie.IsTitanReforged and 0 or 0.1) -- 10% bonus reputation from Human Racial（titan dont have this one）
     end
 
     if knowsMrPopularityRank2 then

--- a/Modules/QuestieReputation.lua
+++ b/Modules/QuestieReputation.lua
@@ -279,7 +279,8 @@ _GetRewardMultiplier = function()
     local multiplier = 1 + buffMultiplier
 
     if playerIsHuman then
-        multiplier = multiplier + (Questie.IsTitanReforged and 0 or 0.1) -- 10% bonus reputation from Human Racial（titan dont have this one）
+        -- Human Racial: 10% bonus reputation (not available on Titan-reforged servers)
+        multiplier = multiplier + (Questie.IsTitanReforged and 0 or 0.1)
     end
 
     if knowsMrPopularityRank2 then


### PR DESCRIPTION
Humans

Replace 【Diplomacy】 with 【Heart of the Lion】.
Lionheart: Increases your critical strike chance by 15% for 15 seconds. (3-minute cooldown) (New)
