### PR TITLE
Fix spell objective ordering and no-objective source item crash

### DIFF
--- a/.types/data/Quest.t.lua
+++ b/.types/data/Quest.t.lua
@@ -73,6 +73,7 @@
 ---@field Type "spell"
 ---@field Id SpellId
 ---@field Text string
+---@field ItemSourceId ItemId
 
 ---@class TriggerEndObjective
 ---@field Type "event"
@@ -148,13 +149,15 @@
 --   ['itemObjective'] = 3, -- table {{item(int), text(string)},...}
 --   ['reputationObjective'] = 4, -- table: {faction(int), value(int)}
 --   ['killCreditObjective'] = 5, -- table: {{{creature(int), ...}, baseCreatureID, baseCreatureText}, ...}
+--   ['spellObjective'] = 6, -- table: {{spell(int), text(string), item(int)},...}
 
----@class RawObjectives : {[1]: RawNpcObjective[], [2]: RawObjectObjective[], [3]: RawItemObjective[], [4]: RawReputationObjective, [5]: RawKillObjective[]}
+---@class RawObjectives : {[1]: RawNpcObjective[], [2]: RawObjectObjective[], [3]: RawItemObjective[], [4]: RawReputationObjective, [5]: RawKillObjective[], [6]: RawSpellObjective[]}
 ---@class RawNpcObjective : { [1]: NpcId, [2]: string }
 ---@class RawObjectObjective : { [1]: ObjectId, [2]: string }
 ---@class RawItemObjective : { [1]: ItemId, [2]: string }
 ---@class RawReputationObjective : { [1]: FactionId, [2]: number }
 ---@class RawKillObjective : { [1]: NpcId[], [2]: NpcId, [3]: string }
+---@class RawSpellObjective : { [1]: SpellId, [2]: string, [3]: ItemId }
 
 
 

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -1632,7 +1632,7 @@ function QuestieDB.GetQuest(questId) -- /dump QuestieDB.GetQuest(867)
         end
     end
 
-    -- Events need to be added at the end of ObjectiveData
+    -- Events are usually added at the end of ObjectiveData, unless corrected below.
     local triggerEnd = QO.triggerEnd
     if triggerEnd then
         ---@type TriggerEndObjective

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -1542,15 +1542,16 @@ function QuestieDB.GetQuest(questId) -- /dump QuestieDB.GetQuest(867)
                         objectObjective[3] = nil
                     end
                     ---@type ObjectObjective
