### PR TITLE
[fix] Fix incorrect quest completion notifications after loading screens

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2476,6 +2476,7 @@ globals = {
     "table.removemulti",
     "table.setn",
     "table.sort",
+    "table.unpack",
     "table.wipe",
     "tan",
     "time",

--- a/Modules/Quest/QuestLogCache.lua
+++ b/Modules/Quest/QuestLogCache.lua
@@ -77,6 +77,12 @@ local cache = {
 local cache = {}
 local questCount = 0
 
+-- Tracks quests where objectives regressed on the last scan (e.g. due to zone transition stale data).
+-- On the first regression, we set cacheMiss and skip the update so no sounds/announces fire.
+-- On the second consecutive regression of the same quest, we accept it as legitimate (e.g. item deletion).
+---@type table<QuestId, boolean>
+local consecutiveRegressions = {}
+
 --- NEVER EVER EDIT this table outside of the QuestLogCache module!  !!!
 ---@type table<QuestId, QuestLogCacheData>
 QuestLogCache.questLog_DO_NOT_MODIFY = cache
@@ -105,6 +111,18 @@ local function GetNewObjectives(questId, oldObjectives, isCompleteAccordingToBli
                     newObjectives[objIndex] = oldObj
                     allObjectivesFinished = allObjectivesFinished and oldObj.finished -- if any objective is not finished, whole quest is not complete
                 else
+                    -- Detect a regression: numFulfilled went down from what we had cached.
+                    -- This can happen during zone transitions when Blizzard temporarily returns incorrect data.
+                    -- On the first sighting we treat it as a cache miss so no sounds/announces fire.
+                    -- On the second consecutive sighting we accept it as a legitimate change (e.g. player deleted a collected item).
+                    if oldObj and newObj.numFulfilled < oldObj.raw_numFulfilled then
+                        if (not consecutiveRegressions[questId]) then
+                            consecutiveRegressions[questId] = true
+                            return nil, nil, isCompleteAccordingToBlizzard
+                        end
+                        -- Second consecutive regression — fall through and accept it
+                    end
+
                     -- objective has changed, add it to list of change ones
                     if (not changedObjIds) then
                         changedObjIds = { objIndex }
@@ -116,7 +134,7 @@ local function GetNewObjectives(questId, oldObjectives, isCompleteAccordingToBli
                         Sounds.PlayObjectiveComplete()
                     end
 
-                    if oldObj and newObj and oldObj.numRequired ~= oldObj.numFulfilled and newObj.numRequired ~= newObj.numFulfilled then
+                    if oldObj and newObj and oldObj.numRequired ~= oldObj.numFulfilled and newObj.numRequired ~= newObj.numFulfilled and newObj.numFulfilled > oldObj.raw_numFulfilled then
                         Sounds.PlayObjectiveProgress()
                     end
 
@@ -157,6 +175,9 @@ local function GetNewObjectives(questId, oldObjectives, isCompleteAccordingToBli
         -- Blizzard keeps adding invalid empty objectives to quests and therefore not marking them as complete, so we need to work around that.
         isComplete = allObjectivesFinished and 1 or 0
     end
+
+    -- Completed a full scan without a first-sighting regression, so any previously recorded regression is resolved.
+    consecutiveRegressions[questId] = nil
 
     return newObjectives, changedObjIds, isComplete
 end
@@ -283,6 +304,7 @@ function QuestLogCache.RemoveQuest(questId)
         cache[questId] = nil
         questCount = questCount - 1
     end
+    consecutiveRegressions[questId] = nil
 end
 
 

--- a/Modules/Quest/QuestLogCache.lua
+++ b/Modules/Quest/QuestLogCache.lua
@@ -182,58 +182,67 @@ function QuestLogCache.CheckForChanges(questIdsToCheck)
             break -- We exceeded the valid quest log entries
         end
         if (not isHeader) and ((not questIdsToCheck) or questIdsToCheck[questId]) then -- check all quests if no list what to check, otherwise just ones in the list
+            ---@cast questId number
             questIdsChecked[questId] = true
 
             if HaveQuestData(questId) then
                 local cachedQuest = cache[questId]
                 local cachedObjectives = cachedQuest and cachedQuest.objectives or {}
 
-                local newObjectives, changedObjIds, isComplete = GetNewObjectives(questId, cachedObjectives, isCompleteAccordingToBlizzard)
+                -- During zone transitions (e.g. entering/leaving a dungeon) GetQuestLogTitle temporarily
+                -- returns incorrect values (e.g. isCompleteAccordingToBlizzard being nil for quests that are actually complete).
+                -- To avoid caching incorrect values, we skip the update entirely and set cacheMiss so we retry next QUEST_LOG_UPDATE.
+                local blizzardCacheIncorrect = (not isCompleteAccordingToBlizzard) and cachedQuest and cachedQuest.isComplete == 1
+                if blizzardCacheIncorrect then
+                    cacheMiss = true
+                else
+                    local newObjectives, changedObjIds, isComplete = GetNewObjectives(questId, cachedObjectives, isCompleteAccordingToBlizzard)
 
-                if newObjectives then
-                    if (not cachedQuest) or (#cachedObjectives == #newObjectives and #cachedObjectives > 0 and
-                        (cachedQuest.title ~= title or cachedQuest.questTag ~= questTag or cachedQuest.isComplete ~= isComplete)) then
-                        -- Mark all objectives changed to force update those too.
+                    if newObjectives then
+                        if (not cachedQuest) or (#cachedObjectives == #newObjectives and #cachedObjectives > 0 and
+                            (cachedQuest.title ~= title or cachedQuest.questTag ~= questTag or cachedQuest.isComplete ~= isComplete)) then
+                            -- Mark all objectives changed to force update those too.
 
-                        -- changedObjIds is nil from GetObjectives() for quests not having objectives. This is easiest place to change it to {}.
-                        changedObjIds = {}
-                        for i=1, #newObjectives do
-                            changedObjIds[i] = i
-                        end
-
-                        if isComplete == 1 then
-                            -- Set all objectives finished if whole quest isComplete.
-                            -- Because of: Game API returns "event" type objectives as unfinished while whole quest isComplete.
-
-                            local o
+                            -- changedObjIds is nil from GetObjectives() for quests not having objectives. This is easiest place to change it to {}.
+                            changedObjIds = {}
                             for i=1, #newObjectives do
-                                o = newObjectives[i]
-                                o.finished = true
-                                o.numFulfilled = o.numRequired
+                                changedObjIds[i] = i
+                            end
+
+                            if isComplete == 1 then
+                                -- Set all objectives finished if whole quest isComplete.
+                                -- Because of: Game API returns "event" type objectives as unfinished while whole quest isComplete.
+
+                                local o
+                                for i=1, #newObjectives do
+                                    o = newObjectives[i]
+                                    o.finished = true
+                                    o.numFulfilled = o.numRequired
+                                end
                             end
                         end
-                    end
 
-                    if cachedQuest and cachedQuest.isComplete == 0 and isComplete == 1 then
-                        Sounds.PlayQuestComplete()
-                    end
-
-                    if changedObjIds then
-                        if (not cache[questId]) then
-                            -- Quest is new to cache
-                            questCount = questCount + 1
+                        if cachedQuest and cachedQuest.isComplete == 0 and isComplete == 1 then
+                            Sounds.PlayQuestComplete()
                         end
-                        -- Save to cache
-                        cache[questId] = {
-                            title = title,
-                            questTag = questTag,
-                            isComplete = isComplete,
-                            objectives = newObjectives,
-                        }
-                        changes[questId] = changedObjIds
+
+                        if changedObjIds then
+                            if (not cache[questId]) then
+                                -- Quest is new to cache
+                                questCount = questCount + 1
+                            end
+                            -- Save to cache
+                            cache[questId] = {
+                                title = title,
+                                questTag = questTag,
+                                isComplete = isComplete,
+                                objectives = newObjectives,
+                            }
+                            changes[questId] = changedObjIds
+                        end
+                    else
+                        cacheMiss = true
                     end
-                else
-                    cacheMiss = true
                 end
             else
                 Questie:Debug(Questie.DEBUG_CRITICAL, "[QuestLogCache.CheckForChanges] HaveQuestData() == false. questId, index:", questId, questLogIndex)

--- a/Modules/Quest/QuestLogCache.test.lua
+++ b/Modules/Quest/QuestLogCache.test.lua
@@ -286,5 +286,141 @@ describe("QuestLogCache", function()
             assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
             assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
         end)
+
+        it("should not play sounds when objective numFulfilled regresses once (zone transition)", function()
+            questLogTitles = {
+                [1] = {"Collect Items", 60, nil, false, false, 0, nil, QUEST_ID},
+            }
+            questObjectives = {
+                [QUEST_ID] = {{
+                    type = "item",
+                    numRequired = 5,
+                    text = "Item: 3/5",
+                    finished = false,
+                    numFulfilled = 3,
+                }}
+            }
+
+            -- Step 1: Initial scan — objective cached at 3/5
+            QuestLogCache.CheckForChanges(nil)
+            assert.is_equal(3, QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID].objectives[1].raw_numFulfilled)
+
+            -- Step 2: Zone transition — Blizzard returns stale 0/5
+            questObjectives[QUEST_ID] = {{
+                type = "item",
+                numRequired = 5,
+                text = "Item: 0/5",
+                finished = false,
+                numFulfilled = 0,
+            }}
+
+            local cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+
+            assert.is_true(cacheMiss)
+            assert.is_nil(changes[QUEST_ID])
+            -- Cache must NOT be updated with the stale value
+            assert.is_equal(3, QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID].objectives[1].raw_numFulfilled)
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+            assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+        end)
+
+        it("should not play sounds on second zone transition when no objective progress was made", function()
+            questLogTitles = {
+                [1] = {"Collect Items", 60, nil, false, false, 0, nil, QUEST_ID},
+            }
+            questObjectives = {
+                [QUEST_ID] = {{
+                    type = "item",
+                    numRequired = 5,
+                    text = "Item: 3/5",
+                    finished = false,
+                    numFulfilled = 3,
+                }}
+            }
+
+            -- Step 1: Initial scan — objective cached at 3/5
+            QuestLogCache.CheckForChanges(nil)
+
+            -- Step 2: First zone transition (enter dungeon) — Blizzard returns stale 0/5
+            questObjectives[QUEST_ID] = {{
+                type = "item",
+                numRequired = 5,
+                text = "Item: 0/5",
+                finished = false,
+                numFulfilled = 0,
+            }}
+            local cacheMiss = QuestLogCache.CheckForChanges(nil)
+            assert.is_true(cacheMiss)
+
+            -- Step 3: Blizzard restores 3/5 — objective unchanged, no sounds
+            questObjectives[QUEST_ID] = {{
+                type = "item",
+                numRequired = 5,
+                text = "Item: 3/5",
+                finished = false,
+                numFulfilled = 3,
+            }}
+            QuestLogCache.CheckForChanges(nil)
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+
+            -- Step 4: Second zone transition (leave dungeon) — stale 0/5 again
+            questObjectives[QUEST_ID] = {{
+                type = "item",
+                numRequired = 5,
+                text = "Item: 0/5",
+                finished = false,
+                numFulfilled = 0,
+            }}
+            cacheMiss = QuestLogCache.CheckForChanges(nil)
+
+            assert.is_true(cacheMiss)
+            assert.is_equal(3, QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID].objectives[1].raw_numFulfilled)
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+            assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+        end)
+
+        it("should accept a regression on second consecutive sighting (item deletion)", function()
+            questLogTitles = {
+                [1] = {"Collect Items", 60, nil, false, false, 0, nil, QUEST_ID},
+            }
+            questObjectives = {
+                [QUEST_ID] = {{
+                    type = "item",
+                    numRequired = 5,
+                    text = "Item: 3/5",
+                    finished = false,
+                    numFulfilled = 3,
+                }}
+            }
+
+            -- Step 1: Initial scan — objective cached at 3/5
+            QuestLogCache.CheckForChanges(nil)
+
+            -- Step 2: First sighting of regression (1/5) — treated as cache miss
+            questObjectives[QUEST_ID] = {{
+                type = "item",
+                numRequired = 5,
+                text = "Item: 1/5",
+                finished = false,
+                numFulfilled = 1,
+            }}
+
+            local cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+            assert.is_true(cacheMiss)
+            assert.is_nil(changes[QUEST_ID])
+            assert.is_equal(3, QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID].objectives[1].raw_numFulfilled)
+
+            -- Step 3: Second consecutive sighting of same regression — accepted as legitimate
+            cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+
+            assert.is_false(cacheMiss)
+            assert.is_not_nil(changes[QUEST_ID])
+            assert.is_equal(1, QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID].objectives[1].raw_numFulfilled)
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+            assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+        end)
     end)
 end)

