### PR TITLE
Update QuestieTracker.lua

### DIFF
--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -1573,6 +1573,12 @@ function QuestieTracker:Update()
                 end
             end
         end
+        -- Icons may have already spawned as visible on the map/minimap before the
+        -- HideIcons flags above were restored from the saved tracker state (e.g.
+        -- the quest log wasn't fully loaded yet on the first Update() after
+        -- login/reload). Force a re-check now so they get hidden retroactively.
+        QuestieQuest:HideQuestIcons()
+        
         isFirstRun = false
         C_Timer.After(1.0, function()
             QuestieCombatQueue:Queue(function()


### PR DESCRIPTION
Fixes the tracker's per-quest "Hide Icons" option not persisting map/minimap icon visibility across reload/login.

Root cause: Questie.db.char.TrackerHiddenQuests/TrackerHiddenObjectives are correctly restored onto quest.HideIcons/objective.HideIcons in the isFirstRun block, but icons that already spawned on the map/minimap before that restoration ran are never re-checked, so they stay visible.

Fix: call QuestieQuest:HideQuestIcons() right after restoring the flags, forcing a re-check of already-spawned icons against the saved hidden state.

Most noticeable on Mists of Pandaria Classic, likely due to slower quest log population on login.

Repro: right-click a tracked quest → "Hide Icons" → /reload → icons reappear despite the setting still showing as hidden.