-                    QO.ObjectiveData[#QO.ObjectiveData+1] = {
+                    local objectObjectiveData = {
                         Type = "object",
                         Id = objectObjective[1],
                         Text = objectObjective[2],
                         Icon = objectObjective[3]
                     }
                     if QuestieCorrections.objectObjectiveFirst[questId] then
-                        tinsert(QO.ObjectiveData, 1, QO.ObjectiveData[#QO.ObjectiveData])
-                        tremove(QO.ObjectiveData)
+                        tinsert(QO.ObjectiveData, 1, objectObjectiveData)
+                    else
+                        QO.ObjectiveData[#QO.ObjectiveData+1] = objectObjectiveData
                     end
                 end
             end
@@ -1562,15 +1563,16 @@ function QuestieDB.GetQuest(questId) -- /dump QuestieDB.GetQuest(867)
                         itemObjective[3] = nil
                     end
                     ---@type ItemObjective
-                    QO.ObjectiveData[#QO.ObjectiveData+1] = {
+                    local itemObjectiveData = {
                         Type = "item",
                         Id = itemObjective[1],
                         Text = itemObjective[2],
                         Icon = itemObjective[3]
                     }
                     if QuestieCorrections.itemObjectiveFirst[questId] then
-                        tinsert(QO.ObjectiveData, 1, QO.ObjectiveData[#QO.ObjectiveData])
-                        tremove(QO.ObjectiveData)
+                        tinsert(QO.ObjectiveData, 1, itemObjectiveData)
+                    else
+                        QO.ObjectiveData[#QO.ObjectiveData+1] = itemObjectiveData
                     end
                 end
             end
@@ -1600,9 +1602,9 @@ function QuestieDB.GetQuest(questId) -- /dump QuestieDB.GetQuest(867)
                 --? There are quest(s) which have the killCredit first so we need to switch them
                 -- Place the kill credit objective first
                 if QuestieCorrections.killCreditObjectiveFirst[questId] then
-                    tinsert(QO.ObjectiveData, 1, killCreditObjective);
+                    tinsert(QO.ObjectiveData, 1, killCreditObjective)
                 else
-                    tinsert(QO.ObjectiveData, killCreditObjective);
+                    QO.ObjectiveData[#QO.ObjectiveData+1] = killCreditObjective
                 end
             end
         end
@@ -1621,9 +1623,9 @@ function QuestieDB.GetQuest(questId) -- /dump QuestieDB.GetQuest(867)
                     --? There are quest(s) which have the spellObjective first so we need to switch them
                     -- Place the spell objective first
                     if QuestieCorrections.spellObjectiveFirst[questId] then
-                        tinsert(QO.ObjectiveData, 1, spellObjectiveData);
+                        tinsert(QO.ObjectiveData, 1, spellObjectiveData)
                     else
-                        tinsert(QO.ObjectiveData, spellObjectiveData);
+                        QO.ObjectiveData[#QO.ObjectiveData+1] = spellObjectiveData
                     end
                 end
             end
@@ -1634,14 +1636,15 @@ function QuestieDB.GetQuest(questId) -- /dump QuestieDB.GetQuest(867)
     local triggerEnd = QO.triggerEnd
     if triggerEnd then
         ---@type TriggerEndObjective
-        QO.ObjectiveData[#QO.ObjectiveData+1] = {
+        local triggerEndObjective = {
             Type = "event",
             Text = triggerEnd[1],
             Coordinates = triggerEnd[2]
         }
         if QuestieCorrections.eventObjectiveFirst[questId] then
-            tinsert(QO.ObjectiveData, 1, QO.ObjectiveData[#QO.ObjectiveData])
-            tremove(QO.ObjectiveData)
+            tinsert(QO.ObjectiveData, 1, triggerEndObjective)
+        else
+            QO.ObjectiveData[#QO.ObjectiveData+1] = triggerEndObjective
         end
     end
 

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -1663,7 +1663,7 @@ function QuestieDB.GetQuest(questId) -- /dump QuestieDB.GetQuest(867)
                 -- TODO: This is not required anymore since we validate the database for this case
                 -- Make sure requiredSourceItems aren't already an objective
                 local itemObjPresent = false
-                if objectives[3] then
+                if objectives and objectives[3] then
                     for _, itemObjective in pairs(objectives[3]) do
                         if itemObjective then
                             if itemId == itemObjective[1] then

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -1607,24 +1607,24 @@ function QuestieDB.GetQuest(questId) -- /dump QuestieDB.GetQuest(867)
             end
         end
         if objectives[6] then
-            for index, spellObjective in pairs(objectives[6]) do
+            for _, spellObjective in pairs(objectives[6]) do
                 if spellObjective then
                     ---@type SpellObjective
-                    QO.ObjectiveData[#QO.ObjectiveData+1] = {
+                    local spellObjectiveData = {
                         Type = "spell",
                         Id = spellObjective[1],
                         Text = spellObjective[2],
                         ItemSourceId = spellObjective[3],
                     }
                     QO.SpellItemId = spellObjective[3]
-                end
 
-                --? There are quest(s) which have the spellObjective first so we need to switch them
-                -- Place the spell objective first
-                if QuestieCorrections.spellObjectiveFirst[questId] then
-                    tinsert(QO.ObjectiveData, 1, spellObjective);
-                else
-                    tinsert(QO.ObjectiveData, spellObjective);
+                    --? There are quest(s) which have the spellObjective first so we need to switch them
+                    -- Place the spell objective first
+                    if QuestieCorrections.spellObjectiveFirst[questId] then
+                        tinsert(QO.ObjectiveData, 1, spellObjectiveData);
+                    else
+                        tinsert(QO.ObjectiveData, spellObjectiveData);
+                    end
                 end
             end
         end

--- a/Database/QuestieDB.test.lua
+++ b/Database/QuestieDB.test.lua
@@ -122,6 +122,25 @@ describe("QuestieDB", function()
                 },
             }, quest.ObjectiveData)
         end)
+
+        it("should add required source items as special objectives when quest has no objectives", function()
+            local questKeys = QuestieDB.questKeys
+            testQuest[questKeys.objectives] = nil
+            testQuest[questKeys.requiredSourceItems] = {67890}
+            QuestieDB.QueryQuest = spy.new(function() return testQuest end)
+            QuestieDB.QueryItemSingle = spy.new(function() return "Required Item" end)
+            QuestieLib.GetTbcLevel = function() return 60, 60 end
+
+            local quest = QuestieDB.GetQuest(123)
+
+            assert.are.same({
+                [67890] = {
+                    Type = "item",
+                    Id = 67890,
+                    Description = "Required Item",
+                },
+            }, quest.SpecialObjectives)
+        end)
     end)
 
     describe("GetItem", function()

--- a/Database/QuestieDB.test.lua
+++ b/Database/QuestieDB.test.lua
@@ -23,6 +23,11 @@ describe("QuestieDB", function()
         QuestieCorrections = require("Database.Corrections.QuestieCorrections")
         QuestieCorrections.hiddenQuests = {}
         QuestieCorrections.questItemBlacklist = {}
+        QuestieCorrections.killCreditObjectiveFirst = {}
+        QuestieCorrections.objectObjectiveFirst = {}
+        QuestieCorrections.itemObjectiveFirst = {}
+        QuestieCorrections.eventObjectiveFirst = {}
+        QuestieCorrections.spellObjectiveFirst = {}
         QuestieDB = require("Database.QuestieDB")
         QuestieDB.QueryNPCSingle = function() return nil end
         QuestieDB.private.questCache = {}
@@ -71,6 +76,51 @@ describe("QuestieDB", function()
             assert.are.same("Finish him!", quest.Description)
 
             assert.are.same({{Type = "monster", Id = 1000}}, quest.ObjectiveData)
+        end)
+
+        it("should return a spell objective once as structured objective data", function()
+            local questKeys = QuestieDB.questKeys
+            testQuest[questKeys.objectives] = {
+                [6] = {{12345, "Cast the spell", 67890}}
+            }
+            QuestieDB.QueryQuest = spy.new(function() return testQuest end)
+            QuestieLib.GetTbcLevel = function() return 60, 60 end
+
+            local quest = QuestieDB.GetQuest(123)
+
+            assert.are.same({{
+                Type = "spell",
+                Id = 12345,
+                Text = "Cast the spell",
+                ItemSourceId = 67890,
+            }}, quest.ObjectiveData)
+        end)
+
+        it("should move a structured spell objective first when corrected", function()
+            local questKeys = QuestieDB.questKeys
+            testQuest[questKeys.objectives] = {
+                [1] = {{1000, "Slay the target"}},
+                [6] = {{12345, "Cast the spell", 67890}}
+            }
+            QuestieCorrections.spellObjectiveFirst[123] = true
+            QuestieDB.QueryQuest = spy.new(function() return testQuest end)
+            QuestieLib.GetTbcLevel = function() return 60, 60 end
+
+            local quest = QuestieDB.GetQuest(123)
+
+            assert.are.same({
+                {
+                    Type = "spell",
+                    Id = 12345,
+                    Text = "Cast the spell",
+                    ItemSourceId = 67890,
+                },
+                {
+                    Type = "monster",
+                    Id = 1000,
+                    Text = "Slay the target",
+                },
+            }, quest.ObjectiveData)
         end)
     end)
 


### PR DESCRIPTION
Summary:
 - Fix spell objectives being added twice, including malformed raw entries.
 - Normalize objective-first insertion across objective types.
 - Handle required source items when quest has no objectives.
 - Update spell objective type annotations.
 - Add regression tests for spell objectives and source-item-only quests.