### PR TITLE
[fix] Prevent auto-accept filters from re-allowing quests

### DIFF
--- a/Modules/Auto/AutoQuesting.lua
+++ b/Modules/Auto/AutoQuesting.lua
@@ -102,7 +102,7 @@ function AutoQuesting.OnGossipShow()
         if #availableQuests > 0 then
             local indexToAccept = 0
 
-            if Questie.db.profile.autoAccept.trivial and Questie.db.profile.autoAccept.repeatable then
+            if Questie.db.profile.autoAccept.trivial and Questie.db.profile.autoAccept.repeatable and Questie.db.profile.autoAccept.pvp then
                 indexToAccept = 1
             else
                 for i = 1, #availableQuests do

--- a/Modules/Auto/AutoQuesting.lua
+++ b/Modules/Auto/AutoQuesting.lua
@@ -29,6 +29,7 @@ function AutoQuesting.OnQuestDetail()
         end
     end
 
+    -- Validate every disabled Auto Accept variant without letting later checks re-allow a rejected quest.
     local doAcceptQuest = true
     if (not Questie.db.profile.autoAccept.trivial) then
         local questLevel = QuestieDB.QueryQuestSingle(questId, "questLevel")
@@ -102,6 +103,7 @@ function AutoQuesting.OnGossipShow()
         if #availableQuests > 0 then
             local indexToAccept = 0
 
+            -- Skip per-quest filtering only when all Auto Accept variants are allowed.
             if Questie.db.profile.autoAccept.trivial and Questie.db.profile.autoAccept.repeatable and Questie.db.profile.autoAccept.pvp then
                 indexToAccept = 1
             else

--- a/Modules/Auto/AutoQuesting.lua
+++ b/Modules/Auto/AutoQuesting.lua
@@ -35,10 +35,10 @@ function AutoQuesting.OnQuestDetail()
         doAcceptQuest = (not QuestieDB.IsTrivial(questLevel))
     end
     if (not Questie.db.profile.autoAccept.repeatable) then
-        doAcceptQuest = (not QuestieDB.IsRepeatable(questId))
+        doAcceptQuest = doAcceptQuest and (not QuestieDB.IsRepeatable(questId))
     end
     if (not Questie.db.profile.autoAccept.pvp) then
-        doAcceptQuest = (not QuestieDB.IsPvPQuest(questId))
+        doAcceptQuest = doAcceptQuest and (not QuestieDB.IsPvPQuest(questId))
     end
 
     if doAcceptQuest then

--- a/Modules/Auto/AutoQuesting.test.lua
+++ b/Modules/Auto/AutoQuesting.test.lua
@@ -174,6 +174,20 @@ describe("AutoQuesting", function()
             assert.spy(_G.AcceptQuest).was_not.called()
         end)
 
