### PR TITLE
[fix] Fix a frame leak when untracked quests are re-populated to the map

### DIFF
--- a/Modules/Map/QuestieMap.lua
+++ b/Modules/Map/QuestieMap.lua
@@ -86,8 +86,16 @@ function QuestieMap:UnloadQuestFrames(questId, iconType)
     if QuestieMap.questIdFrames[questId] then
         if not iconType then
             for _, frame in pairs(QuestieMap:GetFramesForQuest(questId)) do
+                -- Capture this before Unload() because it clears frame.data.
+                local objective = frame.data and frame.data.ObjectiveData
+
                 frame:Unload();
+
+                if objective then
+                    objective.AlreadySpawned = {}
+                end
             end
+
             QuestieMap.questIdFrames[questId] = nil;
         else
             for name, frame in pairs(QuestieMap:GetFramesForQuest(questId)) do

--- a/Modules/Map/QuestieMap.test.lua
+++ b/Modules/Map/QuestieMap.test.lua
@@ -13,6 +13,37 @@ describe("QuestieMap", function()
     before_each(function()
         QuestieLib = require("Modules.Libs.QuestieLib")
         QuestieMap = require("Modules.Map.QuestieMap")
+        QuestieMap.questIdFrames = {}
+    end)
+
+    describe("UnloadQuestFrames", function()
+        it("should clear AlreadySpawned for objective frames on full unload", function()
+            local objective = {AlreadySpawned = {[123] = {}}}
+            local unloadFrame1 = spy.new(function(self)
+                self.data = nil
+            end)
+            local unloadFrame2 = spy.new(function(self)
+                self.data = nil
+            end)
+            _G.QuestieFrame1 = {data = {ObjectiveData = objective}, Unload = unloadFrame1}
+            _G.QuestieFrame2 = {data = {ObjectiveData = objective}, Unload = unloadFrame2}
+            QuestieMap.questIdFrames[1] = {
+                QuestieFrame1 = "QuestieFrame1",
+                QuestieFrame2 = "QuestieFrame2",
+            }
+
+            QuestieMap:UnloadQuestFrames(1)
+
+            assert.spy(unloadFrame1).was_called()
+            assert.spy(unloadFrame2).was_called()
+            assert.is_nil(_G.QuestieFrame1.data)
+            assert.is_nil(_G.QuestieFrame2.data)
+            assert.are.same({}, objective.AlreadySpawned)
+            assert.is_nil(QuestieMap.questIdFrames[1])
+
+            _G.QuestieFrame1 = nil
+            _G.QuestieFrame2 = nil
+        end)
     end)
 
     describe("UpdateDrawnIcons", function()

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -1074,8 +1074,8 @@ _RegisterObjectiveTooltips = function(objective, questId, blockItemTooltips)
 
     if objective.spawnList then
         if (not objective.hasRegisteredTooltips) then
-            for id, spawnData in pairs(objective.spawnList) do
-                if spawnData.TooltipKey and (not objective.AlreadySpawned[id]) then
+            for _, spawnData in pairs(objective.spawnList) do
+                if spawnData.TooltipKey then
                     QuestieTooltips:RegisterObjectiveTooltip(questId, spawnData.TooltipKey, objective)
                 end
             end

--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -93,13 +93,11 @@ function QuestieTooltips:RemoveQuest(questId)
 
     if quest then
         for _, objective in pairs(quest.Objectives) do
-            objective.AlreadySpawned = {}
             objective.hasRegisteredTooltips = false
             objective.registeredItemTooltips = false
         end
 
         for _, objective in pairs(quest.SpecialObjectives) do
-            objective.AlreadySpawned = {}
             objective.hasRegisteredTooltips = false
             objective.registeredItemTooltips = false
         end

--- a/Modules/Tooltips/Tooltip.test.lua
+++ b/Modules/Tooltips/Tooltip.test.lua
@@ -400,11 +400,9 @@ describe("Tooltip", function()
 
             assert.are.same(false, objective.hasRegisteredTooltips)
             assert.are.same(false, objective.registeredItemTooltips)
-            assert.are.same({}, objective.AlreadySpawned)
 
             assert.are.same(false, specialObjective.hasRegisteredTooltips)
             assert.are.same(false, specialObjective.registeredItemTooltips)
-            assert.are.same({}, specialObjective.AlreadySpawned)
 
             assert.are.same({}, QuestieTooltips.lookupByKey)
             assert.are.same({}, QuestieTooltips.lookupKeysByQuestId)

--- a/Modules/Tooltips/Tooltip.test.lua
+++ b/Modules/Tooltips/Tooltip.test.lua
@@ -390,7 +390,11 @@ describe("Tooltip", function()
     end)
 
     describe("RemoveQuest", function()
-        it("should reset tooltip flags", function()
+        it("should reset tooltip flags without clearing AlreadySpawned", function()
+            local objectiveAlreadySpawned = {[123] = {}}
+            local specialObjectiveAlreadySpawned = {[456] = {}}
+            objective.AlreadySpawned = objectiveAlreadySpawned
+            specialObjective.AlreadySpawned = specialObjectiveAlreadySpawned
             QuestieTooltips.lookupKeysByQuestId = {[1] = {"key"}}
             QuestieTooltips.lookupByKey = {["key"] = {["1 test 2"] = {questId = 1, name = "test", starterId = 2}}}
 
@@ -400,9 +404,13 @@ describe("Tooltip", function()
 
             assert.are.same(false, objective.hasRegisteredTooltips)
             assert.are.same(false, objective.registeredItemTooltips)
+            assert.are.equal(objectiveAlreadySpawned, objective.AlreadySpawned)
+            assert.are.same({[123] = {}}, objective.AlreadySpawned)
 
             assert.are.same(false, specialObjective.hasRegisteredTooltips)
             assert.are.same(false, specialObjective.registeredItemTooltips)
+            assert.are.equal(specialObjectiveAlreadySpawned, specialObjective.AlreadySpawned)
+            assert.are.same({[456] = {}}, specialObjective.AlreadySpawned)
 
             assert.are.same({}, QuestieTooltips.lookupByKey)
             assert.are.same({}, QuestieTooltips.lookupKeysByQuestId)


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Problem

When progressing an "untracked quest", Questie re-creates the objective icons, instead of just showing the existing ones. That results in a frame leak in `QuestieFramePool`.

## Issue references

Most likely related to #5046

## Proposed changes

The problem was that removing tooltips for untracked quests also marked the objective icons as "not present" without actually removing them. So Questie re-created the icons. Now `objective.AlreadySpawned` is not cleared when removing tooltips, so Questie can reuse these icons.

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->

Stacked frames for the same quest objectives (before):
<img width="1668" height="941" alt="image" src="https://github.com/user-attachments/assets/5d5f585f-6794-44d8-8a48-8170fdbb17b7" />
