### PR TITLE
Fix comms tooltip registration after skipped item objectives

### DIFF
--- a/Modules/Network/QuestieCommsData.lua
+++ b/Modules/Network/QuestieCommsData.lua
@@ -115,10 +115,10 @@ function QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
                         local sourceLookupKey = sourceType.."_"..sourceId;
                         QuestieComms.data:AddTooltip(playerName, questId, sourceLookupKey, objectiveIndex, objective);
                     end
-
-                    -- Show this objective when hovering the item itself.
-                    QuestieComms.data:AddTooltip(playerName, questId, lookupKey, objectiveIndex, objective);
                 end
+
+                -- Show this objective when hovering the item itself.
+                QuestieComms.data:AddTooltip(playerName, questId, lookupKey, objectiveIndex, objective);
             else
                 -- Show non-item objectives when hovering their direct objective entity.
                 QuestieComms.data:AddTooltip(playerName, questId, lookupKey, objectiveIndex, objective);

--- a/Modules/Network/QuestieCommsData.lua
+++ b/Modules/Network/QuestieCommsData.lua
@@ -87,36 +87,43 @@ function QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
     if(not playerRegisteredTooltips[playerName][questId]) then
         playerRegisteredTooltips[playerName][questId] = {}
     end
-    for objectiveIndex, objective in pairs(objectives) do
-      if(objective.type and objective.id) then
-        local lookupKey = objective.type.."_"..objective.id;
-        --Questie:Debug(Questie.DEBUG_DEVELOP, "Adding tooltip lookup", lookupKey, questId, playerName);
-        if(objective.type == "i") then
-          local item = QuestieDB:GetItem(objective.id);
-          if not item or item.Hidden then
-            return
-          end
-          for index, source in pairs(item.Sources or {}) do
-            local sourceType = string.sub(source.Type, 1, 1);
-            local sourceId = source.Id;
-            local sourceLookupKey = sourceType.."_"..sourceId;
-            QuestieComms.data:AddTooltip(playerName, questId, sourceLookupKey, objectiveIndex, objective);
-          end
-        end
-        --[[if(not commsTooltipLookup[lookupKey]) then
-            commsTooltipLookup[lookupKey] = {}
-        end
-        if(not commsTooltipLookup[lookupKey][playerName]) then
-            commsTooltipLookup[lookupKey][playerName] = {};
-        end
-        if(not commsTooltipLookup[lookupKey][playerName][questId]) then
-            commsTooltipLookup[lookupKey][playerName][questId] = {};
-        end
-        commsTooltipLookup[lookupKey][playerName][questId][objectiveIndex] = objective;
+    --[[if(not commsTooltipLookup[lookupKey]) then
+        commsTooltipLookup[lookupKey] = {}
+    end
+    if(not commsTooltipLookup[lookupKey][playerName]) then
+        commsTooltipLookup[lookupKey][playerName] = {};
+    end
+    if(not commsTooltipLookup[lookupKey][playerName][questId]) then
+        commsTooltipLookup[lookupKey][playerName][questId] = {};
+    end
+    commsTooltipLookup[lookupKey][playerName][questId][objectiveIndex] = objective;
 
-        playerRegisteredTooltips[playerName][questId][lookupKey] = true;]]--
-        QuestieComms.data:AddTooltip(playerName, questId, lookupKey, objectiveIndex, objective);
-      end
+    playerRegisteredTooltips[playerName][questId][lookupKey] = true;]]--
+    for objectiveIndex, objective in pairs(objectives) do
+        if(objective.type and objective.id) then
+            local lookupKey = objective.type.."_"..objective.id;
+            --Questie:Debug(Questie.DEBUG_DEVELOP, "Adding tooltip lookup", lookupKey, questId, playerName);
+
+            -- Item Objective
+            if(objective.type == "i") then
+                local item = QuestieDB:GetItem(objective.id);
+                if item and not item.Hidden then
+                    -- Show this item objective when hovering entities that can provide the item.
+                    for _, source in pairs(item.Sources or {}) do
+                        local sourceType = string.sub(source.Type, 1, 1);
+                        local sourceId = source.Id;
+                        local sourceLookupKey = sourceType.."_"..sourceId;
+                        QuestieComms.data:AddTooltip(playerName, questId, sourceLookupKey, objectiveIndex, objective);
+                    end
+
+                    -- Show this objective when hovering the item itself.
+                    QuestieComms.data:AddTooltip(playerName, questId, lookupKey, objectiveIndex, objective);
+                end
+            else
+                -- Show non-item objectives when hovering their direct objective entity.
+                QuestieComms.data:AddTooltip(playerName, questId, lookupKey, objectiveIndex, objective);
+            end
+        end
     end
 end
 
