### PR TITLE
[fix] remove from map button

### DIFF
--- a/Modules/Journey/QuestieSearchResults.lua
+++ b/Modules/Journey/QuestieSearchResults.lua
@@ -114,12 +114,29 @@ local function AddLinkedParagraph(frame, linkType, lookup, header, query, addTom
 end
 
 -- Create a button for showing/hiding manual notes of NPCs/objects
-local function CreateShowHideButton(id)
+---@param id number @NPC (>0) or object (<0) id, or item id when idsToShow is provided
+---@param idsToShow number[]? @NPC/object ids shown together (e.g. all mobs dropping an item)
+local function CreateShowHideButton(id, idsToShow)
+    -- Check whether any of the relevant manual frames are already shown on the map
+    local function hasShownFrames()
+        if not QuestieMap.manualFrames["any"] then
+            return false
+        end
+        if idsToShow then
+            for _, spawnId in ipairs(idsToShow) do
+                if QuestieMap.manualFrames["any"][spawnId] then
+                    return true
+                end
+            end
+            return false
+        end
+        return QuestieMap.manualFrames["any"][id] ~= nil
+    end
     -- Initialise button
     local button = AceGUI:Create("Button")
     button.id = id
-    button.idsToShow = nil
-    if (not QuestieMap.manualFrames["any"]) or (not QuestieMap.manualFrames["any"][id]) then
+    button.idsToShow = idsToShow
+    if not hasShownFrames() then
         button:SetText(l10n("Show on Map"))
         button:SetCallback("OnClick", function(self) self:ShowOnMap(self) end)
     else
@@ -464,8 +481,7 @@ function QuestieSearchResults:ItemsFrameAfterTicker(f, itemId)
         npcLabel:SetText(l10n("%d NPCs drop this item", #npcIdsWithSpawns))
         f:AddChild(npcLabel)
         if (#npcIdsWithSpawns > 0) then
-            local showHideButton = CreateShowHideButton(itemId)
-            showHideButton.idsToShow = npcIdsWithSpawns
+            local showHideButton = CreateShowHideButton(itemId, npcIdsWithSpawns)
             f:AddChild(showHideButton)
         end
         AddLinkedParagraph(f, "npc", npcIdsWithSpawns, "", QuestieDB.QueryNPCSingle, false)
@@ -495,8 +511,7 @@ function QuestieSearchResults:ItemsFrameAfterTicker(f, itemId)
         objectLabel:SetText(l10n("%d Objects drop this item", #objectIdsWithSpawns))
         f:AddChild(objectLabel)
         if (#objectIdsWithSpawns > 0) then
-            local showHideButton = CreateShowHideButton(itemId)
-            showHideButton.idsToShow = objectIdsWithSpawns
+            local showHideButton = CreateShowHideButton(itemId, objectIdsWithSpawns)
             f:AddChild(showHideButton)
         end
         AddLinkedParagraph(f, "object", objectIdsWithSpawns, "", QuestieDB.QueryObjectSingle, false)
@@ -528,8 +543,7 @@ function QuestieSearchResults:ItemsFrameAfterTicker(f, itemId)
         vendorLabel:SetText(l10n("%d Vendors sell this item", #vendorIdsWithSpawns))
         f:AddChild(vendorLabel)
         if (#vendorIdsWithSpawns > 0) then
-            local showHideButton = CreateShowHideButton(itemId)
-            showHideButton.idsToShow = vendorIdsWithSpawns
+            local showHideButton = CreateShowHideButton(itemId, vendorIdsWithSpawns)
             f:AddChild(showHideButton)
         end
         AddLinkedParagraph(f, "npc", vendorIdsWithSpawns, "", QuestieDB.QueryNPCSingle)

--- a/Modules/Journey/QuestieSearchResults.lua
+++ b/Modules/Journey/QuestieSearchResults.lua
@@ -113,21 +113,19 @@ local function AddLinkedParagraph(frame, linkType, lookup, header, query, addTom
     end
 end
 
+-- Track which items the user explicitly chose to show on the map
+local _shownItemIds = {}
+
 -- Create a button for showing/hiding manual notes of NPCs/objects
 ---@param id number @NPC (>0) or object (<0) id, or item id when idsToShow is provided
 ---@param idsToShow number[]? @NPC/object ids shown together (e.g. all mobs dropping an item)
 local function CreateShowHideButton(id, idsToShow)
-    -- Check whether any of the relevant manual frames are already shown on the map
+    -- Check whether the relevant manual frames are already shown on the map
     local function hasShownFrames()
-        if not QuestieMap.manualFrames["any"] then
-            return false
-        end
         if idsToShow then
-            for _, spawnId in ipairs(idsToShow) do
-                if QuestieMap.manualFrames["any"][spawnId] then
-                    return true
-                end
-            end
+            return _shownItemIds[id] ~= nil
+        end
+        if not QuestieMap.manualFrames["any"] then
             return false
         end
         return QuestieMap.manualFrames["any"][id] ~= nil
@@ -149,6 +147,7 @@ local function CreateShowHideButton(id, idsToShow)
         self:SetCallback("OnClick", function() self:ShowOnMap(self) end)
 
         if self.idsToShow then
+            _shownItemIds[self.id] = nil
             local ids = {}
             for _, spawnId in pairs(self.idsToShow) do
                 ids[#ids + 1] = spawnId
@@ -174,6 +173,7 @@ local function CreateShowHideButton(id, idsToShow)
         self:SetCallback("OnClick", function() self:RemoveFromMap(self) end)
 
         if self.idsToShow then
+            _shownItemIds[self.id] = true
             local ids = {}
             for _, spawnId in pairs(self.idsToShow) do
                 ids[#ids + 1] = spawnId

--- a/Modules/Journey/QuestieSearchResults.lua
+++ b/Modules/Journey/QuestieSearchResults.lua
@@ -114,31 +114,35 @@ local function AddLinkedParagraph(frame, linkType, lookup, header, query, addTom
 end
 
 -- Track which items the user explicitly chose to show on the map
+---@type table<ItemId, true>
 local _shownItemIds = {}
 
 function QuestieSearchResults.ClearShownItemIds()
     _shownItemIds = {}
 end
 
--- Create a button for showing/hiding manual notes of NPCs/objects
----@param id number @NPC (>0) or object (<0) id, or item id when idsToShow is provided
----@param idsToShow number[]? @NPC/object ids shown together (e.g. all mobs dropping an item)
-local function CreateShowHideButton(id, idsToShow)
-    -- Check whether the relevant manual frames are already shown on the map
-    local function hasShownFrames()
-        if idsToShow then
-            return _shownItemIds[id] ~= nil
-        end
-        if not QuestieMap.manualFrames["any"] then
-            return false
-        end
-        return QuestieMap.manualFrames["any"][id] ~= nil
+-- Check whether the relevant manual frames are already shown on the map
+---@param id NpcId|ObjectId|ItemId @NPC (>0) or object (<0) id, or item id when idsToShow is provided
+---@param idsToShow NpcId[]|ObjectId[]? @NPC/object ids shown together (e.g. all mobs dropping an item)
+local function _HasShownFrames(id, idsToShow)
+    if idsToShow then
+        return _shownItemIds[id] ~= nil
     end
+    if (not QuestieMap.manualFrames["any"]) then
+        return false
+    end
+    return QuestieMap.manualFrames["any"][id] ~= nil
+end
+
+-- Create a button for showing/hiding manual notes of NPCs/objects
+---@param id NpcId|ObjectId|ItemId @NPC (>0) or object (<0) id, or item id when idsToShow is provided
+---@param idsToShow NpcId[]|ObjectId[]? @NPC/object ids shown together (e.g. all mobs dropping an item)
+local function CreateShowHideButton(id, idsToShow)
     -- Initialise button
     local button = AceGUI:Create("Button")
     button.id = id
     button.idsToShow = idsToShow
-    if not hasShownFrames() then
+    if (not _HasShownFrames(id, idsToShow)) then
         button:SetText(l10n("Show on Map"))
         button:SetCallback("OnClick", function(self) self:ShowOnMap(self) end)
     else
@@ -391,9 +395,9 @@ QuestieScanningTooltip:SetOwner(WorldFrame, "ANCHOR_NONE")
 
 --- This function queries an item tooltip from the server, waits for the result, then calls the following function to draw an item info frame to a given parent frame.
 ---@param f Frame The frame to attach the created item details frame to
----@param itemId ItemID The ID for the item to show details about
+---@param itemId ItemId The ID for the item to show details about
 ---@return nil
- function QuestieSearchResults:ItemDetailsFrame(f, itemId)
+function QuestieSearchResults:ItemDetailsFrame(f, itemId)
     -- Caching an item creates visible lag of 2 or 3 seconds at times (e.g. 13490, 13492 on Era)
     -- So we need to make sure the item data is *sufficiently* cached before we draw the frame
     -- We can't use the following because it creates a delay in the tooltip being drawn:
@@ -416,8 +420,7 @@ end
 
 --- This function draws an item info frame to a given parent frame after the previous function made sure its data is cached.
 ---@param f Frame The frame to attach the created item details frame to
----@param itemId ItemID The ID for the item to show details about
----@return nil
+---@param itemId ItemId The ID for the item to show details about
 function QuestieSearchResults:ItemsFrameAfterTicker(f, itemId)
     local header = AceGUI:Create("Heading")
     header:SetFullWidth(true)

--- a/Modules/Journey/QuestieSearchResults.lua
+++ b/Modules/Journey/QuestieSearchResults.lua
@@ -114,7 +114,7 @@ local function AddLinkedParagraph(frame, linkType, lookup, header, query, addTom
 end
 
 -- Track which items the user explicitly chose to show on the map
----@type table<ItemId, true>
+---@type table<string, true>
 local _shownItemIds = {}
 
 function QuestieSearchResults.ClearShownItemIds()
@@ -124,9 +124,10 @@ end
 -- Check whether the relevant manual frames are already shown on the map
 ---@param id NpcId|ObjectId|ItemId @NPC (>0) or object (<0) id, or item id when idsToShow is provided
 ---@param idsToShow NpcId[]|ObjectId[]? @NPC/object ids shown together (e.g. all mobs dropping an item)
-local function _HasShownFrames(id, idsToShow)
-    if idsToShow then
-        return _shownItemIds[id] ~= nil
+---@param groupName string? @Source group name for items (e.g. "NPC", "Object", "Vendor")
+local function _HasShownFrames(id, idsToShow, groupName)
+    if idsToShow and groupName then
+        return _shownItemIds[id .. ":" .. groupName] ~= nil
     end
     if (not QuestieMap.manualFrames["any"]) then
         return false
@@ -137,12 +138,14 @@ end
 -- Create a button for showing/hiding manual notes of NPCs/objects
 ---@param id NpcId|ObjectId|ItemId @NPC (>0) or object (<0) id, or item id when idsToShow is provided
 ---@param idsToShow NpcId[]|ObjectId[]? @NPC/object ids shown together (e.g. all mobs dropping an item)
-local function CreateShowHideButton(id, idsToShow)
+---@param groupName string? @Source group name for items (e.g. "NPC", "Object", "Vendor")
+local function CreateShowHideButton(id, idsToShow, groupName)
     -- Initialise button
     local button = AceGUI:Create("Button")
     button.id = id
     button.idsToShow = idsToShow
-    if (not _HasShownFrames(id, idsToShow)) then
+    button.groupName = groupName
+    if (not _HasShownFrames(id, idsToShow, groupName)) then
         button:SetText(l10n("Show on Map"))
         button:SetCallback("OnClick", function(self) self:ShowOnMap(self) end)
     else
@@ -154,8 +157,8 @@ local function CreateShowHideButton(id, idsToShow)
         self:SetText(l10n("Show on Map"))
         self:SetCallback("OnClick", function() self:ShowOnMap(self) end)
 
-        if self.idsToShow then
-            _shownItemIds[self.id] = nil
+        if self.idsToShow and self.groupName then
+            _shownItemIds[self.id .. ":" .. self.groupName] = nil
             local ids = {}
             for _, spawnId in pairs(self.idsToShow) do
                 ids[#ids + 1] = spawnId
@@ -180,8 +183,8 @@ local function CreateShowHideButton(id, idsToShow)
         self:SetText(l10n("Remove from Map"))
         self:SetCallback("OnClick", function() self:RemoveFromMap(self) end)
 
-        if self.idsToShow then
-            _shownItemIds[self.id] = true
+        if self.idsToShow and self.groupName then
+            _shownItemIds[self.id .. ":" .. self.groupName] = true
             local ids = {}
             for _, spawnId in pairs(self.idsToShow) do
                 ids[#ids + 1] = spawnId
@@ -488,7 +491,7 @@ function QuestieSearchResults:ItemsFrameAfterTicker(f, itemId)
         npcLabel:SetText(l10n("%d NPCs drop this item", #npcIdsWithSpawns))
         f:AddChild(npcLabel)
         if (#npcIdsWithSpawns > 0) then
-            local showHideButton = CreateShowHideButton(itemId, npcIdsWithSpawns)
+            local showHideButton = CreateShowHideButton(itemId, npcIdsWithSpawns, "NPC")
             f:AddChild(showHideButton)
         end
         AddLinkedParagraph(f, "npc", npcIdsWithSpawns, "", QuestieDB.QueryNPCSingle, false)
@@ -518,7 +521,7 @@ function QuestieSearchResults:ItemsFrameAfterTicker(f, itemId)
         objectLabel:SetText(l10n("%d Objects drop this item", #objectIdsWithSpawns))
         f:AddChild(objectLabel)
         if (#objectIdsWithSpawns > 0) then
-            local showHideButton = CreateShowHideButton(itemId, objectIdsWithSpawns)
+            local showHideButton = CreateShowHideButton(itemId, objectIdsWithSpawns, "Object")
             f:AddChild(showHideButton)
         end
         AddLinkedParagraph(f, "object", objectIdsWithSpawns, "", QuestieDB.QueryObjectSingle, false)
@@ -550,7 +553,7 @@ function QuestieSearchResults:ItemsFrameAfterTicker(f, itemId)
         vendorLabel:SetText(l10n("%d Vendors sell this item", #vendorIdsWithSpawns))
         f:AddChild(vendorLabel)
         if (#vendorIdsWithSpawns > 0) then
-            local showHideButton = CreateShowHideButton(itemId, vendorIdsWithSpawns)
+            local showHideButton = CreateShowHideButton(itemId, vendorIdsWithSpawns, "Vendor")
             f:AddChild(showHideButton)
         end
         AddLinkedParagraph(f, "npc", vendorIdsWithSpawns, "", QuestieDB.QueryNPCSingle)

--- a/Modules/Journey/QuestieSearchResults.lua
+++ b/Modules/Journey/QuestieSearchResults.lua
@@ -116,6 +116,10 @@ end
 -- Track which items the user explicitly chose to show on the map
 local _shownItemIds = {}
 
+function QuestieSearchResults.ClearShownItemIds()
+    _shownItemIds = {}
+end
+
 -- Create a button for showing/hiding manual notes of NPCs/objects
 ---@param id number @NPC (>0) or object (<0) id, or item id when idsToShow is provided
 ---@param idsToShow number[]? @NPC/object ids shown together (e.g. all mobs dropping an item)

--- a/Modules/QuestieSlash.lua
+++ b/Modules/QuestieSlash.lua
@@ -11,6 +11,8 @@ local QuestieQuest = QuestieLoader:ImportModule("QuestieQuest")
 local QuestieTracker = QuestieLoader:ImportModule("QuestieTracker")
 ---@type QuestieSearch
 local QuestieSearch = QuestieLoader:ImportModule("QuestieSearch")
+---@type QuestieSearchResults
+local QuestieSearchResults = QuestieLoader:ImportModule("QuestieSearchResults")
 ---@type QuestieMap
 local QuestieMap = QuestieLoader:ImportModule("QuestieMap")
 ---@type QuestieLib
@@ -152,7 +154,8 @@ function QuestieSlash.HandleCommands(input)
             -- reset command
             if searchType == "reset" then
                 QuestieMap:ResetManualFrames()
-                print(Questie:Colorize("/questie "..input..":"), l10n("All map markers cleared."))
+                QuestieSearchResults.ClearShownItemIds()
+                print(Questie:Colorize("/questie " .. input .. ":"), l10n("All map markers cleared."))
                 return
             end
             -- no search term provided


### PR DESCRIPTION
The "Remove from map" button changes back to "Show on map" if you exit My Journey for objects in the Advanced Search