### PR TITLE
[fix] Fix available quests sometimes not correctly drawing follow up quests

### DIFF
--- a/Modules/Libs/ThreadLib.lua
+++ b/Modules/Libs/ThreadLib.lua
@@ -13,9 +13,10 @@ local newTicker = C_Timer.NewTicker
 ---@param delay integer @Anything below 0.05 is each frame
 ---@param errorMessage string? @What is the "Prepend" of the error message
 ---@param callbackFunction function? @Function to call when the thread is done
+---@param errorCallback function? @Function to call when the coroutine errors; receives the error message string
 ---@return Ticker Timer @The WoW timer, run Timer:Cancel() and let the handle of the thread become orphaned to cancel
 ---@return thread Thread @The coroutine thread
-function ThreadLib.Thread(threadFunction, delay, errorMessage, callbackFunction)
+function ThreadLib.Thread(threadFunction, delay, errorMessage, callbackFunction, errorCallback)
   if lType(threadFunction) ~= "function" then
     error("ThreadLib:Thread: threadFunction is not a function")
   end
@@ -25,8 +26,11 @@ function ThreadLib.Thread(threadFunction, delay, errorMessage, callbackFunction)
   if errorMessage and lType(errorMessage) ~= "string" then
     error("ThreadLib:Thread: errorMessage is not a string")
   end
-  if callbackFunction and lType(callbackFunction) ~= "function" then
+  if callbackFunction and lType(callbackFunction) ~= "function" and (lType(callbackFunction) ~= "table" or not getmetatable(callbackFunction).__call) then
     error("ThreadLib:Thread: callbackFunction is not a function")
+  end
+  if errorCallback and lType(errorCallback) ~= "function" and (lType(errorCallback) ~= "table" or not getmetatable(errorCallback).__call) then
+    error("ThreadLib:Thread: errorCallback is not a function")
   end
 
   local thread = coCreate(threadFunction)
@@ -40,6 +44,9 @@ function ThreadLib.Thread(threadFunction, delay, errorMessage, callbackFunction)
             local stack = debugstack(thread)
             Questie.Error(errorMessage or "Error in thread", ret, "\n", stack)
             timer:Cancel();
+            if errorCallback then
+                errorCallback(ret)
+            end
         end
       elseif (coStatus(thread) == "dead") then --It's faster not to lookup the value but instead have it here
         timer:Cancel();

--- a/Modules/Libs/ThreadLib.test.lua
+++ b/Modules/Libs/ThreadLib.test.lua
@@ -1,0 +1,82 @@
+dofile("setupTests.lua")
+
+describe("ThreadLib", function()
+    ---@type ThreadLib
+    local ThreadLib
+
+    local tickerFn
+
+    before_each(function()
+        -- Stub C_Timer.NewTicker so we can drive the ticker synchronously in tests.
+        _G.C_Timer = {
+            NewTicker = function(_, fn)
+                tickerFn = fn
+                return {Cancel = function() tickerFn = nil end}
+            end
+        }
+        _G.debugstack = function() return "" end
+
+        dofile("Modules/Libs/ThreadLib.lua")
+        ThreadLib = QuestieLoader:ImportModule("ThreadLib")
+    end)
+
+    local function tick()
+        if tickerFn then
+            tickerFn()
+        end
+    end
+
+    describe("Thread", function()
+        it("should call callbackFunction when the coroutine finishes", function()
+            local callback = spy.new(function() end)
+
+            ThreadLib.Thread(function() end, 0, nil, callback)
+
+            tick() -- coroutine runs to completion -> status "dead" -> callback
+            tick() -- second tick fires the "dead" branch
+
+            assert.spy(callback).was.called()
+        end)
+
+        it("should call errorCallback when the coroutine errors", function()
+            local errorCallback = spy.new(function() end)
+
+            Questie.Error = function() end -- suppress output
+
+            ThreadLib.Thread(function() error("boom") end, 0, nil, nil, errorCallback)
+
+            tick() -- coroutine resumes and errors -> errorCallback fires
+
+            assert.spy(errorCallback).was.called()
+        end)
+
+        it("should not call callbackFunction when the coroutine errors", function()
+            local callback = spy.new(function() end)
+
+            Questie.Error = function() end
+
+            ThreadLib.Thread(function() error("boom") end, 0, nil, callback, function() end)
+
+            tick()
+
+            assert.spy(callback).was.not_called()
+        end)
+
+        it("should not call errorCallback when the coroutine finishes successfully", function()
+            local errorCallback = spy.new(function() end)
+
+            ThreadLib.Thread(function() end, 0, nil, nil, errorCallback)
+
+            tick()
+            tick()
+
+            assert.spy(errorCallback).was.not_called()
+        end)
+
+        it("should error when errorCallback is not a function", function()
+            assert.has_error(function()
+                ThreadLib.Thread(function() end, 0, nil, nil, "not a function")
+            end)
+        end)
+    end)
+end)