@@ -131,7 +138,7 @@ function QuestieComms.data:AddTooltip(playerName, questId, lookupKey, objectiveI
         commsTooltipLookup[lookupKey][playerName][questId] = {};
     end
     commsTooltipLookup[lookupKey][playerName][questId][objectiveIndex] = data;
-    
+
     playerRegisteredTooltips[playerName][questId][lookupKey] = true;
 end
 

--- a/Modules/Network/QuestieCommsData.lua
+++ b/Modules/Network/QuestieCommsData.lua
@@ -87,18 +87,6 @@ function QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
     if(not playerRegisteredTooltips[playerName][questId]) then
         playerRegisteredTooltips[playerName][questId] = {}
     end
-    --[[if(not commsTooltipLookup[lookupKey]) then
-        commsTooltipLookup[lookupKey] = {}
-    end
-    if(not commsTooltipLookup[lookupKey][playerName]) then
-        commsTooltipLookup[lookupKey][playerName] = {};
-    end
-    if(not commsTooltipLookup[lookupKey][playerName][questId]) then
-        commsTooltipLookup[lookupKey][playerName][questId] = {};
-    end
-    commsTooltipLookup[lookupKey][playerName][questId][objectiveIndex] = objective;
-
-    playerRegisteredTooltips[playerName][questId][lookupKey] = true;]]--
     for objectiveIndex, objective in pairs(objectives) do
         if(objective.type and objective.id) then
             local lookupKey = objective.type.."_"..objective.id;

--- a/Modules/Network/QuestieCommsData.test.lua
+++ b/Modules/Network/QuestieCommsData.test.lua
@@ -7,13 +7,22 @@ describe("QuestieCommsData", function()
     ---@type QuestieDB
     local QuestieDB
 
-    before_each(function()
-        QuestieComms = require("Modules.Network.QuestieComms")
+    local originalGetItem
 
-        QuestieDB = require("Database.QuestieDB")
+    before_each(function()
+        QuestieComms = QuestieLoader:ImportModule("QuestieComms")
+        QuestieComms.data = {}
+
+        QuestieDB = QuestieLoader:ImportModule("QuestieDB")
+        originalGetItem = QuestieDB.GetItem
         QuestieDB.GetItem = function() return nil end
 
-        require("Modules.Network.QuestieCommsData")
+        dofile("Modules/Network/QuestieCommsData.lua")
+        QuestieComms.data:ResetAll()
+    end)
+
+    after_each(function()
+        QuestieDB.GetItem = originalGetItem
         QuestieComms.data:ResetAll()
     end)
 

--- a/Modules/Network/QuestieCommsData.test.lua
+++ b/Modules/Network/QuestieCommsData.test.lua
@@ -1,0 +1,67 @@
+dofile("setupTests.lua")
+
+describe("QuestieCommsData", function()
+    ---@type QuestieComms
+    local QuestieComms
+
+    ---@type QuestieDB
+    local QuestieDB
+
+    before_each(function()
+        QuestieComms = QuestieLoader:ImportModule("QuestieComms")
+        QuestieComms.data = {}
+
+        QuestieDB = QuestieLoader:ImportModule("QuestieDB")
+        QuestieDB.GetItem = function(_, itemId)
+            if itemId == 1001 then
+                return nil
+            elseif itemId == 1002 then
+                return { Hidden = true }
+            end
+        end
+
+        dofile("Modules/Network/QuestieCommsData.lua")
+        QuestieComms.data:ResetAll()
+    end)
+
+    describe("RegisterTooltip", function()
+        local cases = {
+            {
+                name = "missing item data",
+                itemId = 1001,
+                monsterId = 2002,
+            },
+            {
+                name = "hidden item data",
+                itemId = 1002,
+                monsterId = 2003,
+            },
+        }
+
+        for _, case in ipairs(cases) do
+            it("continues registering later objectives after skipping " .. case.name, function()
+                local questId = 42
+                local playerName = "OtherPlayer"
+                local objectives = {
+                    [1] = {
+                        type = "i",
+                        id = case.itemId,
+                        fulfilled = 0,
+                        required = 1,
+                    },
+                    [2] = {
+                        type = "m",
+                        id = case.monsterId,
+                        fulfilled = 0,
+                        required = 1,
+                    },
+                }
+
+                QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
+
+                assert.is_false(QuestieComms.data:KeyExists("i_" .. case.itemId))
+                assert.is_true(QuestieComms.data:KeyExists("m_" .. case.monsterId))
+            end)
+        end
+    end)
+end)

--- a/Modules/Network/QuestieCommsData.test.lua
+++ b/Modules/Network/QuestieCommsData.test.lua
@@ -8,13 +8,12 @@ describe("QuestieCommsData", function()
     local QuestieDB
 
     before_each(function()
-        QuestieComms = QuestieLoader:ImportModule("QuestieComms")
-        QuestieComms.data = {}
+        QuestieComms = require("Modules.Network.QuestieComms")
 
-        QuestieDB = QuestieLoader:ImportModule("QuestieDB")
+        QuestieDB = require("Database.QuestieDB")
         QuestieDB.GetItem = function() return nil end
 
-        dofile("Modules/Network/QuestieCommsData.lua")
+        require("Modules.Network.QuestieCommsData")
         QuestieComms.data:ResetAll()
     end)
 

--- a/Modules/Network/QuestieCommsData.test.lua
+++ b/Modules/Network/QuestieCommsData.test.lua
@@ -16,7 +16,15 @@ describe("QuestieCommsData", function()
             if itemId == 1001 then
                 return nil
             elseif itemId == 1002 then
-                return { Hidden = true }
+                return {
+                    Hidden = true,
+                    Sources = {
+                        {
+                            Type = "monster",
+                            Id = 3003,
+                        },
+                    },
+                }
             end
         end
 
@@ -35,11 +43,12 @@ describe("QuestieCommsData", function()
                 name = "hidden item data",
                 itemId = 1002,
                 monsterId = 2003,
+                skippedSourceKey = "m_3003",
             },
         }
 
         for _, case in ipairs(cases) do
-            it("continues registering later objectives after skipping " .. case.name, function()
+            it("registers direct item and later objectives while skipping source expansion for " .. case.name, function()
                 local questId = 42
                 local playerName = "OtherPlayer"
                 local objectives = {
@@ -59,7 +68,10 @@ describe("QuestieCommsData", function()
 
                 QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
 
-                assert.is_false(QuestieComms.data:KeyExists("i_" .. case.itemId))
+                assert.is_true(QuestieComms.data:KeyExists("i_" .. case.itemId))
+                if case.skippedSourceKey then
+                    assert.is_false(QuestieComms.data:KeyExists(case.skippedSourceKey))
+                end
                 assert.is_true(QuestieComms.data:KeyExists("m_" .. case.monsterId))
             end)
         end

--- a/Modules/Network/QuestieCommsData.test.lua
+++ b/Modules/Network/QuestieCommsData.test.lua
@@ -12,68 +12,75 @@ describe("QuestieCommsData", function()
         QuestieComms.data = {}
 
         QuestieDB = QuestieLoader:ImportModule("QuestieDB")
-        QuestieDB.GetItem = function(_, itemId)
-            if itemId == 1001 then
-                return nil
-            elseif itemId == 1002 then
-                return {
-                    Hidden = true,
-                    Sources = {
-                        {
-                            Type = "monster",
-                            Id = 3003,
-                        },
-                    },
-                }
-            end
-        end
+        QuestieDB.GetItem = function() return nil end
 
         dofile("Modules/Network/QuestieCommsData.lua")
         QuestieComms.data:ResetAll()
     end)
 
     describe("RegisterTooltip", function()
-        local cases = {
-            {
-                name = "missing item data",
-                itemId = 1001,
-                monsterId = 2002,
-            },
-            {
-                name = "hidden item data",
-                itemId = 1002,
-                monsterId = 2003,
-                skippedSourceKey = "m_3003",
-            },
-        }
+        it("should register direct item key and skip source expansion when item data is missing", function()
+            local questId = 42
+            local playerName = "OtherPlayer"
+            local objectives = {
+                [1] = {
+                    type = "i",
+                    id = 1001,
+                    fulfilled = 0,
+                    required = 1,
+                },
+                [2] = {
+                    type = "m",
+                    id = 2002,
+                    fulfilled = 0,
+                    required = 1,
+                },
+            }
 
-        for _, case in ipairs(cases) do
-            it("registers direct item and later objectives while skipping source expansion for " .. case.name, function()
-                local questId = 42
-                local playerName = "OtherPlayer"
-                local objectives = {
-                    [1] = {
-                        type = "i",
-                        id = case.itemId,
-                        fulfilled = 0,
-                        required = 1,
-                    },
-                    [2] = {
-                        type = "m",
-                        id = case.monsterId,
-                        fulfilled = 0,
-                        required = 1,
-                    },
-                }
+            QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
 
-                QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
+            assert.is_true(QuestieComms.data:KeyExists("i_1001"))
+            assert.is_true(QuestieComms.data:KeyExists("m_2002"))
+        end)
 
-                assert.is_true(QuestieComms.data:KeyExists("i_" .. case.itemId))
-                if case.skippedSourceKey then
-                    assert.is_false(QuestieComms.data:KeyExists(case.skippedSourceKey))
+        it("should register direct item key and skip source expansion when item is hidden", function()
+            QuestieDB.GetItem = function(_, itemId)
+                if itemId == 1002 then
+                    return {
+                        Hidden = true,
+                        Sources = {
+                            {
+                                Type = "monster",
+                                Id = 3003,
+                            },
+                        },
+                    }
                 end
-                assert.is_true(QuestieComms.data:KeyExists("m_" .. case.monsterId))
-            end)
-        end
+                return nil
+            end
+
+            local questId = 42
+            local playerName = "OtherPlayer"
+            local objectives = {
+                [1] = {
+                    type = "i",
+                    id = 1002,
+                    fulfilled = 0,
+                    required = 1,
+                },
+                [2] = {
+                    type = "m",
+                    id = 2003,
+                    fulfilled = 0,
+                    required = 1,
+                },
+            }
+
+            QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
+
+            assert.is_true(QuestieComms.data:KeyExists("i_1002"))
+            assert.is_false(QuestieComms.data:KeyExists("m_3003"))
+            assert.is_true(QuestieComms.data:KeyExists("m_2003"))
+        end)
     end)
 end)

--- a/Modules/Network/QuestieCommsData.test.lua
+++ b/Modules/Network/QuestieCommsData.test.lua
@@ -7,88 +7,134 @@ describe("QuestieCommsData", function()
     ---@type QuestieDB
     local QuestieDB
 
+    local originalData
     local originalGetItem
+
+    local questId = 42
+    local playerName = "OtherPlayer"
+
+    -- Objectives arrive over comms with single character types, see QuestieComms:InsertQuestDataPacket
+    local function objective(objectiveType, id)
+        return {
+            type = objectiveType,
+            id = id,
+            fulfilled = 0,
+            required = 1,
+        }
+    end
+
+    ---@param itemsById table<number, table> @Item DB entries by item id, any other item counts as missing
+    local function mockItemDb(itemsById)
+        QuestieDB.GetItem = function(_, itemId)
+            return itemsById[itemId]
+        end
+    end
 
     before_each(function()
         QuestieComms = QuestieLoader:ImportModule("QuestieComms")
-        QuestieComms.data = {}
-
         QuestieDB = QuestieLoader:ImportModule("QuestieDB")
-        originalGetItem = QuestieDB.GetItem
-        QuestieDB.GetItem = function() return nil end
 
+        originalData = QuestieComms.data
+        originalGetItem = QuestieDB.GetItem
+
+        QuestieComms.data = {}
+        mockItemDb({})
+
+        -- Loading the file gives it fresh lookup tables, so each test starts with empty tooltip data
         dofile("Modules/Network/QuestieCommsData.lua")
-        QuestieComms.data:ResetAll()
     end)
 
     after_each(function()
+        QuestieComms.data = originalData
         QuestieDB.GetItem = originalGetItem
-        QuestieComms.data:ResetAll()
     end)
 
     describe("RegisterTooltip", function()
-        it("should register direct item key and skip source expansion when item data is missing", function()
-            local questId = 42
-            local playerName = "OtherPlayer"
+        it("should register an item objective on the item and on everything that provides it", function()
+            mockItemDb({
+                [1003] = {
+                    Sources = {
+                        {Type = "monster", Id = 3003},
+                        {Type = "object", Id = 4004},
+                    },
+                },
+            })
+
+            QuestieComms.data:RegisterTooltip(questId, playerName, {objective("i", 1003)})
+
+            assert.is_true(QuestieComms.data:KeyExists("i_1003"))
+            assert.is_true(QuestieComms.data:KeyExists("m_3003"))
+            assert.is_true(QuestieComms.data:KeyExists("o_4004"))
+        end)
+
+        it("should register an item objective when the item has no sources", function()
+            mockItemDb({
+                [1004] = {},
+            })
+
+            QuestieComms.data:RegisterTooltip(questId, playerName, {objective("i", 1004)})
+
+            assert.is_true(QuestieComms.data:KeyExists("i_1004"))
+        end)
+
+        -- The two skip path tests below each contain two unresolvable item objectives on purpose.
+        -- Bailing out of the loop instead of skipping the objective always leaves one of them
+        -- unregistered, no matter which order the objectives end up being listed in.
+        it("should register the direct item key and later objectives when item data is missing", function()
             local objectives = {
-                [1] = {
-                    type = "i",
-                    id = 1001,
-                    fulfilled = 0,
-                    required = 1,
-                },
-                [2] = {
-                    type = "m",
-                    id = 2002,
-                    fulfilled = 0,
-                    required = 1,
-                },
+                objective("i", 1001),
+                objective("m", 2002),
+                objective("i", 1005),
             }
 
             QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
 
             assert.is_true(QuestieComms.data:KeyExists("i_1001"))
             assert.is_true(QuestieComms.data:KeyExists("m_2002"))
+            assert.is_true(QuestieComms.data:KeyExists("i_1005"))
         end)
 
-        it("should register direct item key and skip source expansion when item is hidden", function()
-            QuestieDB.GetItem = function(_, itemId)
-                if itemId == 1002 then
-                    return {
-                        Hidden = true,
-                        Sources = {
-                            {
-                                Type = "monster",
-                                Id = 3003,
-                            },
-                        },
-                    }
-                end
-                return nil
-            end
+        it("should skip source expansion but keep later objectives when the item is hidden", function()
+            mockItemDb({
+                [1002] = {
+                    Hidden = true,
+                    Sources = {
+                        {Type = "monster", Id = 9009},
+                    },
+                },
+                [1006] = {
+                    Hidden = true,
+                    Sources = {
+                        {Type = "monster", Id = 9010},
+                    },
+                },
+            })
 
-            local questId = 42
-            local playerName = "OtherPlayer"
             local objectives = {
-                [1] = {
-                    type = "i",
-                    id = 1002,
-                    fulfilled = 0,
-                    required = 1,
-                },
-                [2] = {
-                    type = "m",
-                    id = 2003,
-                    fulfilled = 0,
-                    required = 1,
-                },
+                objective("i", 1002),
+                objective("m", 2003),
+                objective("i", 1006),
             }
 
             QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
 
             assert.is_true(QuestieComms.data:KeyExists("i_1002"))
-            assert.is_false(QuestieComms.data:KeyExists("m_3003"))
+            assert.is_true(QuestieComms.data:KeyExists("i_1006"))
+            assert.is_false(QuestieComms.data:KeyExists("m_9009"))
+            assert.is_false(QuestieComms.data:KeyExists("m_9010"))
             assert.is_true(QuestieComms.data:KeyExists("m_2003"))
+        end)
+
+        it("should skip objectives that are missing a type or an id", function()
+            local objectives = {
+                {type = "i"},
+                {id = 5005},
+                objective("m", 2002),
+            }
+
+            QuestieComms.data:RegisterTooltip(questId, playerName, objectives)
+
+            assert.is_true(QuestieComms.data:KeyExists("m_2002"))
         end)
     end)
 end)


### PR DESCRIPTION
## Summary
Previously, `QuestieCommsData:RegisterTooltip` treated missing or hidden item DB data as control flow for the whole objective list. That meant one item objective could stop registration for its direct item tooltip and for later valid objectives. Now source/provider expansion is gated by usable item DB data, while direct item tooltip registration remains keyed by the received item objective and the loop continues registering later objectives.

## Before
```text
received quest objective list
  -> RegisterTooltip loops objectives
  -> missing/hidden item DB data
  -> return from whole RegisterTooltip call
  -> no direct i_<itemId> tooltip
  -> later valid objectives never register tooltip keys
```

## After
```text
received quest objective list
  -> RegisterTooltip loops objectives
  -> missing/hidden item DB data skips source/provider expansion
  -> direct i_<itemId> tooltip still registers for item hover
  -> later valid objectives continue registering tooltip keys
```

## Example
If a party member sends quest progress where objective 1 is a hidden or locally missing item and objective 2 is “kill this monster,” the old code stopped at objective 1. Hovering the item or the monster would not show that party member’s progress. The new code avoids expanding the item onto unknown or hidden source entities, but still registers the direct item tooltip and continues to register the monster tooltip.

## Responsibility / ownership
Usable item DB data owns source/provider expansion because those tooltip keys come from `item.Sources`. The received item objective owns the direct `i_<itemId>` tooltip because that key comes from the objective itself. A missing or hidden item should not abort the rest of the objective list.

## Validation
- `busted -p ".test.lua" --filter "RegisterTooltip" Modules/Network/QuestieCommsData.test.lua`: `2 successes / 0 failures / 0 errors`
- `busted -p ".test.lua" Modules/Network`: `19 successes / 0 failures / 0 errors`
