### PR TITLE
Fix SetFont call in tracker Wowhead link popups on strict clients

### DIFF
--- a/Modules/Tracker/LinePool/TrackerMenu.lua
+++ b/Modules/Tracker/LinePool/TrackerMenu.lua
@@ -379,7 +379,7 @@ StaticPopupDialogs["QUESTIE_WOWHEAD_URL"] = {
         local quest_wow = QuestieDB.GetQuest(questID)
         local name = quest_wow.name
 
-        textFrame:SetFont("GameFontNormal", 12)
+        textFrame:SetFont(GameFontNormal:GetFont(), 12)
         textFrame:SetText(textFrame:GetText() .. Questie:Colorize("\n\n" .. name, "gold"))
 
         local wowheadLink = _GetWowheadLinkForLanguage() .. "quest=" .. questID -- all expansions follow this system as of 2024 start of Cata
@@ -542,7 +542,7 @@ StaticPopupDialogs["QUESTIE_WOWHEAD_AURL"] = {
         local achieveID = textFrame.text_arg1
         local name = select(2, GetAchievementInfo(achieveID))
 
-        textFrame:SetFont("GameFontNormal", 12)
+        textFrame:SetFont(GameFontNormal:GetFont(), 12)
         textFrame:SetText(textFrame:GetText() .. Questie:Colorize("\n\n" .. name, "gold"))
 
         local wowheadLink = _GetWowheadLinkForLanguage() .. "achievement=" .. achieveID


### PR DESCRIPTION
## Problem

The Wowhead-link popups in the tracker menu (quest and achievement) call:

```lua
textFrame:SetFont(GameFontNormal, 12)
```

`FontString:SetFont()` expects a font **file path**, not a font object name. Older clients failed this call silently, but the TBC Anniversary 2.5.6 client (build 68502) that shipped 2026-07-07 — like other modern-engine clients — now raises an error when the popup opens:

```
SetFont(): Invalid font asset (GameFontNormal): file not found
```

(Same validation seen breaking other addons on this patch, e.g. Details raised the identical error for `GameFontHighlightSmall` before its update.)

## Fix

Resolve the actual font file from the `GameFontNormal` font object:

```lua
textFrame:SetFont(GameFontNormal:GetFont(), 12)
```

This keeps the intended size-12 override and works on both old and new clients. Both occurrences in `TrackerMenu.lua` (quest popup and achievement popup) are updated.