### PR TITLE
[Fix] Also show NPC levels for requiredSourceItems

### DIFF
--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -1801,6 +1801,14 @@ function QuestieDB:GetCreatureLevels(quest)
             end
         end
     end
+    if quest.requiredSourceItems then
+        for _, itemId in pairs(quest.requiredSourceItems) do
+            local npcIds = QuestieDB.QueryItemSingle(itemId, "npcDrops")
+            if npcIds then
+                _CollectCreatureLevels(npcIds)
+            end
+        end
+    end
     if quest.Id then
         QuestieDB._CreatureLevelCache[quest.Id] = creatureLevels
     end


### PR DESCRIPTION
Adds creature levels in map icon tooltips for requiredSourceItems

Fixes #7777