### PR TITLE
[fix] Show Required Faction for faction-wide quests in quest details

### DIFF
--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -1006,11 +1006,11 @@ function QuestieDB.IsDoableVerbose(questId, debugPrint, returnText, returnBrief)
     -- Check character race
     local requiredRaces = QuestieDB.QueryQuestSingle(questId, "requiredRaces")
     if (requiredRaces and not checkRace[requiredRaces]) then
-        local msg = "Race requirement not fulfilled for quest " .. questId
         local requirementLabel = "Race requirement"
         if requiredRaces == QuestieDB.raceKeys.ALL_ALLIANCE or requiredRaces == QuestieDB.raceKeys.ALL_HORDE then
             requirementLabel = "Faction requirement"
         end
+        local msg = requirementLabel .. " not fulfilled for quest " .. questId
         if returnText and returnBrief then
             return l10n("Unavailable")..l10n(": ")..l10n(requirementLabel), true, DoableStates.WRONG_RACE
         elseif returnText and not returnBrief then

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -1007,8 +1007,12 @@ function QuestieDB.IsDoableVerbose(questId, debugPrint, returnText, returnBrief)
     local requiredRaces = QuestieDB.QueryQuestSingle(questId, "requiredRaces")
     if (requiredRaces and not checkRace[requiredRaces]) then
         local msg = "Race requirement not fulfilled for quest " .. questId
+        local requirementLabel = "Race requirement"
+        if requiredRaces == QuestieDB.raceKeys.ALL_ALLIANCE or requiredRaces == QuestieDB.raceKeys.ALL_HORDE then
+            requirementLabel = "Faction requirement"
+        end
         if returnText and returnBrief then
-            return l10n("Unavailable")..l10n(": ")..l10n("Race requirement"), true, DoableStates.WRONG_RACE
+            return l10n("Unavailable")..l10n(": ")..l10n(requirementLabel), true, DoableStates.WRONG_RACE
         elseif returnText and not returnBrief then
             return msg, true, DoableStates.WRONG_RACE
         end

--- a/Localization/Translations/Generics.lua
+++ b/Localization/Translations/Generics.lua
@@ -290,6 +290,18 @@ local genericsLocales = {
         ["zhCN"] = "需要种族",
         ["zhTW"] = "需要種族",
     },
+    ["Required Faction"] = {
+        ["enUS"] = true,
+        ["deDE"] = "Benötigte Fraktion",
+        ["esES"] = "Facción requerida",
+        ["esMX"] = "Facción requerida",
+        ["frFR"] = "Faction requise",
+        ["koKR"] = "필요 진영",
+        ["ptBR"] = "Facção necessária",
+        ["ruRU"] = "Требуемая фракция",
+        ["zhCN"] = "需要阵营",
+        ["zhTW"] = "需要陣營",
+    },
     ["Required Class"] = {
         ["enUS"] = true,
         ["deDE"] = "Benötigte Klasse",

--- a/Localization/Translations/Journey/MyJourney.lua
+++ b/Localization/Translations/Journey/MyJourney.lua
@@ -446,6 +446,18 @@ local myJourneyLocales = {
         ["zhCN"] = "种族要求",
         ["zhTW"] = "種族要求",
     },
+    ["Faction requirement"] = {
+        ["enUS"] = true,
+        ["deDE"] = "Fraktionsanforderung",
+        ["esES"] = "Requisito de facción",
+        ["esMX"] = "Requisito de facción",
+        ["frFR"] = "Condition de faction",
+        ["koKR"] = "진영 조건",
+        ["ptBR"] = "Requisito de facção",
+        ["ruRU"] = "Требование фракции",
+        ["zhCN"] = "阵营要求",
+        ["zhTW"] = "陣營要求",
+    },
     ["Incomplete pre-quest"] = {
         ["enUS"] = true,
         ["deDE"] = "Prequest nicht abgeschlossen",

--- a/Modules/Journey/QuestDetailsFrame.lua
+++ b/Modules/Journey/QuestDetailsFrame.lua
@@ -336,11 +336,15 @@ function QuestDetailsFrame:Draw(container, quest)
     local minLevelLabel = CreateLabel(Questie:Colorize(l10n("Required Level") .. l10n(": "), 'yellow') .. requiredLevel, true)
     container:AddChild(minLevelLabel)
 
-    -- Required Race
+    -- Required Race / Faction
     local requiredRaces = QuestieDB.QueryQuestSingle(quest.Id, "requiredRaces")
     local reqRaces = QuestieLib:GetRaceString(requiredRaces)
     if (reqRaces ~= "") then
-        local reqRacesLabel = CreateLabel(Questie:Colorize(l10n("Required Race") .. l10n(": "), 'yellow') .. reqRaces, true)
+        local requiredLabel = "Required Race"
+        if requiredRaces == QuestieDB.raceKeys.ALL_ALLIANCE or requiredRaces == QuestieDB.raceKeys.ALL_HORDE then
+            requiredLabel = "Required Faction"
+        end
+        local reqRacesLabel = CreateLabel(Questie:Colorize(l10n(requiredLabel) .. l10n(": "), 'yellow') .. reqRaces, true)
         container:AddChild(reqRacesLabel)
     end
 


### PR DESCRIPTION
Before:
<img width="692" height="509" alt="image" src="https://github.com/user-attachments/assets/26444613-22f1-41ce-8d5e-2cd14b06a904" />

Now: 
<img width="694" height="513" alt="image" src="https://github.com/user-attachments/assets/f8e1ce10-7143-4473-9516-af82e9f6d70e" />

