### PR TITLE
[Fix] Fix Bloodsail Buccaneers reputation included in QBF

### DIFF
--- a/Modules/Journey/QuestieJourneyFactions.lua
+++ b/Modules/Journey/QuestieJourneyFactions.lua
@@ -21,6 +21,7 @@ QuestieJourneyFactions.expansionFactionCandidates = {
         factionIDs.STORMWIND,
         factionIDs.ORGRIMMAR,
         factionIDs.THUNDER_BLUFF,
+        factionIDs.BLOODSAIL_BUCCANEERS,
         factionIDs.GELKIS_CLAN_CENTAUR,
         factionIDs.MAGRAM_CLAN_CENTAUR,
         factionIDs.STEAMWHEEDLE_CARTEL,


### PR DESCRIPTION
## Proposed changes

FIX: bloodsail buccaneers reputation included in QBF