### PR TITLE
[fix] Prevent hidden map icons from reappearing after map exploration

### DIFF
--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -99,7 +99,7 @@ function QuestieMap.utils.MapExplorationUpdate()
         for _, frameName in pairs(frameList) do
             local frame = _G[frameName]
             if (frame and frame.x and frame.y and frame.UiMapID and frame.hidden) then
-                if (QuestieMap.utils.IsExplored(frame.UiMapID, frame.x, frame.y)) then
+                if (QuestieMap.utils.IsExplored(frame.UiMapID, frame.x, frame.y) and not frame:ShouldBeHidden()) then
                     frame:FakeShow()
                 end
             end

--- a/Modules/Map/QuestieMapUtils.test.lua
+++ b/Modules/Map/QuestieMapUtils.test.lua
@@ -254,4 +254,28 @@ describe("QuestieMapUtils", function()
             assert.spy(SetFrameLevelSpy).was.called_with(frame, 2024)
         end)
     end)
+
+    describe("MapExplorationUpdate", function()
+        it("should keep map icons hidden when settings hide them", function()
+            local frame = {
+                x = 50,
+                y = 50,
+                UiMapID = 1,
+                hidden = true,
+                FakeShow = function() end,
+                ShouldBeHidden = function() return true end,
+            }
+            _G.QuestieMapUtilsTestFrame = frame
+            QuestieMap.questIdFrames = {
+                [1] = {"QuestieMapUtilsTestFrame"},
+            }
+            QuestieMap.utils.IsExplored = function() return true end
+
+            local fakeShowSpy = spy.on(frame, "FakeShow")
+
+            QuestieMap.utils.MapExplorationUpdate()
+
+            assert.spy(fakeShowSpy).was.not_called()
+        end)
+    end)
 end)


### PR DESCRIPTION
<!-- READ THIS FIRST

Hello, thank you very much for using your time to submit a pull request for Questie.

Please fill in the information below as good as you can to speed up the review.

If you are updating/adding translations just list the languages you are editing.
-->

## Issue references

Fixes #7812

## Proposed changes

- Respect map icon visibility settings when updating icons after map exploration.
- Add a regression test to ensure hidden map icons remain hidden after discovering a new area.

## Screenshots

<!-- If you think ingame screenshots would be helpful to understand your changes, it would be great if you simply paste them below -->
