### PR TITLE
[fix] Fix quest link showing incorrect level after level up

### DIFF
--- a/Modules/FramePool/QuestieFrame.lua
+++ b/Modules/FramePool/QuestieFrame.lua
@@ -198,7 +198,7 @@ function _Qframe.OnClick(self, button)
             local frameData = self.data
             if ChatEdit_GetActiveWindow() and frameData.QuestData then
                 if Questie.db.profile.trackerShowQuestLevel then
-                    ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(frameData.QuestData.level, frameData.QuestData.name, frameData.Id))
+                    ChatEdit_InsertLink(QuestieLink:GetQuestLinkStringById(frameData.Id))
                 else
                     ChatEdit_InsertLink("[" .. frameData.QuestData.name .. " (" .. frameData.Id .. ")]")
                 end

--- a/Modules/Journey/QuestieSearchResults.lua
+++ b/Modules/Journey/QuestieSearchResults.lua
@@ -693,12 +693,10 @@ _HandleTreeItemClick = function(group, ...)
     -- This is either the questId, npcId, objectId or itemId
     local selectedId = tonumber(treePath[2])
     if IsShiftKeyDown() and lastOpenSearch == "quest" then
-        local questName = QuestieDB.QueryQuestSingle(selectedId, "name")
-        local questLevel, _ = QuestieLib.GetTbcLevel(selectedId);
-
         if Questie.db.profile.trackerShowQuestLevel then
-            ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(questLevel, questName, selectedId))
+            ChatEdit_InsertLink(QuestieLink:GetQuestLinkStringById(selectedId))
         else
+            local questName = QuestieDB.QueryQuestSingle(selectedId, "name")
             ChatEdit_InsertLink("[" .. questName .. " (" .. selectedId .. ")]")
         end
     end

--- a/Modules/Journey/tabs/QuestsByFaction/QuestsByFactions.lua
+++ b/Modules/Journey/tabs/QuestsByFaction/QuestsByFactions.lua
@@ -338,7 +338,7 @@ function _QuestieJourney.questsByFaction:ManageTree(container, factionTree)
 
         if (IsModifiedClick("CHATLINK") and ChatEdit_GetActiveWindow()) then
             if Questie.db.profile.trackerShowQuestLevel then
-                ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(quest.level, quest.name, quest.Id))
+                ChatEdit_InsertLink(QuestieLink:GetQuestLinkStringById(quest.Id))
             else
                 ChatEdit_InsertLink("[" .. quest.name .. " (" .. quest.Id .. ")]")
             end

--- a/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
+++ b/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
@@ -147,7 +147,7 @@ function _QuestieJourney.questsByZone:ManageTree(container, zoneTree)
         -- Add the quest to the open chat window if it was a shift click
         if (IsModifiedClick("CHATLINK") and ChatEdit_GetActiveWindow()) then
             if Questie.db.profile.trackerShowQuestLevel then
-                ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(quest.level, quest.name, quest.Id))
+                ChatEdit_InsertLink(QuestieLink:GetQuestLinkStringById(quest.Id))
             else
                 ChatEdit_InsertLink("[" .. quest.name .. " (" .. quest.Id .. ")]")
             end

--- a/Modules/QuestLinks/Link.lua
+++ b/Modules/QuestLinks/Link.lua
@@ -64,13 +64,9 @@ end
 
 ---@return string
 function QuestieLink:GetQuestLinkStringById(questId)
-    local questName = QuestieDB.QueryQuestSingle(questId, "name");
-    local questLevel, _ = QuestieLib.GetTbcLevel(questId);
-    return QuestieLink:GetQuestLinkString(questLevel, questName, questId)
-end
+    local questName = QuestieDB.QueryQuestSingle(questId, "name")
+    local questLevel, _ = QuestieLib.GetTbcLevel(questId)
 
----@return string
-function QuestieLink:GetQuestLinkString(questLevel, questName, questId)
     return "[["..tostring(questLevel).."] "..questName.." ("..tostring(questId)..")]"
 end
 

--- a/Modules/QuestLinks/Link.test.lua
+++ b/Modules/QuestLinks/Link.test.lua
@@ -77,6 +77,21 @@ describe("QuestieLink", function()
         QuestieLink = require("Modules.QuestLinks.Link")
     end)
 
+    describe("GetQuestLinkStringById", function()
+        it("should return a formatted link string with level and name from the database", function()
+            QuestieDB.QueryQuestSingle = function()
+                return "Test Quest"
+            end
+            QuestieLib.GetTbcLevel = function()
+                return 15
+            end
+
+            local result = QuestieLink:GetQuestLinkStringById(1234)
+
+            assert.are.same("[[15] Test Quest (1234)]", result)
+        end)
+    end)
+
     describe("CreateQuestTooltip", function()
         it("should show quest requirements including reputation when quest is not in the player quest log", function()
             QuestieDB.GetQuest = function(questId)

--- a/Modules/Tracker/LinePool/TrackerLine.lua
+++ b/Modules/Tracker/LinePool/TrackerLine.lua
@@ -208,7 +208,7 @@ _OnClickQuest = function(self, button)
     elseif TrackerUtils:IsBindTrue(Questie.db.profile.trackerbindUntrack, button) then
         if (IsModifiedClick("CHATLINK") and ChatEdit_GetActiveWindow()) then
             if Questie.db.profile.trackerShowQuestLevel then
-                ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(self.Quest.level, self.Quest.name, self.Quest.Id))
+                ChatEdit_InsertLink(QuestieLink:GetQuestLinkStringById(self.Quest.Id))
             else
                 ChatEdit_InsertLink("[" .. self.Quest.name .. " (" .. self.Quest.Id .. ")]")
             end

--- a/Modules/Tracker/LinePool/TrackerMenu.lua
+++ b/Modules/Tracker/LinePool/TrackerMenu.lua
@@ -222,13 +222,13 @@ TrackerMenu.addLinkToChatOption = function(menu, quest)
 
             if (not ChatFrame1EditBox:IsVisible()) then
                 if Questie.db.profile.trackerShowQuestLevel then
-                    ChatFrame_OpenChat(QuestieLink:GetQuestLinkString(quest.level, quest.name, quest.Id))
+                    ChatFrame_OpenChat(QuestieLink:GetQuestLinkStringById(quest.Id))
                 else
                     ChatFrame_OpenChat("[" .. quest.name .. " (" .. quest.Id .. ")]")
                 end
             else
                 if Questie.db.profile.trackerShowQuestLevel then
-                    ChatEdit_InsertLink(QuestieLink:GetQuestLinkString(quest.level, quest.name, quest.Id))
+                    ChatEdit_InsertLink(QuestieLink:GetQuestLinkStringById(quest.Id))
                 else
                     ChatEdit_InsertLink("[" .. quest.name .. " (" .. quest.Id .. ")]")
                 end


### PR DESCRIPTION
This fixes quest links for -1 level quests

<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Related to #3534

## Proposed changes

-
-

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->
