### PR TITLE
Fix tracker focus removal to match exact quest ids

### DIFF
--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -1911,8 +1911,14 @@ function QuestieTracker:RemoveQuest(questId)
     end
 
     if Questie.db.char.TrackerFocus then
-        if (type(Questie.db.char.TrackerFocus) == "number" and Questie.db.char.TrackerFocus == questId)
-            or (type(Questie.db.char.TrackerFocus) == "string" and Questie.db.char.TrackerFocus:sub(1, #tostring(questId)) == tostring(questId)) then
+        local focusedQuestId
+        if type(Questie.db.char.TrackerFocus) == "number" then
+            focusedQuestId = Questie.db.char.TrackerFocus
+        elseif type(Questie.db.char.TrackerFocus) == "string" then
+            focusedQuestId = tonumber(Questie.db.char.TrackerFocus:match("^(%d+)%s"))
+        end
+
+        if focusedQuestId == questId then
             TrackerUtils:UnFocus()
             QuestieQuest:ToggleNotes(true)
         end

--- a/Modules/Tracker/QuestieTracker.test.lua
+++ b/Modules/Tracker/QuestieTracker.test.lua
@@ -1,0 +1,53 @@
+dofile("setupTests.lua")
+
+_G.GetQuestTimers = function() return nil end
+
+-- Real Classic Alliance Elwynn Forest quests: 11 = Riverpaw Gnoll Bounty, 112 = Collecting Kelp.
+local RIVERPAW_GNOLL_BOUNTY_ID = 11
+local COLLECTING_KELP_ID = 112
+local COLLECTING_KELP_OBJECTIVE_INDEX = 1
+
+describe("QuestieTracker", function()
+    ---@type QuestieTracker
+    local QuestieTracker
+    ---@type TrackerUtils
+    local TrackerUtils
+    ---@type QuestieQuest
+    local QuestieQuest
+
+    before_each(function()
+        Questie.db.char = {
+            collapsedQuests = {},
+            AutoUntrackedQuests = {},
+            TrackedQuests = {},
+        }
+        Questie.db.profile = {}
+
+        QuestieTracker = require("Modules.Tracker.QuestieTracker")
+        TrackerUtils = require("Modules.Tracker.TrackerUtils")
+        QuestieQuest = require("Modules.Quest.QuestieQuest")
+
+        TrackerUtils.UnFocus = spy.new(function() end)
+        QuestieQuest.ToggleNotes = spy.new(function() end)
+    end)
+
+    describe("RemoveQuest", function()
+        it("should not unfocus when the removed quest id is only a prefix of the focused quest id", function()
+            Questie.db.char.TrackerFocus = tostring(COLLECTING_KELP_ID) .. " " .. tostring(COLLECTING_KELP_OBJECTIVE_INDEX)
+
+            QuestieTracker:RemoveQuest(RIVERPAW_GNOLL_BOUNTY_ID)
+
+            assert.spy(TrackerUtils.UnFocus).was_not_called()
+            assert.spy(QuestieQuest.ToggleNotes).was_not_called()
+        end)
+
+        it("should unfocus when the removed quest id matches the focused quest id", function()
+            Questie.db.char.TrackerFocus = tostring(COLLECTING_KELP_ID) .. " " .. tostring(COLLECTING_KELP_OBJECTIVE_INDEX)
+
+            QuestieTracker:RemoveQuest(COLLECTING_KELP_ID)
+
+            assert.spy(TrackerUtils.UnFocus).was_called()
+            assert.spy(QuestieQuest.ToggleNotes).was_called_with(QuestieQuest, true)
+        end)
+    end)
+end)


### PR DESCRIPTION
## Summary
`QuestieTracker:RemoveQuest` previously checked whether `TrackerFocus` started with the removed quest id. That made focus cleanup use a string prefix instead of the actual focused quest id, so removing quest `11` could accidentally clear focus for objective focus `"112 1"`. Now `RemoveQuest` parses the focused quest id from strings like `"<questId> <objectiveIndex>"` and only unfocuses when it exactly matches the removed quest.

## Before
```text
Player focuses objective 1 of quest 112
  -> TrackerFocus = "112 1"

Quest 11 is removed
  -> RemoveQuest(11)
  -> prefix check sees "112 1" starts with "11"
  -> Questie incorrectly treats quest 11 as focused
  -> UnFocus()
  -> ToggleNotes(true)
  -> focus for quest 112 is lost
```

## After
```text
Player focuses objective 1 of quest 112
  -> TrackerFocus = "112 1"

Quest 11 is removed
  -> RemoveQuest(11)
  -> focused quest id is parsed as 112
  -> exact comparison checks 112 == 11
  -> no unfocus
  -> focus for quest 112 remains active
```

## Example
A player can focus an objective for **Collecting Kelp** (`112`), which stores tracker focus as `"112 1"`. If **Riverpaw Gnoll Bounty** (`11`) is then removed from the tracker, the old prefix check treated `"112 1"` as matching quest `11` and cleared the player's focus. The new logic parses `112` from the focus string, sees that quest `11` is not the focused quest, and leaves the focused objective alone.

## Responsibility / ownership
Tracker focus belongs to the quest id encoded in `TrackerFocus`, not to any quest id that happens to share the same leading digits. `RemoveQuest` should only clean up focus for the quest being removed, so the cleanup is now keyed by the parsed numeric quest id instead of a string prefix.

## Validation
- `busted Modules/Tracker/QuestieTracker.test.lua`: passed, `2 successes / 0 failures / 0 errors`
- `busted -p ".test.lua" Modules/Tracker`: passed, `62 successes / 0 failures / 0 errors`
- `luacheck -q Modules/Tracker/QuestieTracker.lua`: passed, `0 warnings / 0 errors`
