### PR TITLE
[fix] Use remote player name for tooltip class lookup

### DIFF
--- a/Modules/Tooltips/Tooltip.lua
+++ b/Modules/Tooltips/Tooltip.lua
@@ -392,7 +392,7 @@ function QuestieTooltips.GetTooltip(key, playerZone)
                 if playerInfo then
                     playerColor = "|c" .. playerInfo.colorHex
                 elseif QuestieComms.remotePlayerEnabled[objectivePlayerName] and QuestieComms.remoteQuestLogs[questId] and QuestieComms.remoteQuestLogs[questId][objectivePlayerName] and (not Questie.db.profile.onlyPartyShared or UnitInParty(objectivePlayerName)) then
-                    playerColor = QuestieComms.remotePlayerClasses[playerName]
+                    playerColor = QuestieComms.remotePlayerClasses[objectivePlayerName]
                     if playerColor then
                         playerColor = Questie:GetClassColor(playerColor)
                         playerType = " (" .. l10n("Nearby") .. ")"

--- a/Modules/Tooltips/Tooltip.test.lua
+++ b/Modules/Tooltips/Tooltip.test.lua
@@ -7,6 +7,8 @@ describe("Tooltip", function()
     local QuestieDB
     ---@type QuestieLib
     local QuestieLib
+    ---@type QuestieComms
+    local QuestieComms
     ---@type QuestiePlayer
     local QuestiePlayer
     ---@type QuestieTooltips
@@ -43,6 +45,13 @@ describe("Tooltip", function()
         QuestieLib.GetRGBForObjective = spy.new(function()
             return "gold"
         end)
+        QuestieComms = require("Modules.Network.QuestieComms")
+        QuestieComms.remoteQuestLogs = {}
+        QuestieComms.remotePlayerClasses = {}
+        QuestieComms.remotePlayerEnabled = {}
+        QuestieComms.data.KeyExists = function() return false end
+        QuestieComms.data.GetTooltip = function() return {} end
+        require("Localization.l10n")
         QuestiePlayer = require("Modules.QuestiePlayer")
         QuestieTooltips = require("Modules.Tooltips.Tooltip")
     end)
@@ -75,6 +84,47 @@ describe("Tooltip", function()
 
             assert.spy(QuestieLib.GetColoredQuestName).was_not_called()
             assert.is_nil(tooltip)
+        end)
+
+        it("should use the objective player name for remote player class lookup", function()
+            _G.UnitName = function() return "Local" end
+            _G.IsInGroup = function() return true end
+            Questie.GetClassColor = spy.new(function()
+                return "|cFFC79C6E"
+            end)
+            QuestieTooltips.lookupByKey = {}
+            QuestieComms.remotePlayerEnabled["Bob"] = true
+            QuestieComms.remotePlayerClasses["Bob"] = "WARRIOR"
+            QuestieComms.remoteQuestLogs[1] = { ["Bob"] = {} }
+            QuestieComms.data.KeyExists = function(_, key)
+                return key == "m_123"
+            end
+            QuestieComms.data.GetTooltip = function(_, key)
+                if key == "m_123" then
+                    return {
+                        [1] = {
+                            ["Bob"] = {
+                                [1] = {
+                                    fulfilled = 3,
+                                    required = 5,
+                                    text = "do it",
+                                }
+                            }
+                        }
+                    }
+                end
+
+                return {}
+            end
+
+            local tooltip = QuestieTooltips.GetTooltip("m_123")
+
+            assert.is_nil(QuestieComms.remotePlayerClasses["Local"])
+            assert.spy(Questie.GetClassColor).was_called_with(Questie, "WARRIOR")
+            assert.are.same({
+                "Quest Name",
+                "   gold3/5 do it (|cFFC79C6EBob|rgold)|r (Nearby)",
+            }, tooltip)
         end)
 
         it("should return quest name and objective when tooltip has spell objective", function()


### PR DESCRIPTION
## Summary

This fixes remote player class coloring in tooltip data.

Before this PR, tooltip data for a remote/objective player could still look up class information using the local player name:

```text
QuestieTooltips.GetTooltip(objectivePlayerName)
  -> local player name is read from UnitName("player")
  -> remote tooltip data is built for objectivePlayerName
  -> class lookup uses QuestieComms.remotePlayerClasses[playerName]
       where playerName is the local player
```

That was wrong for remote player objectives. If the local player is `"Local"` and the tooltip is being built for `"Bob"`, the tooltip should use Bob's class data:

```lua
QuestieComms.remotePlayerClasses["Bob"] = "WARRIOR"
```

But the old lookup checked:

```lua
QuestieComms.remotePlayerClasses["Local"]
```

So if `"Local"` had no remote class entry, Questie could miss Bob's class entirely, or in other cases use the wrong player's class information.

After this PR, the remote class lookup uses the player whose tooltip objective data is being rendered:

```text
QuestieTooltips.GetTooltip(objectivePlayerName)
  -> remote tooltip data is built for objectivePlayerName
  -> class lookup uses QuestieComms.remotePlayerClasses[objectivePlayerName]
       where objectivePlayerName is the remote/objective player
```

Concretely, `Tooltip.lua` now looks up the class using the remote/objective player name instead of the local player viewing the tooltip.

A regression test was added for the Local/Bob case:

```text
Local player: "Local"
Remote/objective player: "Bob"
Bob class: "WARRIOR"
Local class entry: nil
```

The test verifies that Bob appears in the tooltip using Bob's Warrior class information.

## Validation

```bash
busted Modules/Tooltips/Tooltip.test.lua
busted -p ".test.lua" Modules/Tooltips
git diff --check
```
