### PR TITLE
Enhance tooltip formatting for Questie options

### DIFF
--- a/Modules/Tracker/TrackerHeaderFrame.lua
+++ b/Modules/Tracker/TrackerHeaderFrame.lua
@@ -88,8 +88,14 @@ function TrackerHeaderFrame.Initialize(baseFrame, OnTrackedQuestClick)
         GameTooltip:AddDoubleLine(Questie:Colorize(l10n("Left Click"), "lightBlue"), Questie:Colorize(l10n("Toggle Options"), "white"))
         GameTooltip:AddDoubleLine(Questie:Colorize(l10n("Right Click"), "lightBlue"), Questie:Colorize(l10n("Toggle My Journey"), "white"))
         GameTooltip:AddLine(" ")
-        GameTooltip:AddDoubleLine(Questie:Colorize(l10n("Left Click + Hold"), "lightBlue"), Questie:Colorize(l10n("Drag while Unlocked"), "white"))
-        GameTooltip:AddDoubleLine(Questie:Colorize(l10n("Ctrl + Left Click + Hold"), "lightBlue"), Questie:Colorize(l10n("Drag while Locked"), "white"))
+        GameTooltip:AddDoubleLine(
+            Questie:Colorize(l10n("Left Click + Hold"), "lightBlue"),
+            Questie:Colorize(l10n("Drag while Unlocked"), "white")
+        )
+        GameTooltip:AddDoubleLine(
+            Questie:Colorize(l10n("Ctrl + Left Click + Hold"), "lightBlue"),
+            Questie:Colorize(l10n("Drag while Locked"), "white")
+        )
 
         local VoiceOver, TomTom = TrackerUtils:IsVoiceOverLoaded(), IsAddOnLoaded("TomTom")
 
@@ -99,11 +105,17 @@ function TrackerHeaderFrame.Initialize(baseFrame, OnTrackedQuestClick)
             GameTooltip:AddLine(" ")
 
             if VoiceOver then
-                GameTooltip:AddDoubleLine(Questie:Colorize(l10n("VoiceOver"), "lightBlue"), Questie:Colorize(l10n("Hold shift to see PlayButtons"), "white"))
+                GameTooltip:AddDoubleLine(
+                    Questie:Colorize(l10n("VoiceOver"), "lightBlue"),
+                    Questie:Colorize(l10n("Hold shift to see PlayButtons"), "white")
+                )
             end
 
             if TomTom then
-                GameTooltip:AddDoubleLine(Questie:Colorize(l10n("TomTom"), "lightBlue"), Questie:Colorize(l10n("Ctrl + Left Click or Right Click a Quest Title"), "white"))
+                GameTooltip:AddDoubleLine(
+                    Questie:Colorize(l10n("TomTom"), "lightBlue"),
+                    Questie:Colorize(l10n("Ctrl + Left Click or Right Click a Quest Title"), "white")
+                )
             end
         end
 

--- a/Modules/Tracker/TrackerHeaderFrame.lua
+++ b/Modules/Tracker/TrackerHeaderFrame.lua
@@ -83,25 +83,27 @@ function TrackerHeaderFrame.Initialize(baseFrame, OnTrackedQuestClick)
         end
         GameTooltip._owner = self
         GameTooltip:SetOwner(self, "ANCHOR_CURSOR")
-        GameTooltip:AddLine("Questie " .. QuestieLib:GetAddonVersionString(), 1, 1, 1)
-        GameTooltip:AddLine(Questie:Colorize(l10n("Left Click") .. l10n(": "), "gray") .. l10n("Toggle Options"))
-        GameTooltip:AddLine(Questie:Colorize(l10n("Right Click") .. l10n(": "), "gray") .. l10n("Toggle My Journey"))
+        GameTooltip:AddDoubleLine(Questie:Colorize("Questie", "gold"), Questie:Colorize(QuestieLib:GetAddonVersionString(), "gray"))
         GameTooltip:AddLine(" ")
-        GameTooltip:AddLine(Questie:Colorize(l10n("Left Click + Hold") .. l10n(": "), "gray") .. l10n("Drag while Unlocked"))
-        GameTooltip:AddLine(Questie:Colorize(l10n("Ctrl + Left Click + Hold") .. l10n(": "), "gray") .. l10n("Drag while Locked"))
+        GameTooltip:AddDoubleLine(Questie:Colorize(l10n("Left Click"), "lightBlue"), Questie:Colorize(l10n("Toggle Options"), "white"))
+        GameTooltip:AddDoubleLine(Questie:Colorize(l10n("Right Click"), "lightBlue"), Questie:Colorize(l10n("Toggle My Journey"), "white"))
+        GameTooltip:AddLine(" ")
+        GameTooltip:AddDoubleLine(Questie:Colorize(l10n("Left Click + Hold"), "lightBlue"), Questie:Colorize(l10n("Drag while Unlocked"), "white"))
+        GameTooltip:AddDoubleLine(Questie:Colorize(l10n("Ctrl + Left Click + Hold"), "lightBlue"), Questie:Colorize(l10n("Drag while Locked"), "white"))
 
         local VoiceOver, TomTom = TrackerUtils:IsVoiceOverLoaded(), IsAddOnLoaded("TomTom")
 
         if VoiceOver or TomTom then
             GameTooltip:AddLine(" ")
-            GameTooltip:AddLine(Questie:Colorize(l10n("Questie Tracker Integrations") .. l10n(": "), "gray"))
+            GameTooltip:AddLine(Questie:Colorize(l10n("Questie Tracker Integrations"), "gold"))
+            GameTooltip:AddLine(" ")
 
             if VoiceOver then
-                GameTooltip:AddLine(Questie:Colorize(l10n("VoiceOver") .. l10n(": "), "white") .. l10n("Hold shift to see PlayButtons"))
+                GameTooltip:AddDoubleLine(Questie:Colorize(l10n("VoiceOver"), "lightBlue"), Questie:Colorize(l10n("Hold shift to see PlayButtons"), "white"))
             end
 
             if TomTom then
-                GameTooltip:AddLine(Questie:Colorize(l10n("TomTom") .. l10n(": "), "white") .. l10n("Ctrl + Left Click or Right Click a Quest Title"))
+                GameTooltip:AddDoubleLine(Questie:Colorize(l10n("TomTom"), "lightBlue"), Questie:Colorize(l10n("Ctrl + Left Click or Right Click a Quest Title"), "white"))
             end
         end
 


### PR DESCRIPTION
Bringing this into alignment with the other tooltip layouts.

<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->

OLD

<img width="290" height="148" alt="image" src="https://github.com/user-attachments/assets/17cdfbea-6e20-4d46-a94b-8820e841ab35" />


NEW

<img width="308" height="138" alt="image" src="https://github.com/user-attachments/assets/0d453ed3-f208-4556-8027-3e7249461b36" />

Matches other tooltips now.

<img width="306" height="222" alt="image" src="https://github.com/user-attachments/assets/6654e92c-619d-4643-ad21-f1235627d7e1" />

<img width="260" height="156" alt="image" src="https://github.com/user-attachments/assets/75cd50fd-829c-460f-bbd0-22fb02114043" />