--- a/Modules/Quest/AvailableQuests/AvailableQuests.lua
+++ b/Modules/Quest/AvailableQuests/AvailableQuests.lua
@@ -167,6 +167,13 @@ local function _StartPass()
         if passQueued then
             _StartPass()
         end
+    end, function()
+        -- The coroutine errored: reset state and start any queued pass.
+        -- Callbacks are intentionally skipped — the draw was incomplete.
+        passRunning = false
+        if passQueued then
+            _StartPass()
+        end
     end)
 end
 

--- a/Modules/Quest/AvailableQuests/AvailableQuests.lua
+++ b/Modules/Quest/AvailableQuests/AvailableQuests.lua
@@ -31,9 +31,20 @@ local NewThread = ThreadLib.ThreadSimple
 
 local QUESTS_PER_YIELD = 24
 
---- Used to keep track of the active timer for CalculateAndDrawAll
----@type Ticker|nil
-local timer
+--- When CalculateAndDrawAll is called while a pass is already running, we queue a follow-up
+--- pass instead of cancelling the running one. This prevents a burst of concurrent callers
+--- (turn-in event + reputation event etc.) from repeatedly cancelling each other mid-pass
+--- so that a draw pass always runs to completion.
+--- true = another pass must start once the current one finishes.
+local passQueued = false
+
+--- true while a ThreadLib pass coroutine is alive.
+local passRunning = false
+
+--- Callbacks accumulated from callers that arrived while a pass was in flight.
+--- They are all invoked after the next completed pass.
+---@type function[]
+local pendingCallbacks = {}
 
 -- Keep track of all available quests to unload undoable when abandoning a quest
 ---@type table<QuestId, boolean>
@@ -57,6 +68,11 @@ local playerFaction
 local QIsComplete, IsLevelRequirementsFulfilled, IsDoable = QuestieDB.IsComplete, AvailableQuests.IsLevelRequirementsFulfilled, QuestieDB.IsDoable
 
 local _CalculateAndDrawAvailableQuests, _DrawChildQuests, _AddStarter, _DrawAvailableQuest, _GetIconScaleForAvailable, _HasProperDistanceToAlreadyAddedSpawns, _MarkQuestAsUnavailableFromNPC, _ScheduleDailyResetTimer
+
+-- Exposed for testing only
+AvailableQuests.__getPassState = function()
+    return passRunning, passQueued
+end
 
 function AvailableQuests.Initialize()
     Questie.Debug(Questie.DEBUG_DEVELOP, "AvailableQuests: Initialize")
@@ -135,15 +151,41 @@ function AvailableQuests.GetUnavailableDailyQuests()
     return result
 end
 
+--- Starts a fresh draw pass, draining any accumulated pending callbacks as the
+--- ThreadLib completion callback so they fire once the new pass finishes.
+local function _StartPass()
+    passQueued = false
+    passRunning = true
+    local callbacks = pendingCallbacks
+    pendingCallbacks = {}
+    ThreadLib.Thread(_CalculateAndDrawAvailableQuests, 0, "Error in AvailableQuests.CalculateAndDrawAll", function()
+        passRunning = false
+        for i = 1, #callbacks do
+            callbacks[i]()
+        end
+        -- If another CalculateAndDrawAll arrived while this pass was running, start it now.
+        if passQueued then
+            _StartPass()
+        end
+    end)
+end
+
 ---@param callback function | nil
 function AvailableQuests.CalculateAndDrawAll(callback)
     Questie.Debug(Questie.DEBUG_INFO, "[AvailableQuests.CalculateAndDrawAll]")
 
