### PR TITLE
[fix] Unlearning a profession now calls redraw of available quests

### DIFF
--- a/Modules/QuestieProfessions.lua
+++ b/Modules/QuestieProfessions.lua
@@ -2,6 +2,8 @@
 local QuestieProfessions = QuestieLoader:CreateModule("QuestieProfessions");
 ---@type QuestieQuest
 local QuestieQuest = QuestieLoader:ImportModule("QuestieQuest");
+---@type AvailableQuests
+local AvailableQuests = QuestieLoader:ImportModule("AvailableQuests")
 ---@type Expansions
 local Expansions = QuestieLoader:ImportModule("Expansions")
 
@@ -25,6 +27,7 @@ hooksecurefunc("AbandonSkill", function(skillIndex)
             playerProfessions[professionTable[skillName]] = nil
             --? Reset all autoBlacklisted quests if a skill is abandoned
             QuestieQuest.ResetAutoblacklistCategory("skill")
+            AvailableQuests.CalculateAndDrawAll()
         end
     end
 end)

--- a/Modules/QuestieProfessions.test.lua
+++ b/Modules/QuestieProfessions.test.lua
@@ -41,7 +41,7 @@ describe("QuestieProfessions", function()
             ["Inscription"] = {["enUS"] = true},
             ["Riding"] = {["enUS"] = true},
         }
-        QuestieQuest = require("Modules.Quest.QuestieQuest")
+        QuestieQuest = QuestieLoader:CreateModule("QuestieQuest")
         QuestieQuest.ResetAutoblacklistCategory = spy.new(function()  end)
         QuestieProfessions = require("Modules.QuestieProfessions")
         QuestieProfessions:Init()
@@ -103,7 +103,7 @@ describe("QuestieProfessions", function()
                 end
             end
 
-            AvailableQuests = require("Modules.Quest.AvailableQuests.AvailableQuests")
+            AvailableQuests = QuestieLoader:CreateModule("AvailableQuests")
             AvailableQuests.CalculateAndDrawAll = spy.new(function() end)
 
             -- Force a fresh load so the hooksecurefunc("AbandonSkill", ...) registration re-runs and is captured

--- a/Modules/QuestieProfessions.test.lua
+++ b/Modules/QuestieProfessions.test.lua
@@ -90,4 +90,36 @@ describe("QuestieProfessions", function()
             assert.spy(QuestieQuest.ResetAutoblacklistCategory).was_not.called()
         end)
     end)
+
+    describe("AbandonSkill", function()
+        local AvailableQuests
+        local abandonSkillCallback
+
+        before_each(function()
+            _G.AbandonSkill = function() end
+            _G.hooksecurefunc = function(name, callback)
+                if name == "AbandonSkill" then
+                    abandonSkillCallback = callback
+                end
+            end
+
+            AvailableQuests = require("Modules.Quest.AvailableQuests.AvailableQuests")
+            AvailableQuests.CalculateAndDrawAll = spy.new(function() end)
+
+            -- Force a fresh load so the hooksecurefunc("AbandonSkill", ...) registration re-runs and is captured
+            package.loaded["Modules.QuestieProfessions"] = nil
+            QuestieProfessions = require("Modules.QuestieProfessions")
+            QuestieProfessions:Init()
+
+            -- Register the profession so the abandon hook acts on it
+            QuestieProfessions:Update()
+        end)
+
+        it("should reset the skill blacklist and recalculate available quests when a profession is abandoned", function()
+            abandonSkillCallback(1)
+
+            assert.spy(QuestieQuest.ResetAutoblacklistCategory).was.called_with("skill")
+            assert.spy(AvailableQuests.CalculateAndDrawAll).was.called()
+        end)
+    end)
 end)

--- a/Modules/QuestieProfessions.test.lua
+++ b/Modules/QuestieProfessions.test.lua
@@ -41,7 +41,7 @@ describe("QuestieProfessions", function()
             ["Inscription"] = {["enUS"] = true},
             ["Riding"] = {["enUS"] = true},
         }
-        QuestieQuest = QuestieLoader:CreateModule("QuestieQuest")
+        QuestieQuest = QuestieLoader:ImportModule("QuestieQuest")
         QuestieQuest.ResetAutoblacklistCategory = spy.new(function()  end)
         QuestieProfessions = require("Modules.QuestieProfessions")
         QuestieProfessions:Init()
@@ -103,7 +103,7 @@ describe("QuestieProfessions", function()
                 end
             end
 
-            AvailableQuests = QuestieLoader:CreateModule("AvailableQuests")
+            AvailableQuests = QuestieLoader:ImportModule("AvailableQuests")
             AvailableQuests.CalculateAndDrawAll = spy.new(function() end)
 
             -- Force a fresh load so the hooksecurefunc("AbandonSkill", ...) registration re-runs and is captured


### PR DESCRIPTION
## Issue references

Fixes #7619

## Proposed changes

- FIX: unlearning a profession now calls a calculate and redraw of available quests
