### PR TITLE
Enable AutoCompleteFrame for Titan Reforged Classic

### DIFF
--- a/Modules/Tracker/QuestieTracker.lua
+++ b/Modules/Tracker/QuestieTracker.lua
@@ -104,7 +104,7 @@ function QuestieTracker.Initialize()
     trackerHeaderFrame = TrackerHeaderFrame.Initialize(trackerBaseFrame, QuestieTracker.Update)
     trackerQuestFrame = TrackerQuestFrame.Initialize(trackerBaseFrame, trackerHeaderFrame)
 
-    if Expansions.Current >= Expansions.Cata then
+    if Expansions.Current >= Expansions.Cata or Questie.IsTitanReforged then
         AutoCompleteFrame.Initialize(trackerBaseFrame)
     end
 

--- a/Questie-WOTLKC.toc
+++ b/Questie-WOTLKC.toc
@@ -1,4 +1,4 @@
-## Interface: 38000, 38001
+## Interface: 38000, 38002
 ## Title: Questie|cFF00FF00 v11.33.3|r
 ## Author: Aero/Logon/Muehe/TheCrux(BreakBB)/Drejjmit/Dyaxler/Cheeq/TechnoHunter/Everyone else
 ## Notes: A standalone Classic QuestHelper
@@ -248,6 +248,7 @@ Modules\Journey\QuestieSearch.lua
 Modules\Journey\QuestieSearchResults.lua
 
 # Tracker
+Modules\Tracker\AutoCompleteFrame.lua
 Modules\Tracker\QuestieTracker.lua
 Modules\Tracker\Sorter\Sorter.lua
 Modules\Tracker\Sorter\byComplete.lua


### PR DESCRIPTION
On Titan Reforged Classic, a quest after 《昔日的传奇》 named 《另辟蹊径》 cannot popup the AutoCompleteFrame, so need disable this addon.

I enable this feature for Titan as Mop or Cata.

## Screenshots

<img width="507" height="248" alt="AutoCompleteFrame" src="https://github.com/user-attachments/assets/32df1164-cdea-422f-9126-2aec69363223" />
