### PR TITLE
Added check for correct current frame level before setting

### DIFF
--- a/Modules/FramePool/QuestieFrame.lua
+++ b/Modules/FramePool/QuestieFrame.lua
@@ -263,7 +263,7 @@ function _QuestieFrame.BaseOnHide(self)
         if (type(frameLevel) == "number" and frameLevel > 0) then
             self:SetFrameLevel(frameLevel - 1)
         else
-            self:SetFrameLevel( 0)
+            self:SetFrameLevel(0)
         end
     end
     self.glowTexture:Hide()

--- a/Modules/FramePool/QuestieFrame.lua
+++ b/Modules/FramePool/QuestieFrame.lua
@@ -258,7 +258,13 @@ function _QuestieFrame.BaseOnHide(self)
     local data = self.data
 
     if data and data.Type and data.Type == "complete" then
-        self:SetFrameLevel(self:GetFrameLevel() - 1)
+        local frameLevel = self:GetFrameLevel()
+
+        if (type(frameLevel) == "number" and frameLevel > 0) then
+            self:SetFrameLevel(frameLevel - 1)
+        else
+            self:SetFrameLevel( 0)
+        end
     end
     self.glowTexture:Hide()
 end


### PR DESCRIPTION
While playing in WoW classic and using the `FarmHud` addon, I keep seeing the below Lua error when showing/hiding the hud caused by Questie (but not really Questie's fault). I've updated the Questie code to be compatible with FarmHud and I don't think this change has any negative side effects and may also result in better compatibility with other MiniMap/Map related addons.

This is the error that this PR fixes (and the fix is very minor):

```lua
Message: ...ce/AddOns/Questie/Modules/FramePool/QuestieFrame.lua:261: bad argument #1 to 'SetFrameLevel' (outside of expected range 0 to 65535 - Usage: self:SetFrameLevel(frameLevel))
Time: Fri Aug 14 13:34:32 2026
Count: 1167
Stack:
[Interface/AddOns/Questie/Modules/FramePool/QuestieFrame.lua]:261: in function <...ce/AddOns/Questie/Modules/FramePool/QuestieFrame.lua:257>
[C]: in function 'Show'
[Interface/AddOns/Questie/Libs/HereBeDragons/HereBeDragons-Pins-2.0.lua]:176: in function <...uestie/Libs/HereBeDragons/HereBeDragons-Pins-2.0.lua:131>
[Interface/AddOns/Questie/Libs/HereBeDragons/HereBeDragons-Pins-2.0.lua]:334: in function <...uestie/Libs/HereBeDragons/HereBeDragons-Pins-2.0.lua:278>
[Interface/AddOns/Questie/Libs/HereBeDragons/HereBeDragons-Pins-2.0.lua]:547: in function <...uestie/Libs/HereBeDragons/HereBeDragons-Pins-2.0.lua:535>

Locals:
self=QuestieFrame58 <QuestieFrame.lua:36>{
 frameId=58
 data=<table>
 isManualIcon=false
 _loaded=true
 AreaID=1519
 texture=Texture <QuestieFrame.lua:50>
 overlayTexture=Texture <QuestieFrame.lua:58>
 UiMapID=1453
 lastGlowFade=0.510997
 worldY=-8427.000947
 worldX=600.374116
 y=16.528117
 x=58.068460
 glowTexture=Texture <QuestieFrame.lua:65>
 miniMapIcon=true
}
data=<table>{
 Type="complete"
 IconScale=1.350000
 Id=1338
 QuestData=<table>
 IsObjectiveNote=false
 Name="Furen Longbeard"
 Icon=8
 ObjectiveIndex=0
}
```