### PR TITLE
[fix] Hide vendors when not active

### DIFF
--- a/Database/Corrections/Holidays/QuestieEvent.lua
+++ b/Database/Corrections/Holidays/QuestieEvent.lua
@@ -254,8 +254,10 @@ function QuestieEvent:Load()
     SetCVar("calendarShowDarkmoon", shouldShowDmfEvents and "1" or "0")
 
     -- TODO: Also handle WotLK which has a different starting schedule
-    if (Questie.IsClassic and (((not Questie.IsAnniversaryEra) and (not Questie.IsAnniversaryHardcore)) or (ContentPhases.activePhases.Anniversary >= 3)))
-            or Questie.IsTBC then
+    local dmfAvailable = (Questie.IsClassic and (((not Questie.IsAnniversaryEra) and (not Questie.IsAnniversaryHardcore)) or (ContentPhases.activePhases.Anniversary >= 3)))
+            or Questie.IsTBC
+
+    if dmfAvailable then
         _LoadDarkmoonFaire()
     end
 
@@ -268,7 +270,7 @@ function QuestieEvent:Load()
 
     local dmfNpcs = {14844} -- Sylannia <Darkmoon Faire Drink Vendor>
     local dmfActive = dmfIsActive
-    if not dmfActive and (Questie.IsClassic or Questie.IsTBC) then
+    if not dmfActive and dmfAvailable then
         dmfActive = _GetDarkmoonFaireLocation() ~= DMF_LOCATIONS.NONE
     end
     local hideDmf = not dmfActive

--- a/Database/Corrections/Holidays/QuestieEvent.lua
+++ b/Database/Corrections/Holidays/QuestieEvent.lua
@@ -259,6 +259,23 @@ function QuestieEvent:Load()
         _LoadDarkmoonFaire()
     end
 
+    -- Hide event-only NPCs outside their event window
+    local winterVeilNpcs = {13418, 13420, 13429, 13430, 13431, 13432, 13433, 13434, 13435, 13436, 14961, 14962, 14963, 14964, 15124, 15125, 15732} -- Smokywood Pastures vendors
+    local hideWinterVeil = not activeEvents["Winter Veil"]
+    for _, npcId in ipairs(winterVeilNpcs) do
+        QuestieCorrections.questNPCBlacklist[npcId] = hideWinterVeil
+    end
+
+    local dmfNpcs = {14844} -- Sylannia <Darkmoon Faire Drink Vendor>
+    local dmfActive = dmfIsActive
+    if not dmfActive and (Questie.IsClassic or Questie.IsTBC) then
+        dmfActive = _GetDarkmoonFaireLocation() ~= DMF_LOCATIONS.NONE
+    end
+    local hideDmf = not dmfActive
+    for _, npcId in ipairs(dmfNpcs) do
+        QuestieCorrections.questNPCBlacklist[npcId] = hideDmf
+    end
+
     -- Clear the quests to save memory
     QuestieEvent.eventQuests = nil
 end

--- a/Database/Corrections/Holidays/QuestieEvent.lua
+++ b/Database/Corrections/Holidays/QuestieEvent.lua
@@ -255,7 +255,7 @@ function QuestieEvent:Load()
 
     -- TODO: Also handle WotLK which has a different starting schedule
     local dmfAvailable = (Questie.IsClassic and (((not Questie.IsAnniversaryEra) and (not Questie.IsAnniversaryHardcore)) or (ContentPhases.activePhases.Anniversary >= 3)))
-            or Questie.IsTBC
+            or Questie.IsTBC or Questie.IsWotlk
 
     if dmfAvailable then
         _LoadDarkmoonFaire()

--- a/Database/Corrections/Holidays/QuestieEvent.test.lua
+++ b/Database/Corrections/Holidays/QuestieEvent.test.lua
@@ -30,6 +30,7 @@ describe("QuestieEvent", function()
         _G.SetCVar = function() end
         QuestieCorrections = QuestieLoader:ImportModule("QuestieCorrections")
         QuestieCorrections.hiddenQuests = {}
+        QuestieCorrections.questNPCBlacklist = {}
 
         Expansions = QuestieLoader:ImportModule("Expansions")
 


### PR DESCRIPTION
Winter Veil / DMF vendors should not show when their respective events are not active.