+        it("should not re-allow trivial quest when repeatable and PvP checks pass", function()
+            Questie.db.profile.autoAccept.repeatable = false
+            Questie.db.profile.autoAccept.pvp = false
+            _G.GetQuestID = function() return 123 end
+            QuestieDB.QueryQuestSingle = spy.new(function() return 10 end)
+            QuestieDB.IsTrivial = spy.new(function() return true end)
+            QuestieDB.IsRepeatable = spy.new(function() return false end)
+            QuestieDB.IsPvPQuest = spy.new(function() return false end)
+
+            AutoQuesting.OnQuestDetail()
+
+            assert.spy(_G.AcceptQuest).was_not.called()
+        end)
+
         it("should accept repeatable quest when setting is enabled", function()
             Questie.db.profile.autoAccept.trivial = true
             Questie.db.profile.autoAccept.repeatable = true
@@ -187,6 +201,7 @@ describe("AutoQuesting", function()
         end)
 
         it("should not accept repeatable quest when setting is disabled", function()
+            Questie.db.profile.autoAccept.trivial = true
             Questie.db.profile.autoAccept.repeatable = false
             _G.GetQuestID = function() return 123 end
             QuestieDB.IsRepeatable = spy.new(function() return true end)
@@ -195,6 +210,19 @@ describe("AutoQuesting", function()
 
             assert.spy(_G.AcceptQuest).was_not.called()
             assert.spy(QuestieDB.IsRepeatable).was.called_with(123)
+        end)
+
+        it("should not re-allow repeatable quest when PvP check passes", function()
+            Questie.db.profile.autoAccept.trivial = true
+            Questie.db.profile.autoAccept.repeatable = false
+            Questie.db.profile.autoAccept.pvp = false
+            _G.GetQuestID = function() return 123 end
+            QuestieDB.IsRepeatable = spy.new(function() return true end)
+            QuestieDB.IsPvPQuest = spy.new(function() return false end)
+
+            AutoQuesting.OnQuestDetail()
+
+            assert.spy(_G.AcceptQuest).was_not.called()
         end)
 
         it("should accept PvP quest when setting is enabled", function()
@@ -210,6 +238,7 @@ describe("AutoQuesting", function()
         end)
 
         it("should not accept PvP quest when setting is disabled", function()
+            Questie.db.profile.autoAccept.trivial = true
             Questie.db.profile.autoAccept.pvp = false
             _G.GetQuestID = function() return 123 end
             QuestieDB.IsPvPQuest = spy.new(function() return true end)

--- a/Modules/Auto/AutoQuesting.test.lua
+++ b/Modules/Auto/AutoQuesting.test.lua
@@ -580,6 +580,21 @@ describe("AutoQuesting", function()
             assert.spy(_G.QuestieCompat.SelectAvailableQuest).was_called_with(2)
         end)
 
+        it("should skip PvP quest when trivial and repeatable settings are enabled", function()
+            Questie.db.profile.autoAccept.trivial = true
+            Questie.db.profile.autoAccept.repeatable = true
+            Questie.db.profile.autoAccept.pvp = false
+            _G.QuestieCompat.GetAvailableQuests = function()
+                return {getAvailableTestQuest({questID = 1}), getAvailableTestQuest({questID = 2})}
+            end
+            QuestieDB.IsPvPQuest = spy.new(function(questId) return questId == 1 end)
+
+            AutoQuesting.OnGossipShow()
+
+            assert.spy(_G.QuestieCompat.SelectAvailableQuest).was_not.called_with(1)
+            assert.spy(_G.QuestieCompat.SelectAvailableQuest).was_called_with(2)
+        end)
+
         it("should not turn in quest when no quest is complete", function()
             _G.QuestieCompat.GetActiveQuests = function()
                 return {getActiveTestQuest({})}


### PR DESCRIPTION
## What changed

### Part 1: `OnQuestDetail()` filter accumulation
`AutoQuesting.OnQuestDetail()` now preserves earlier auto-accept filter rejections when later filters are evaluated.

Previously, the repeatable/PvP checks reassigned `doAcceptQuest`, so a quest rejected by an earlier filter could be re-allowed by a later passing check. For example, a trivial quest could still be accepted when trivial auto-accept was disabled if subsequent repeatable/PvP checks passed.

The repeatable and PvP checks now accumulate with the existing decision using `and`, so once a quest is rejected, later filters cannot turn the decision back to accepted.

### Part 2: `OnGossipShow()` PvP filtering
`AutoQuesting.OnGossipShow()` now still honors the PvP auto-accept filter when trivial and repeatable quests are allowed.

Previously, gossip auto-accept short-circuited to the first available quest whenever trivial and repeatable quests were allowed. That bypassed the PvP filter, so with PvP auto-accept disabled, a PvP quest could still be selected.

The shortcut now only applies when trivial, repeatable, and PvP quests are all allowed. Otherwise, the existing filtering loop runs and can skip PvP quests as intended.

### Intent comments
Added concise comments near both filter blocks to document that all Auto Accept variants must be considered. This should make it clearer for future changes that new variants must not accidentally re-allow rejected quests or bypass filtering shortcuts.

## Tests

Added regression tests covering:
- `OnQuestDetail()`: trivial quests are not accepted even when repeatable/PvP checks would pass
- `OnQuestDetail()`: repeatable quests are not accepted even when the PvP check would pass
- `OnGossipShow()`: PvP quests are skipped even when trivial and repeatable settings are enabled

Validation run:
- `busted Modules/Auto/AutoQuesting.test.lua --filter "OnGossipShow"`
- `busted Modules/Auto/AutoQuesting.test.lua --filter "OnQuestDetail"`
- `busted Modules/Auto/AutoQuesting.test.lua`

Fixes #1
