### PR TITLE
Ammo vendor class restriction

### DIFF
--- a/Modules/QuestieMenu/Townsfolk.lua
+++ b/Modules/QuestieMenu/Townsfolk.lua
@@ -529,12 +529,23 @@ local function _UpdatePetFood() -- call on change pet
     Questie.db.char.vendorList["Pet Food"] = _reformatVendors(Questie.db.char.vendorList["Pet Food"])
 end
 
+local _ammoUsingClasses = {
+    ["ROGUE"] = true,
+    ["WARRIOR"] = true,
+    ["HUNTER"] = true,
+}
+
 local function _UpdateAmmoVendors() -- call on change weapon
     if Expansions.Current >= Expansions.Cata then
         return
     end
 
-    Questie.db.char.vendorList["Ammo"] = _reformatVendors(Townsfolk:PopulateVendors({11285,3030,19316,2515,2512,11284,19317,2519,2516,3033,28056,28053,28061,28060}, {}, true))
+    -- Only classes that use ammo benefit from ammo vendors
+    if _ammoUsingClasses[playerClass] then
+        Questie.db.char.vendorList["Ammo"] = _reformatVendors(Townsfolk:PopulateVendors({11285,3030,19316,2515,2512,11284,19317,2519,2516,3033,28056,28053,28061,28060}, {}, true))
+    else
+        Questie.db.char.vendorList["Ammo"] = nil
+    end
 end
 
 local function _UpdateFoodDrink()

--- a/Modules/QuestieMenu/Townsfolk.test.lua
+++ b/Modules/QuestieMenu/Townsfolk.test.lua
@@ -51,6 +51,33 @@ describe("Townsfolk", function()
         Townsfolk = QuestieLoader:ImportModule("Townsfolk")
     end)
 
+    describe("Ammo vendors class filter", function()
+        local function loadTownsfolkForClass(classBase)
+            _G.UnitClassBase = function() return classBase end
+            dofile("Modules/QuestieMenu/Townsfolk.lua")
+            Townsfolk = QuestieLoader:ImportModule("Townsfolk")
+        end
+
+        it("should populate ammo vendors for ammo-using classes", function()
+            _G.GetStablePetFoodTypes = function() return nil end
+            for _, class in pairs({"ROGUE", "WARRIOR", "HUNTER"}) do
+                loadTownsfolkForClass(class)
+                Questie.db.char = {vendorList = {}}
+                Townsfolk.PopulateVendors = function() return {1} end
+                Townsfolk:UpdatePlayerVendors()
+                assert.is_not_nil(Questie.db.char.vendorList["Ammo"])
+            end
+        end)
+
+        it("should not populate ammo vendors for other classes", function()
+            loadTownsfolkForClass("DRUID")
+            Questie.db.char = {vendorList = {["Ammo"] = {1, 2, 3}}}
+            Townsfolk.PopulateVendors = function() return {1} end
+            Townsfolk:UpdatePlayerVendors()
+            assert.is_nil(Questie.db.char.vendorList["Ammo"])
+        end)
+    end)
+
     describe("Townsfolk.GetFactionSpecificMailboxes", function()
         it("should correctly filter mailboxes by faction", function()
             Townsfolk.GetMailboxes = function()


### PR DESCRIPTION
Ammo vendors only show for Rogue, Warrior, Hunter