--- a/Modules/Quest/QuestLogCache.test.lua
+++ b/Modules/Quest/QuestLogCache.test.lua
@@ -1,0 +1,290 @@
+dofile("setupTests.lua")
+
+describe("QuestLogCache", function()
+    ---@type QuestLogCache
+    local QuestLogCache
+    ---@type Sounds
+    local Sounds
+
+    local QUEST_ID = 1234
+
+    local questLogTitles = {}
+    local questObjectives = {}
+
+    before_each(function()
+        questLogTitles = {}
+        questObjectives = {}
+
+        _G.HaveQuestData = function() return true end
+        _G.GetQuestLogTitle = function(index)
+            local entry = questLogTitles[index]
+            if entry then
+                return table.unpack(entry)
+            end
+            return nil
+        end
+        _G.C_QuestLog = {
+            GetQuestObjectives = function(questId)
+                return questObjectives[questId] or {}
+            end
+        }
+
+        dofile("Modules/Libs/QuestieLib.lua")
+
+        Sounds = QuestieLoader:ImportModule("Sounds")
+        Sounds.PlayQuestComplete = spy.new(function() end)
+        Sounds.PlayObjectiveComplete = spy.new(function() end)
+        Sounds.PlayObjectiveProgress = spy.new(function() end)
+
+        dofile("Modules/Quest/QuestLogCache.lua")
+        QuestLogCache = QuestieLoader:ImportModule("QuestLogCache")
+    end)
+
+    describe("CheckForChanges", function()
+        it("should add a new quest to the cache on first scan without playing any sounds", function()
+            questLogTitles = {
+                [1] = {"Kill the Boss", 60, nil, false, false, 0, nil, QUEST_ID},
+            }
+            questObjectives = {
+                [QUEST_ID] = {{
+                    type = "monster",
+                    numRequired = 3,
+                    text = "Boss slain: 0/3",
+                    finished = false,
+                    numFulfilled = 0,
+                }}
+            }
+
+            local cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+
+            assert.is_false(cacheMiss)
+            assert.is_not_nil(changes[QUEST_ID])
+            assert.is_not_nil(QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID])
+            assert.is_equal(0, QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID].isComplete)
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+        end)
+
+        it("should play PlayQuestComplete when quest transitions from incomplete to complete", function()
+            questLogTitles = {
+                [1] = {"Kill the Boss", 60, nil, false, false, 0, nil, QUEST_ID},
+            }
+            questObjectives = {
+                [QUEST_ID] = {{
+                    type = "monster",
+                    numRequired = 1,
+                    text = "Boss slain: 0/1",
+                    finished = false,
+                    numFulfilled = 0,
+                }}
+            }
+
+            -- Step 1: Initial scan — quest enters cache as isComplete=0
+            QuestLogCache.CheckForChanges(nil)
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+            assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
+
+            -- Step 2: Quest completes
+            questLogTitles[1] = {"Kill the Boss", 60, nil, false, false, 1, nil, QUEST_ID}
+            questObjectives[QUEST_ID] = {{
+                type = "monster",
+                numRequired = 1,
+                text = "Boss slain: 1/1",
+                finished = true,
+                numFulfilled = 1,
+            }}
+
+            local cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+
+            assert.is_false(cacheMiss)
+            assert.is_not_nil(changes[QUEST_ID])
+            assert.is_equal(1, QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID].isComplete)
+            assert.spy(Sounds.PlayQuestComplete).was.called(1)
+            assert.spy(Sounds.PlayObjectiveComplete).was.called(1)
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+        end)
+
+        it("should play PlayObjectiveProgress when an objective partially progresses", function()
+            questLogTitles = {
+                [1] = {"Collect Items", 60, nil, false, false, 0, nil, QUEST_ID},
+            }
+            questObjectives = {
+                [QUEST_ID] = {{
+                    type = "item",
+                    numRequired = 5,
+                    text = "Item: 0/5",
+                    finished = false,
+                    numFulfilled = 0,
+                }}
+            }
+
+            -- Step 1: Initial scan
+            QuestLogCache.CheckForChanges(nil)
+
+            -- Step 2: Partial progress
+            questObjectives[QUEST_ID] = {{
+                type = "item",
+                numRequired = 5,
+                text = "Item: 3/5",
+                finished = false,
+                numFulfilled = 3,
+            }}
+
+            local cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+
+            assert.is_false(cacheMiss)
+            assert.is_not_nil(changes[QUEST_ID])
+            assert.spy(Sounds.PlayObjectiveProgress).was.called(1)
+            assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+        end)
+
+        it("should play PlayObjectiveComplete when an objective reaches its required count", function()
+            questLogTitles = {
+                [1] = {"Collect Items", 60, nil, false, false, 0, nil, QUEST_ID},
+            }
+            questObjectives = {
+                [QUEST_ID] = {{
+                    type = "item",
+                    numRequired = 5,
+                    text = "Item: 0/5",
+                    finished = false,
+                    numFulfilled = 0,
+                }}
+            }
+
+            -- Step 1: Initial scan
+            QuestLogCache.CheckForChanges(nil)
+
+            -- Step 2: Objective finishes
+            questObjectives[QUEST_ID] = {{
+                type = "item",
+                numRequired = 5,
+                text = "Item: 5/5",
+                finished = true,
+                numFulfilled = 5,
+            }}
+
+            local cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+
+            assert.is_false(cacheMiss)
+            assert.is_not_nil(changes[QUEST_ID])
+            assert.spy(Sounds.PlayObjectiveComplete).was.called(1)
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+        end)
+
+        it("should return cacheMiss=true and no changes when HaveQuestData returns false", function()
+            questLogTitles = {
+                [1] = {"Kill the Boss", 60, nil, false, false, 0, nil, QUEST_ID},
+            }
+            _G.HaveQuestData = function() return false end
+
+            local cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+
+            assert.is_true(cacheMiss)
+            assert.is_nil(changes[QUEST_ID])
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+        end)
+
+        it("should skip header entries", function()
+            questLogTitles = {
+                [1] = {"Zone Header", 0, nil, true, false, 0, nil, 0},
+                [2] = {"Kill the Boss", 60, nil, false, false, 0, nil, QUEST_ID},
+            }
+            questObjectives = {
+                [QUEST_ID] = {}
+            }
+
+            local cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+
+            assert.is_false(cacheMiss)
+            assert.is_nil(changes[0])
+            assert.is_not_nil(changes[QUEST_ID])
+        end)
+
+        it("should only process quests listed in questIdsToCheck", function()
+            local OTHER_QUEST_ID = 5678
+            questLogTitles = {
+                [1] = {"Kill the Boss", 60, nil, false, false, 0, nil, QUEST_ID},
+                [2] = {"Collect Items", 60, nil, false, false, 0, nil, OTHER_QUEST_ID},
+            }
+            questObjectives = {
+                [QUEST_ID] = {},
+                [OTHER_QUEST_ID] = {},
+            }
+
+            local cacheMiss, changes = QuestLogCache.CheckForChanges({[QUEST_ID] = true})
+
+            assert.is_false(cacheMiss)
+            assert.is_not_nil(changes[QUEST_ID])
+            assert.is_nil(changes[OTHER_QUEST_ID])
+        end)
+
+        it("should not re-trigger PlayQuestComplete when isCompleteAccordingToBlizzard temporarily returns nil", function()
+            -- title, level, questTag, isHeader, isCollapsed, isComplete, frequency, questId
+            questLogTitles = {
+                [1] = {"Kill the Boss", 60, "Dungeon", false, false, 1, nil, QUEST_ID},
+            }
+            questObjectives = {
+                [QUEST_ID] = {{
+                    type = "monster",
+                    numRequired = 1,
+                    text = "Boss killed",
+                    finished = true,
+                    numFulfilled = 1,
+                }}
+            }
+
+            -- Step 1: Normal completion scan — quest enters cache as isComplete=1
+            local cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+            assert.is_false(cacheMiss)
+            assert.is_not_nil(changes[QUEST_ID])
+            assert.is_equal(1, QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID].isComplete)
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+
+            -- Step 2: Zone transition — Blizzard incorrectly returns nil for isComplete
+            questLogTitles[1] = {"Kill the Boss", 60, "Dungeon", false, false, nil, nil, QUEST_ID}
+            questObjectives[QUEST_ID] = {{
+                type = "monster",
+                numRequired = 1,
+                text = "Boss killed",
+                finished = false,   -- Blizzard reports event objectives as unfinished when uncached
+                numFulfilled = 0,
+            }}
+
+            cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+            assert.is_true(cacheMiss)
+            assert.is_equal(0, #changes)
+            -- isComplete must NOT be downgraded to 0
+            assert.is_equal(1, QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID].isComplete)
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+
+            -- Step 3: Blizzard restores isComplete=1 — must NOT be treated as a fresh completion
+            questLogTitles[1] = {"Kill the Boss", 60, "Dungeon", false, false, 1, nil, QUEST_ID}
+            questObjectives[QUEST_ID] = {{
+                type = "monster",
+                numRequired = 1,
+                text = "Boss killed",
+                finished = true,
+                numFulfilled = 1,
+            }}
+
+            cacheMiss, changes = QuestLogCache.CheckForChanges(nil)
+            assert.is_false(cacheMiss)
+            assert.is_equal(0, #changes)
+            assert.is_equal(1, QuestLogCache.questLog_DO_NOT_MODIFY[QUEST_ID].isComplete)
+            assert.spy(Sounds.PlayQuestComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveComplete).was.not_called()
+            assert.spy(Sounds.PlayObjectiveProgress).was.not_called()
+        end)
+    end)
+end)


### PR DESCRIPTION
Fixes #6047

<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #6047

## Proposed changes

During zone transitions (e.g. entering/leaving a dungeon) `GetQuestLogTitle` temporarily returns incorrect values (e.g. `isCompleteAccordingToBlizzard` being `nil` for quests that are actually complete). To avoid caching incorrect values, we skip the update entirely and set `cacheMiss` so we retry next `QUEST_LOG_UPDATE`.

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->