-    --? Cancel the previously running timer to not have multiple running at the same time
-    if timer then
-        timer:Cancel()
+    if callback then
+        pendingCallbacks[#pendingCallbacks + 1] = callback
     end
-    timer = ThreadLib.Thread(_CalculateAndDrawAvailableQuests, 0, "Error in AvailableQuests.CalculateAndDrawAll", callback)
+
+    if passRunning then
+        -- A pass is already running. Queue a follow-up so the running pass is not
+        -- cancelled mid-flight; it will start once the current pass completes.
+        passQueued = true
+        return
+    end
+
+    _StartPass()
 end
 
 --Draw a single available quest, it is used by the CalculateAndDrawAll function.

--- a/Modules/Quest/AvailableQuests/AvailableQuests.lua
+++ b/Modules/Quest/AvailableQuests/AvailableQuests.lua
@@ -160,8 +160,12 @@ local function _StartPass()
     pendingCallbacks = {}
     ThreadLib.Thread(_CalculateAndDrawAvailableQuests, 0, "Error in AvailableQuests.CalculateAndDrawAll", function()
         passRunning = false
+
         for i = 1, #callbacks do
-            callbacks[i]()
+            local success, err = pcall(callbacks[i])
+            if (not success) then
+                Questie.Error("Error in AvailableQuests.CalculateAndDrawAll callback", err)
+            end
         end
         -- If another CalculateAndDrawAll arrived while this pass was running, start it now.
         if passQueued then

--- a/Modules/Quest/AvailableQuests/AvailableQuests.test.lua
+++ b/Modules/Quest/AvailableQuests/AvailableQuests.test.lua
@@ -896,4 +896,102 @@ describe("AvailableQuests", function()
             assert.is_true(AvailableQuests.__unavailableQuestsDeterminedByTalking[QUEST_ID])
         end)
     end)
+
+    describe("CalculateAndDrawAll", function()
+        it("should start a pass immediately when none is running", function()
+            local passCount = 0
+            TheadLib.Thread = function()
+                passCount = passCount + 1
+            end
+
+            AvailableQuests.CalculateAndDrawAll()
+
+            assert.are_equal(1, passCount)
+        end)
+
+        it("should queue a second call instead of starting a new pass while one is running", function()
+            local passCount = 0
+            TheadLib.Thread = function()
+                passCount = passCount + 1
+            end
+
+            AvailableQuests.CalculateAndDrawAll()
+            AvailableQuests.CalculateAndDrawAll()
+            AvailableQuests.CalculateAndDrawAll()
+
+            -- Only one pass started; the other two are coalesced into a single queued follow-up
+            assert.are_equal(1, passCount)
+            local _, queued = AvailableQuests.__getPassState()
+            assert.is_true(queued)
+        end)
+
+        it("should start the queued pass once the running pass completes", function()
+            local passCount = 0
+            local firstCallback
+
+            -- First call: capture callback without running the body
+            TheadLib.Thread = function(_, _, _, cb)
+                passCount = passCount + 1
+                firstCallback = cb
+            end
+            AvailableQuests.CalculateAndDrawAll()
+
+            -- Second call while first is in flight — should queue, not start
+            AvailableQuests.CalculateAndDrawAll()
+            assert.are_equal(1, passCount)
+
+            -- Complete the first pass — the queued pass should auto-start
+            firstCallback()
+
+            -- The queued pass was consumed (no longer queued) and a new pass has started
+            assert.are_equal(2, passCount)
+            local _, queued = AvailableQuests.__getPassState()
+            assert.is_false(queued)
+        end)
+
+        it("should fire a callback after the pass it was registered with completes", function()
+            local result = 0
+            local firstCallback
+
+            TheadLib.Thread = function(_, _, _, cb)
+                firstCallback = cb
+            end
+
+            AvailableQuests.CalculateAndDrawAll(function() result = result + 1 end)
+
+            -- Callback has not fired yet (pass still running)
+            assert.are_equal(0, result)
+
+            firstCallback()
+
+            assert.are_equal(1, result)
+        end)
+
+        it("should fire callbacks from concurrent calls each after their respective pass", function()
+            local results = {}
+            local firstCallback, secondCallback
+
+            TheadLib.Thread = function(_, _, _, cb)
+                if (not firstCallback) then
+                    firstCallback = cb
+                else
+                    secondCallback = cb
+                end
+            end
+
+            -- Both calls arrive while no pass is running — first starts immediately, second queues
+            AvailableQuests.CalculateAndDrawAll(function() results[#results + 1] = "first" end)
+            AvailableQuests.CalculateAndDrawAll(function() results[#results + 1] = "second" end)
+
+            assert.are_equal(0, #results)
+
+            -- Complete the first pass; the queued pass starts and "first" callback fires
+            firstCallback()
+            assert.are_same({"first"}, results)
+
+            -- Complete the second pass; "second" callback fires
+            secondCallback()
+            assert.are_same({"first", "second"}, results)
+        end)
+    end)
 end)

--- a/Modules/Quest/AvailableQuests/AvailableQuests.test.lua
+++ b/Modules/Quest/AvailableQuests/AvailableQuests.test.lua
@@ -1046,5 +1046,45 @@ describe("AvailableQuests", function()
 
             assert.is_false(callbackFired)
         end)
+
+        it("should handle callback errors without breaking pass cleanup", function()
+            local successCallback = spy.new(function() error("callback error") end)
+            local capturedSuccessCallback
+
+            Questie.Error = spy.new(function() end)
+
+            TheadLib.Thread = function(_, _, _, cb)
+                capturedSuccessCallback = cb
+            end
+
+            AvailableQuests.CalculateAndDrawAll(successCallback)
+
+            capturedSuccessCallback()
+
+            -- Callback was called despite the error
+            assert.spy(successCallback).was.called()
+            assert.spy(Questie.Error).was.called()
+
+            local running = AvailableQuests.__getPassState()
+            assert.is_false(running)
+        end)
+
+        it("should start queued pass even if callback errors", function()
+            local passCount = 0
+
+            Questie.Error = function() end
+
+            TheadLib.Thread = function(_, _, _, cb)
+                passCount = passCount + 1
+                if passCount == 1 then
+                    cb() -- first pass completes, callback errors
+                end
+            end
+
+            AvailableQuests.CalculateAndDrawAll(function() error("callback error") end)
+            AvailableQuests.CalculateAndDrawAll() -- queued
+
+            assert.are_equal(2, passCount)
+        end)
     end)
 end)

--- a/Modules/Quest/AvailableQuests/AvailableQuests.test.lua
+++ b/Modules/Quest/AvailableQuests/AvailableQuests.test.lua
@@ -993,5 +993,58 @@ describe("AvailableQuests", function()
             secondCallback()
             assert.are_same({"first", "second"}, results)
         end)
+
+        it("should reset passRunning when the pass coroutine errors", function()
+            local capturedErrorCallback
+            TheadLib.Thread = function(_, _, _, _, errorCb)
+                capturedErrorCallback = errorCb
+            end
+
+            AvailableQuests.CalculateAndDrawAll()
+
+            local running = AvailableQuests.__getPassState()
+            assert.is_true(running)
+
+            capturedErrorCallback()
+
+            running = AvailableQuests.__getPassState()
+            assert.is_false(running)
+        end)
+
+        it("should start queued pass after a coroutine error", function()
+            local passCount = 0
+            local capturedErrorCallback
+
+            TheadLib.Thread = function(_, _, _, _, errorCb)
+                passCount = passCount + 1
+                capturedErrorCallback = errorCb
+            end
+
+            AvailableQuests.CalculateAndDrawAll()
+            AvailableQuests.CalculateAndDrawAll() -- queued
+
+            assert.are_equal(1, passCount)
+
+            capturedErrorCallback() -- first pass errors; queued pass should start
+
+            assert.are_equal(2, passCount)
+            local _, queued = AvailableQuests.__getPassState()
+            assert.is_false(queued)
+        end)
+
+        it("should not fire pending callbacks when the pass errors", function()
+            local callbackFired = false
+            local capturedErrorCallback
+
+            TheadLib.Thread = function(_, _, _, _, errorCb)
+                capturedErrorCallback = errorCb
+            end
+
+            AvailableQuests.CalculateAndDrawAll(function() callbackFired = true end)
+
+            capturedErrorCallback()
+
+            assert.is_false(callbackFired)
+        end)
     end)
 end)


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #7761

## Proposed changes

- Instead of canceling currently running `AvailableQuests.CalculateAndDrawAll` threads, we queue another run and let the current one finish

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->
