### PR TITLE
[fix] Prune departed party members from tooltips

### DIFF
--- a/Modules/EventHandler/GroupEventHandler.lua
+++ b/Modules/EventHandler/GroupEventHandler.lua
@@ -48,6 +48,9 @@ function GroupEventHandler.GroupRosterUpdate()
     local sizeChanged = currentMembers ~= QuestiePlayer.numberOfGroupMembers
     QuestiePlayer.numberOfGroupMembers = currentMembers
 
+    -- Prune quest and tooltip data even when one member replaces another and the group size stays the same.
+    local groupMembersChanged = QuestieComms:PruneRemotePlayers()
+
     -- Evaluate unconditionally so the online snapshot stays current even when the size also changed.
     local onlineChanged = _OnlineStatusChanged()
 
@@ -57,7 +60,7 @@ function GroupEventHandler.GroupRosterUpdate()
 
     -- Only resync visibility when group size or a quest-sharing member's online state changed.
     -- Pure zone changes also fire GROUP_ROSTER_UPDATE and must NOT trigger a redraw.
-    if sizeChanged or onlineChanged then
+    if sizeChanged or onlineChanged or groupMembersChanged then
         CommsVisibility:ScheduleSnapshot("GROUP_ROSTER_UPDATE")
         QuestiePartyObjectives:ScheduleUpdate()
     end

--- a/Modules/EventHandler/GroupEventHandler.lua
+++ b/Modules/EventHandler/GroupEventHandler.lua
@@ -92,8 +92,8 @@ function GroupEventHandler.GroupJoined()
 end
 
 function GroupEventHandler.GroupLeft()
-    --Resets both QuestieComms.remoteQuestLog and QuestieComms.data
-    QuestieComms:ResetAll()
+    -- Keep Nearby/YELL data while removing the group-specific snapshots.
+    QuestieComms:RemoveAllRemoteGroupPlayers()
     CommsVisibility:ResetAll()
     QuestiePartyObjectives:Clear()
     previousOnlineStatus = {}

--- a/Modules/EventHandler/GroupEventHandler.test.lua
+++ b/Modules/EventHandler/GroupEventHandler.test.lua
@@ -1,0 +1,53 @@
+dofile("setupTests.lua")
+
+describe("GroupEventHandler", function()
+    ---@type GroupEventHandler
+    local GroupEventHandler
+    ---@type QuestiePlayer
+    local QuestiePlayer
+    ---@type QuestieComms
+    local QuestieComms
+    ---@type CommsVisibility
+    local CommsVisibility
+    ---@type QuestiePartyObjectives
+    local QuestiePartyObjectives
+
+    before_each(function()
+        _G.GetNumGroupMembers = function() return 2 end
+
+        QuestiePlayer = QuestieLoader:ImportModule("QuestiePlayer")
+        QuestiePlayer.numberOfGroupMembers = 2
+
+        QuestieComms = QuestieLoader:ImportModule("QuestieComms")
+        QuestieComms.remoteQuestLogs = {}
+        QuestieComms.PruneRemotePlayers = spy.new(function() return false end)
+
+        CommsVisibility = QuestieLoader:ImportModule("CommsVisibility")
+        CommsVisibility.PruneRemotePlayers = spy.new(function() end)
+        CommsVisibility.ScheduleSnapshot = spy.new(function() end)
+
+        QuestiePartyObjectives = QuestieLoader:ImportModule("QuestiePartyObjectives")
+        QuestiePartyObjectives.ScheduleUpdate = spy.new(function() end)
+
+        dofile("Modules/EventHandler/GroupEventHandler.lua")
+        GroupEventHandler = QuestieLoader:ImportModule("GroupEventHandler")
+    end)
+
+    it("should redraw after a same-size roster replacement prunes a former member", function()
+        QuestieComms.PruneRemotePlayers = spy.new(function() return true end)
+
+        GroupEventHandler.GroupRosterUpdate()
+
+        assert.spy(QuestieComms.PruneRemotePlayers).was.called_with(QuestieComms)
+        assert.spy(CommsVisibility.ScheduleSnapshot).was.called_with(CommsVisibility, "GROUP_ROSTER_UPDATE")
+        assert.spy(QuestiePartyObjectives.ScheduleUpdate).was.called_with(QuestiePartyObjectives)
+    end)
+
+    it("should not redraw for an unchanged roster", function()
+        GroupEventHandler.GroupRosterUpdate()
+
+        assert.spy(QuestieComms.PruneRemotePlayers).was.called_with(QuestieComms)
+        assert.spy(CommsVisibility.ScheduleSnapshot).was.not_called()
+        assert.spy(QuestiePartyObjectives.ScheduleUpdate).was.not_called()
+    end)
+end)

--- a/Modules/EventHandler/GroupEventHandler.test.lua
+++ b/Modules/EventHandler/GroupEventHandler.test.lua
@@ -21,13 +21,17 @@ describe("GroupEventHandler", function()
         QuestieComms = QuestieLoader:ImportModule("QuestieComms")
         QuestieComms.remoteQuestLogs = {}
         QuestieComms.PruneRemotePlayers = spy.new(function() return false end)
+        QuestieComms.RemoveAllRemoteGroupPlayers = spy.new(function() end)
+        QuestieComms.ResetAll = spy.new(function() end)
 
         CommsVisibility = QuestieLoader:ImportModule("CommsVisibility")
         CommsVisibility.PruneRemotePlayers = spy.new(function() end)
         CommsVisibility.ScheduleSnapshot = spy.new(function() end)
+        CommsVisibility.ResetAll = spy.new(function() end)
 
         QuestiePartyObjectives = QuestieLoader:ImportModule("QuestiePartyObjectives")
         QuestiePartyObjectives.ScheduleUpdate = spy.new(function() end)
+        QuestiePartyObjectives.Clear = spy.new(function() end)
 
         dofile("Modules/EventHandler/GroupEventHandler.lua")
         GroupEventHandler = QuestieLoader:ImportModule("GroupEventHandler")
@@ -49,5 +53,14 @@ describe("GroupEventHandler", function()
         assert.spy(QuestieComms.PruneRemotePlayers).was.called_with(QuestieComms)
         assert.spy(CommsVisibility.ScheduleSnapshot).was.not_called()
         assert.spy(QuestiePartyObjectives.ScheduleUpdate).was.not_called()
+    end)
+
+    it("should remove only group quest data when the local player leaves", function()
+        GroupEventHandler.GroupLeft()
+
+        assert.spy(QuestieComms.RemoveAllRemoteGroupPlayers).was.called_with(QuestieComms)
+        assert.spy(QuestieComms.ResetAll).was.not_called()
+        assert.spy(CommsVisibility.ResetAll).was.called_with(CommsVisibility)
+        assert.spy(QuestiePartyObjectives.Clear).was.called_with(QuestiePartyObjectives)
     end)
 end)

--- a/Modules/Network/QuestieComms.lua
+++ b/Modules/Network/QuestieComms.lua
@@ -37,6 +37,11 @@ QuestieComms.remotePlayerClasses = {}
 QuestieComms.remotePlayerEnabled = {}
 QuestieComms.remotePlayerTimes = {}
 
+-- Players whose quest data was received while they were in the group. Keep this separate from
+-- remotePlayerTimes because that table tracks nearby/YELL players, whose data must not be pruned
+-- just because they are not in the current party or raid.
+local remoteGroupPlayers = {}
+
 -- The idea here is that all messages with the same "base number" are compatible
 -- New message versions increase the number by 0.1, and if the message becomes "incompatible" you increase with 1
 -- Say if the message is 1.5 it is valid as long as it is < 2. If it is 2.5 it is not compatible for example.
@@ -47,6 +52,12 @@ local suggestUpdate = true;
 
 -- forward declaration
 local _DoYell
+
+local function _TrackRemoteGroupPlayer(playerName)
+    if QuestieComms:CheckInGroup(playerName) then
+        remoteGroupPlayers[playerName] = true
+    end
+end
 
 --Not used, contains a list of hashes for quest, used to compare change.
 --_QuestieComms.questHashes = {};
@@ -323,6 +334,8 @@ function QuestieComms:InsertQuestDataPacketV2_noclass_RenameMe(questPacket, play
     --We don't want to insert our own quest data.
     local allDone = true
     if questPacket then
+        _TrackRemoteGroupPlayer(playerName)
+
         --Does it contain id and objectives?
         if (questPacket[1 + offset]) then
             -- Create empty quest.
@@ -379,6 +392,8 @@ function QuestieComms:InsertQuestDataPacketV2(questPacket, playerName, offset, d
     --We don't want to insert our own quest data.
     local allDone = true
     if questPacket then
+        _TrackRemoteGroupPlayer(playerName)
+
         --Does it contain id and objectives?
         if (questPacket[2 + offset]) then
             -- Create empty quest.
@@ -449,11 +464,29 @@ function QuestieComms:RemoveRemotePlayer(name)
     QuestieComms.remotePlayerEnabled[name] = nil
     QuestieComms.remotePlayerClasses[name] = nil
     if not QuestieComms:CheckInGroup(name) then
+        remoteGroupPlayers[name] = nil
         for _, players in pairs(QuestieComms.remoteQuestLogs) do
             players[name] = nil
         end
+        QuestieComms.data:RemovePlayer(name)
     end
     QuestiePartyObjectives:ScheduleUpdate()
+end
+
+---@return boolean changed Whether a former group member was removed.
+function QuestieComms:PruneRemotePlayers()
+    local playersToRemove = {}
+    for name in pairs(remoteGroupPlayers) do
+        if not QuestieComms:CheckInGroup(name) then
+            playersToRemove[#playersToRemove + 1] = name
+        end
+    end
+
+    for _, name in ipairs(playersToRemove) do
+        QuestieComms:RemoveRemotePlayer(name)
+    end
+
+    return #playersToRemove > 0
 end
 
 function QuestieComms:SortRemotePlayers()
@@ -826,6 +859,8 @@ end
 function QuestieComms:InsertQuestDataPacket(questPacket, playerName)
     --We don't want to insert our own quest data.
     if questPacket and playerName ~= UnitName("player") then
+        _TrackRemoteGroupPlayer(playerName)
+
         --Does it contain id and objectives?
         if (questPacket.objectives and questPacket.id) then
             -- Create empty quest.
@@ -1119,5 +1154,6 @@ end
 function QuestieComms:ResetAll()
     QuestieComms.data:ResetAll()
     QuestieComms.remoteQuestLogs = {}
+    remoteGroupPlayers = {}
     QuestiePartyObjectives:ScheduleUpdate()
 end

--- a/Modules/Network/QuestieComms.lua
+++ b/Modules/Network/QuestieComms.lua
@@ -43,11 +43,16 @@ local NEARBY_SOURCE = "nearby"
 
 -- Keep the independently received group and Nearby/YELL snapshots so removing one source can
 -- restore the other instead of deleting or preserving unrelated quest data for the whole player.
+---@class RemoteQuestSources
+---@field group table?
+---@field nearby table?
+---@type table<number, table<string, RemoteQuestSources>>
 local remoteQuestSources = {}
 
 -- Players whose quest data was received while they were in the group. Keep this separate from
 -- remotePlayerTimes because that table tracks nearby/YELL players, whose data must not be pruned
 -- just because they are not in the current party or raid.
+---@type table<string, boolean>
 local remoteGroupPlayers = {}
 
 -- The idea here is that all messages with the same "base number" are compatible
@@ -61,6 +66,8 @@ local suggestUpdate = true;
 -- forward declaration
 local _DoYell
 
+---@param playerName string
+---@return boolean
 local function _TrackRemoteGroupPlayer(playerName)
     if QuestieComms:CheckInGroup(playerName) then
         remoteGroupPlayers[playerName] = true
@@ -70,6 +77,9 @@ local function _TrackRemoteGroupPlayer(playerName)
     return false
 end
 
+---@param questId number
+---@param playerName string
+---@param sources RemoteQuestSources?
 local function _RefreshRemoteQuestProjection(questId, playerName, sources)
     local questLogs = QuestieComms.remoteQuestLogs[questId]
     local current = questLogs and questLogs[playerName]
@@ -97,6 +107,11 @@ local function _RefreshRemoteQuestProjection(questId, playerName, sources)
     end
 end
 
+---@param questId number
+---@param playerName string
+---@param source "group"|"nearby"
+---@param objectives table
+---@return boolean
 local function _SetRemoteQuestSource(questId, playerName, source, objectives)
     if source == GROUP_SOURCE and not _TrackRemoteGroupPlayer(playerName) then
         return false
@@ -115,6 +130,10 @@ local function _SetRemoteQuestSource(questId, playerName, source, objectives)
     return true
 end
 
+---@param questId number
+---@param playerName string
+---@param source "group"|"nearby"
+---@return boolean
 local function _RemoveRemoteQuestSource(questId, playerName, source)
     local players = remoteQuestSources[questId]
     local sources = players and players[playerName]
@@ -134,6 +153,9 @@ local function _RemoveRemoteQuestSource(questId, playerName, source)
     return true
 end
 
+---@param playerName string
+---@param source "group"|"nearby"
+---@return boolean
 local function _RemoveRemotePlayerSource(playerName, source)
     local questIds = {}
     for questId, players in pairs(remoteQuestSources) do
@@ -161,6 +183,7 @@ _QuestieComms.QC_WRITE_WHISPER = "WHISPER"
 _QuestieComms.QC_WRITE_CHANNEL = "CHANNEL"
 _QuestieComms.QC_WRITE_YELL = "YELL"
 
+---@type table<string, boolean>
 local groupMessageDistributions = {
     [_QuestieComms.QC_WRITE_ALLGROUP] = true,
     [_QuestieComms.QC_WRITE_ALLINSTANCE] = true,
@@ -523,6 +546,7 @@ function QuestieComms:CheckInGroup(name)
     return IsInRaid() and UnitInRaid(name) or UnitInParty(name)
 end
 
+---@param name string
 local function _RemoveNearbyPlayer(name)
     QuestieComms.remotePlayerTimes[name] = nil
     QuestieComms.remotePlayerEnabled[name] = nil

--- a/Modules/Network/QuestieComms.lua
+++ b/Modules/Network/QuestieComms.lua
@@ -37,6 +37,14 @@ QuestieComms.remotePlayerClasses = {}
 QuestieComms.remotePlayerEnabled = {}
 QuestieComms.remotePlayerTimes = {}
 
+local REMOTE_PLAYER_TIMEOUT = 60 * 4
+local GROUP_SOURCE = "group"
+local NEARBY_SOURCE = "nearby"
+
+-- Keep the independently received group and Nearby/YELL snapshots so removing one source can
+-- restore the other instead of deleting or preserving unrelated quest data for the whole player.
+local remoteQuestSources = {}
+
 -- Players whose quest data was received while they were in the group. Keep this separate from
 -- remotePlayerTimes because that table tracks nearby/YELL players, whose data must not be pruned
 -- just because they are not in the current party or raid.
@@ -56,7 +64,89 @@ local _DoYell
 local function _TrackRemoteGroupPlayer(playerName)
     if QuestieComms:CheckInGroup(playerName) then
         remoteGroupPlayers[playerName] = true
+        return true
     end
+
+    return false
+end
+
+local function _RefreshRemoteQuestProjection(questId, playerName, sources)
+    local questLogs = QuestieComms.remoteQuestLogs[questId]
+    local current = questLogs and questLogs[playerName]
+    local projected = sources and (sources[GROUP_SOURCE] or sources[NEARBY_SOURCE])
+
+    if current == projected then
+        return
+    end
+
+    if current then
+        QuestieComms.data:RemoveQuestFromPlayer(questId, playerName)
+    end
+    if projected then
+        if not questLogs then
+            questLogs = {}
+            QuestieComms.remoteQuestLogs[questId] = questLogs
+        end
+        questLogs[playerName] = projected
+        QuestieComms.data:RegisterTooltip(questId, playerName, projected)
+    elseif questLogs then
+        questLogs[playerName] = nil
+        if not next(questLogs) then
+            QuestieComms.remoteQuestLogs[questId] = nil
+        end
+    end
+end
+
+local function _SetRemoteQuestSource(questId, playerName, source, objectives)
+    if source == GROUP_SOURCE and not _TrackRemoteGroupPlayer(playerName) then
+        return false
+    end
+
+    if not remoteQuestSources[questId] then
+        remoteQuestSources[questId] = {}
+    end
+    if not remoteQuestSources[questId][playerName] then
+        remoteQuestSources[questId][playerName] = {}
+    end
+
+    local sources = remoteQuestSources[questId][playerName]
+    sources[source] = objectives
+    _RefreshRemoteQuestProjection(questId, playerName, sources)
+    return true
+end
+
+local function _RemoveRemoteQuestSource(questId, playerName, source)
+    local players = remoteQuestSources[questId]
+    local sources = players and players[playerName]
+    if not sources or not sources[source] then
+        return false
+    end
+
+    sources[source] = nil
+    _RefreshRemoteQuestProjection(questId, playerName, sources)
+
+    if not next(sources) then
+        players[playerName] = nil
+        if not next(players) then
+            remoteQuestSources[questId] = nil
+        end
+    end
+    return true
+end
+
+local function _RemoveRemotePlayerSource(playerName, source)
+    local questIds = {}
+    for questId, players in pairs(remoteQuestSources) do
+        if players[playerName] and players[playerName][source] then
+            questIds[#questIds + 1] = questId
+        end
+    end
+
+    for _, questId in ipairs(questIds) do
+        _RemoveRemoteQuestSource(questId, playerName, source)
+    end
+
+    return #questIds > 0
 end
 
 --Not used, contains a list of hashes for quest, used to compare change.
@@ -334,8 +424,6 @@ function QuestieComms:InsertQuestDataPacketV2_noclass_RenameMe(questPacket, play
     --We don't want to insert our own quest data.
     local allDone = true
     if questPacket then
-        _TrackRemoteGroupPlayer(playerName)
-
         --Does it contain id and objectives?
         if (questPacket[1 + offset]) then
             -- Create empty quest.
@@ -368,18 +456,9 @@ function QuestieComms:InsertQuestDataPacketV2_noclass_RenameMe(questPacket, play
                 offset = offset + 4
             end
             if not (allDone and disableCompleteQuests) then
-                if not QuestieComms.remoteQuestLogs[questPacketid] then
-                    QuestieComms.remoteQuestLogs[questPacketid] = {}
-                end
-                -- Create empty player.
-                if not QuestieComms.remoteQuestLogs[questPacketid][playerName] then
-                    QuestieComms.remoteQuestLogs[questPacketid][playerName] = {}
-                end
-
-                QuestieComms.remoteQuestLogs[questPacketid][playerName] = objectives
-
-                --Write to tooltip data
-                QuestieComms.data:RegisterTooltip(questPacketid, playerName, objectives)
+                _SetRemoteQuestSource(questPacketid, playerName, GROUP_SOURCE, objectives)
+            elseif disableCompleteQuests then
+                _RemoveRemoteQuestSource(questPacketid, playerName, GROUP_SOURCE)
             end
 
             QuestiePartyObjectives:ScheduleUpdate(questPacketid)
@@ -392,8 +471,6 @@ function QuestieComms:InsertQuestDataPacketV2(questPacket, playerName, offset, d
     --We don't want to insert our own quest data.
     local allDone = true
     if questPacket then
-        _TrackRemoteGroupPlayer(playerName)
-
         --Does it contain id and objectives?
         if (questPacket[2 + offset]) then
             -- Create empty quest.
@@ -423,24 +500,10 @@ function QuestieComms:InsertQuestDataPacketV2(questPacket, playerName, offset, d
                 offset = offset + 4
             end
             if not (allDone and disableCompleteQuests) then
-                if not QuestieComms.remoteQuestLogs[questPacketid] then
-                    QuestieComms.remoteQuestLogs[questPacketid] = {}
-                end
-                -- Create empty player.
-                if not QuestieComms.remoteQuestLogs[questPacketid][playerName] then
-                    QuestieComms.remoteQuestLogs[questPacketid][playerName] = {}
-                end
-
-                QuestieComms.remoteQuestLogs[questPacketid][playerName] = objectives
+                _SetRemoteQuestSource(questPacketid, playerName, NEARBY_SOURCE, objectives)
                 QuestieComms.remotePlayerClasses[playerName] = class
-
-                --Write to tooltip data
-                QuestieComms.data:RegisterTooltip(questPacketid, playerName, objectives)
             elseif disableCompleteQuests then
-                -- remove player if they exist
-                if QuestieComms.remoteQuestLogs[questPacketid] and QuestieComms.remoteQuestLogs[questPacketid][playerName] then
-                    QuestieComms.remoteQuestLogs[questPacketid][playerName] = nil
-                end
+                _RemoveRemoteQuestSource(questPacketid, playerName, NEARBY_SOURCE)
             end
 
             QuestiePartyObjectives:ScheduleUpdate(questPacketid)
@@ -453,24 +516,43 @@ function QuestieComms:CheckInGroup(name)
     return IsInRaid() and UnitInRaid(name) or UnitInParty(name)
 end
 
+local function _RemoveNearbyPlayer(name)
+    QuestieComms.remotePlayerTimes[name] = nil
+    QuestieComms.remotePlayerEnabled[name] = nil
+    QuestieComms.remotePlayerClasses[name] = nil
+    _RemoveRemotePlayerSource(name, NEARBY_SOURCE)
+    QuestiePartyObjectives:ScheduleUpdate()
+end
+
 function QuestieComms:RemoveAllRemotePlayers()
     for name in pairs(QuestieComms.remotePlayerTimes) do
-        QuestieComms:RemoveRemotePlayer(name)
+        _RemoveNearbyPlayer(name)
     end
 end
 
 function QuestieComms:RemoveRemotePlayer(name)
-    QuestieComms.remotePlayerTimes[name] = nil
-    QuestieComms.remotePlayerEnabled[name] = nil
-    QuestieComms.remotePlayerClasses[name] = nil
+    _RemoveNearbyPlayer(name)
     if not QuestieComms:CheckInGroup(name) then
+        _RemoveRemotePlayerSource(name, GROUP_SOURCE)
         remoteGroupPlayers[name] = nil
-        for _, players in pairs(QuestieComms.remoteQuestLogs) do
-            players[name] = nil
-        end
         QuestieComms.data:RemovePlayer(name)
     end
-    QuestiePartyObjectives:ScheduleUpdate()
+end
+
+function QuestieComms:RemoveAllRemoteGroupPlayers()
+    local playerNames = {}
+    for name in pairs(remoteGroupPlayers) do
+        playerNames[#playerNames + 1] = name
+    end
+
+    for _, name in ipairs(playerNames) do
+        remoteGroupPlayers[name] = nil
+        _RemoveRemotePlayerSource(name, GROUP_SOURCE)
+    end
+
+    if #playerNames > 0 then
+        QuestiePartyObjectives:ScheduleUpdate()
+    end
 end
 
 ---@return boolean changed Whether a former group member was removed.
@@ -483,9 +565,13 @@ function QuestieComms:PruneRemotePlayers()
     end
 
     for _, name in ipairs(playersToRemove) do
-        QuestieComms:RemoveRemotePlayer(name)
+        remoteGroupPlayers[name] = nil
+        _RemoveRemotePlayerSource(name, GROUP_SOURCE)
     end
 
+    if #playersToRemove > 0 then
+        QuestiePartyObjectives:ScheduleUpdate()
+    end
     return #playersToRemove > 0
 end
 
@@ -493,8 +579,8 @@ function QuestieComms:SortRemotePlayers()
     local now = GetTime()
     local current = {}
     for name, time in pairs(QuestieComms.remotePlayerTimes) do
-        if now - time > 60 * 4 then -- not seen in the last 4 minutes
-            QuestieComms:RemoveRemotePlayer(name)
+        if now - time > REMOTE_PLAYER_TIMEOUT then -- not seen in the last 4 minutes
+            _RemoveNearbyPlayer(name)
         else
             tinsert(current, name)
         end
@@ -859,18 +945,8 @@ end
 function QuestieComms:InsertQuestDataPacket(questPacket, playerName)
     --We don't want to insert our own quest data.
     if questPacket and playerName ~= UnitName("player") then
-        _TrackRemoteGroupPlayer(playerName)
-
         --Does it contain id and objectives?
         if (questPacket.objectives and questPacket.id) then
-            -- Create empty quest.
-            if not QuestieComms.remoteQuestLogs[questPacket.id] then
-                QuestieComms.remoteQuestLogs[questPacket.id] = {}
-            end
-            -- Create empty player.
-            if not QuestieComms.remoteQuestLogs[questPacket.id][playerName] then
-                QuestieComms.remoteQuestLogs[questPacket.id][playerName] = {}
-            end
             local objectives = {}
             for objectiveIndex, objectiveData in pairs(questPacket.objectives) do
                 --This is to check that all the data we require exist.
@@ -883,12 +959,9 @@ function QuestieComms:InsertQuestDataPacket(questPacket, playerName)
                     required = objectiveData.req,
                 }
             end
-            QuestieComms.remoteQuestLogs[questPacket.id][playerName] = objectives;
-
-            --Write to tooltip data
-            QuestieComms.data:RegisterTooltip(questPacket.id, playerName, objectives);
-
-            QuestiePartyObjectives:ScheduleUpdate(questPacket.id)
+            if _SetRemoteQuestSource(questPacket.id, playerName, GROUP_SOURCE, objectives) then
+                QuestiePartyObjectives:ScheduleUpdate(questPacket.id)
+            end
         end
     end
 end
@@ -926,11 +999,9 @@ _QuestieComms.packets = {
             local playerName = remoteQuestPacket.playerName;
             local questId = remoteQuestPacket.id;
 
-            if (QuestieComms.remoteQuestLogs[questId] and QuestieComms.remoteQuestLogs[questId][playerName]) then
+            if _RemoveRemoteQuestSource(questId, playerName, GROUP_SOURCE) then
                 Questie.Debug(Questie.DEBUG_INFO, "[QuestieComms] Removed quest:", questId, "for player:", playerName);
-                QuestieComms.remoteQuestLogs[questId][playerName] = nil;
             end
-            QuestieComms.data:RemoveQuestFromPlayer(questId, playerName);
             QuestiePartyObjectives:ScheduleUpdate(questId)
         end
     },
@@ -1154,6 +1225,10 @@ end
 function QuestieComms:ResetAll()
     QuestieComms.data:ResetAll()
     QuestieComms.remoteQuestLogs = {}
+    QuestieComms.remotePlayerClasses = {}
+    QuestieComms.remotePlayerEnabled = {}
+    QuestieComms.remotePlayerTimes = {}
+    remoteQuestSources = {}
     remoteGroupPlayers = {}
     QuestiePartyObjectives:ScheduleUpdate()
 end

--- a/Modules/Network/QuestieComms.lua
+++ b/Modules/Network/QuestieComms.lua
@@ -161,6 +161,13 @@ _QuestieComms.QC_WRITE_WHISPER = "WHISPER"
 _QuestieComms.QC_WRITE_CHANNEL = "CHANNEL"
 _QuestieComms.QC_WRITE_YELL = "YELL"
 
+local groupMessageDistributions = {
+    [_QuestieComms.QC_WRITE_ALLGROUP] = true,
+    [_QuestieComms.QC_WRITE_ALLINSTANCE] = true,
+    [_QuestieComms.QC_WRITE_ALLRAID] = true,
+    [_QuestieComms.QC_WRITE_WHISPER] = true,
+}
+
 --Message types.
 _QuestieComms.QC_ID_BROADCAST_QUEST_UPDATE = 1 -- send quest_log_update status to party/raid members
 _QuestieComms.QC_ID_BROADCAST_QUEST_REMOVE = 2 -- send quest remove status to party/raid members
@@ -1145,6 +1152,10 @@ function _QuestieComms:OnCommReceived_unsafe(message, distribution, sender)
     --print("[" .. distribution .."][" .. sender .. "] " .. message)
     Questie.Debug(Questie.DEBUG_DEVELOP, "|cFF22FF22", "sender:", "|r", sender, "distribution:", distribution, "Packet length:", string.len(message))
     if message and sender and sender ~= UnitName("player") then
+        if groupMessageDistributions[distribution] and not QuestieComms:CheckInGroup(sender) then
+            return
+        end
+
         local decompressedData
         if distribution == "YELL" then
             --print("Decompressing YELL data")

--- a/Modules/Network/QuestieComms.test.lua
+++ b/Modules/Network/QuestieComms.test.lua
@@ -1,0 +1,92 @@
+dofile("setupTests.lua")
+
+describe("QuestieComms", function()
+    ---@type QuestieComms
+    local QuestieComms
+    ---@type QuestiePartyObjectives
+    local QuestiePartyObjectives
+
+    local playerName = "OtherPlayer-FancyRealm"
+    local isPlayerInGroup
+
+    local function questPacket()
+        return {
+            id = 42,
+            objectives = {
+                {
+                    id = 123,
+                    typ = "m",
+                    fin = false,
+                    ful = 0,
+                    req = 1,
+                },
+            },
+        }
+    end
+
+    before_each(function()
+        isPlayerInGroup = true
+        _G.IsInRaid = function() return false end
+        _G.UnitInParty = spy.new(function(name)
+            return isPlayerInGroup and name == playerName
+        end)
+        _G.UnitInRaid = function() return false end
+        _G.UnitName = function() return "LocalPlayer" end
+
+        QuestiePartyObjectives = QuestieLoader:ImportModule("QuestiePartyObjectives")
+        QuestiePartyObjectives.ScheduleUpdate = spy.new(function() end)
+
+        dofile("Modules/Network/QuestieComms.lua")
+        QuestieComms = QuestieLoader:ImportModule("QuestieComms")
+        QuestieComms.remoteQuestLogs = {}
+        QuestieComms.remotePlayerClasses = {}
+        QuestieComms.remotePlayerEnabled = {}
+        QuestieComms.remotePlayerTimes = {}
+        QuestieComms.data.RegisterTooltip = spy.new(function() end)
+        QuestieComms.data.RemovePlayer = spy.new(function() end)
+    end)
+
+    describe("PruneRemotePlayers", function()
+        it("should remove a cross-realm player who left the group", function()
+            QuestieComms:InsertQuestDataPacket(questPacket(), playerName)
+            QuestieComms.remotePlayerClasses[playerName] = "MAGE"
+            QuestieComms.remotePlayerEnabled[playerName] = true
+            QuestieComms.remotePlayerTimes[playerName] = 123
+            isPlayerInGroup = false
+
+            local changed = QuestieComms:PruneRemotePlayers()
+
+            assert.is_true(changed)
+            assert.is_nil(QuestieComms.remoteQuestLogs[42][playerName])
+            assert.is_nil(QuestieComms.remotePlayerClasses[playerName])
+            assert.is_nil(QuestieComms.remotePlayerEnabled[playerName])
+            assert.is_nil(QuestieComms.remotePlayerTimes[playerName])
+            assert.spy(QuestieComms.data.RemovePlayer).was.called_with(QuestieComms.data, playerName)
+            assert.spy(_G.UnitInParty).was.called_with(playerName)
+        end)
+
+        it("should keep a tracked player who is still in the group", function()
+            QuestieComms:InsertQuestDataPacket(questPacket(), playerName)
+
+            local changed = QuestieComms:PruneRemotePlayers()
+
+            assert.is_false(changed)
+            assert.is_not_nil(QuestieComms.remoteQuestLogs[42][playerName])
+            assert.spy(QuestieComms.data.RemovePlayer).was.not_called()
+        end)
+
+        it("should keep nearby player data that was not received from a group member", function()
+            isPlayerInGroup = false
+            QuestieComms:InsertQuestDataPacket(questPacket(), playerName)
+            QuestieComms.remotePlayerTimes[playerName] = 123
+            QuestieComms.remotePlayerEnabled[playerName] = true
+
+            local changed = QuestieComms:PruneRemotePlayers()
+
+            assert.is_false(changed)
+            assert.is_not_nil(QuestieComms.remoteQuestLogs[42][playerName])
+            assert.is_true(QuestieComms.remotePlayerEnabled[playerName])
+            assert.spy(QuestieComms.data.RemovePlayer).was.not_called()
+        end)
+    end)
+end)

--- a/Modules/Network/QuestieComms.test.lua
+++ b/Modules/Network/QuestieComms.test.lua
@@ -8,6 +8,9 @@ describe("QuestieComms", function()
     ---@type QuestieLib
     local QuestieLib
     local originalQuestieLibCount
+    ---@type QuestieSerializer
+    local QuestieSerializer
+    local originalQuestieSerializerDeserialize
 
     local playerName = "OtherPlayer-FancyRealm"
     local isPlayerInGroup
@@ -71,6 +74,8 @@ describe("QuestieComms", function()
         QuestiePartyObjectives.ScheduleUpdate = spy.new(function() end)
         QuestieLib = QuestieLoader:ImportModule("QuestieLib")
         originalQuestieLibCount = QuestieLib.Count
+        QuestieSerializer = QuestieLoader:ImportModule("QuestieSerializer")
+        originalQuestieSerializerDeserialize = QuestieSerializer.Deserialize
 
         dofile("Modules/Network/QuestieComms.lua")
         QuestieComms = QuestieLoader:ImportModule("QuestieComms")
@@ -86,6 +91,7 @@ describe("QuestieComms", function()
 
     after_each(function()
         QuestieLib.Count = originalQuestieLibCount
+        QuestieSerializer.Deserialize = originalQuestieSerializerDeserialize
     end)
 
     describe("remote quest sources", function()
@@ -309,6 +315,65 @@ describe("QuestieComms", function()
             isPlayerInGroup = false
             assert.is_false(QuestieComms:PruneRemotePlayers())
             assert.is_nil(next(QuestieComms.remoteQuestLogs))
+        end)
+    end)
+
+    describe("OnCommReceived_unsafe", function()
+        it("should reject group transports from a player who already left", function()
+            local deserializeCalls = 0
+            QuestieSerializer.Deserialize = function()
+                deserializeCalls = deserializeCalls + 1
+                return {}
+            end
+            isPlayerInGroup = false
+
+            for _, distribution in ipairs({"PARTY", "RAID", "INSTANCE_CHAT", "WHISPER"}) do
+                QuestieComms.private:OnCommReceived_unsafe("payload", distribution, playerName)
+            end
+
+            assert.are_equal(0, deserializeCalls)
+        end)
+
+        it("should accept group transports from a current party member", function()
+            local deserializeCalls = 0
+            QuestieSerializer.Deserialize = function()
+                deserializeCalls = deserializeCalls + 1
+                return {}
+            end
+
+            for _, distribution in ipairs({"PARTY", "RAID", "INSTANCE_CHAT", "WHISPER"}) do
+                QuestieComms.private:OnCommReceived_unsafe("payload", distribution, playerName)
+            end
+
+            assert.are_equal(4, deserializeCalls)
+        end)
+
+        it("should accept YELL from a player outside the group", function()
+            local deserializeEncoding
+            QuestieSerializer.Deserialize = function(_, _, encoding)
+                deserializeEncoding = encoding
+                return {}
+            end
+            isPlayerInGroup = false
+
+            QuestieComms.private:OnCommReceived_unsafe("payload", "YELL", playerName)
+
+            assert.are_equal("b89", deserializeEncoding)
+        end)
+
+        it("should leave non-group transports unchanged", function()
+            local deserializeCalls = 0
+            QuestieSerializer.Deserialize = function()
+                deserializeCalls = deserializeCalls + 1
+                return {}
+            end
+            isPlayerInGroup = false
+
+            for _, distribution in ipairs({"GUILD", "CHANNEL"}) do
+                QuestieComms.private:OnCommReceived_unsafe("payload", distribution, playerName)
+            end
+
+            assert.are_equal(2, deserializeCalls)
         end)
     end)
 end)

--- a/Modules/Network/QuestieComms.test.lua
+++ b/Modules/Network/QuestieComms.test.lua
@@ -5,16 +5,20 @@ describe("QuestieComms", function()
     local QuestieComms
     ---@type QuestiePartyObjectives
     local QuestiePartyObjectives
+    ---@type QuestieLib
+    local QuestieLib
+    local originalQuestieLibCount
 
     local playerName = "OtherPlayer-FancyRealm"
     local isPlayerInGroup
+    local currentTime
 
-    local function questPacket()
+    local function groupQuestPacket(questId, objectiveId)
         return {
-            id = 42,
+            id = questId,
             objectives = {
                 {
-                    id = 123,
+                    id = objectiveId,
                     typ = "m",
                     fin = false,
                     ful = 0,
@@ -24,17 +28,49 @@ describe("QuestieComms", function()
         }
     end
 
+    local function nearbyQuestPacket(questId, objectiveId, fulfilled, required)
+        return {
+            questId,
+            1,
+            3, -- MAGE
+            objectiveId,
+            string.byte("m"),
+            fulfilled or 0,
+            required or 1,
+        }
+    end
+
+    local function groupQuestPacketV2(questId, objectiveId)
+        return {
+            questId,
+            1,
+            objectiveId,
+            string.byte("m"),
+            0,
+            1,
+        }
+    end
+
+    local function insertNearbyQuest(questId, objectiveId)
+        QuestieComms.remotePlayerTimes[playerName] = currentTime
+        QuestieComms:InsertQuestDataPacketV2(nearbyQuestPacket(questId, objectiveId), playerName, 1, true)
+    end
+
     before_each(function()
         isPlayerInGroup = true
+        currentTime = 1000
         _G.IsInRaid = function() return false end
         _G.UnitInParty = spy.new(function(name)
             return isPlayerInGroup and name == playerName
         end)
         _G.UnitInRaid = function() return false end
         _G.UnitName = function() return "LocalPlayer" end
+        _G.GetTime = function() return currentTime end
 
         QuestiePartyObjectives = QuestieLoader:ImportModule("QuestiePartyObjectives")
         QuestiePartyObjectives.ScheduleUpdate = spy.new(function() end)
+        QuestieLib = QuestieLoader:ImportModule("QuestieLib")
+        originalQuestieLibCount = QuestieLib.Count
 
         dofile("Modules/Network/QuestieComms.lua")
         QuestieComms = QuestieLoader:ImportModule("QuestieComms")
@@ -43,50 +79,236 @@ describe("QuestieComms", function()
         QuestieComms.remotePlayerEnabled = {}
         QuestieComms.remotePlayerTimes = {}
         QuestieComms.data.RegisterTooltip = spy.new(function() end)
+        QuestieComms.data.RemoveQuestFromPlayer = spy.new(function() end)
         QuestieComms.data.RemovePlayer = spy.new(function() end)
+        QuestieComms.data.ResetAll = spy.new(function() end)
     end)
 
-    describe("PruneRemotePlayers", function()
-        it("should remove a cross-realm player who left the group", function()
-            QuestieComms:InsertQuestDataPacket(questPacket(), playerName)
-            QuestieComms.remotePlayerClasses[playerName] = "MAGE"
-            QuestieComms.remotePlayerEnabled[playerName] = true
-            QuestieComms.remotePlayerTimes[playerName] = 123
+    after_each(function()
+        QuestieLib.Count = originalQuestieLibCount
+    end)
+
+    describe("remote quest sources", function()
+        it("should remove group-only data for a cross-realm player who left", function()
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 123), playerName)
             isPlayerInGroup = false
 
             local changed = QuestieComms:PruneRemotePlayers()
 
             assert.is_true(changed)
-            assert.is_nil(QuestieComms.remoteQuestLogs[42][playerName])
-            assert.is_nil(QuestieComms.remotePlayerClasses[playerName])
-            assert.is_nil(QuestieComms.remotePlayerEnabled[playerName])
-            assert.is_nil(QuestieComms.remotePlayerTimes[playerName])
-            assert.spy(QuestieComms.data.RemovePlayer).was.called_with(QuestieComms.data, playerName)
+            assert.is_nil(QuestieComms.remoteQuestLogs[42])
+            assert.spy(QuestieComms.data.RemoveQuestFromPlayer).was.called_with(QuestieComms.data, 42, playerName)
             assert.spy(_G.UnitInParty).was.called_with(playerName)
+            assert.is_false(QuestieComms:PruneRemotePlayers())
         end)
 
         it("should keep a tracked player who is still in the group", function()
-            QuestieComms:InsertQuestDataPacket(questPacket(), playerName)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 123), playerName)
 
             local changed = QuestieComms:PruneRemotePlayers()
 
             assert.is_false(changed)
-            assert.is_not_nil(QuestieComms.remoteQuestLogs[42][playerName])
-            assert.spy(QuestieComms.data.RemovePlayer).was.not_called()
+            assert.are_equal(123, QuestieComms.remoteQuestLogs[42][playerName][1].id)
+            assert.spy(QuestieComms.data.RemoveQuestFromPlayer).was.not_called()
         end)
 
-        it("should keep nearby player data that was not received from a group member", function()
+        it("should not store a group packet from a player outside the group", function()
             isPlayerInGroup = false
-            QuestieComms:InsertQuestDataPacket(questPacket(), playerName)
-            QuestieComms.remotePlayerTimes[playerName] = 123
+
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 123), playerName)
+
+            assert.is_nil(QuestieComms.remoteQuestLogs[42])
+            assert.spy(QuestieComms.data.RegisterTooltip).was.not_called()
+            assert.is_false(QuestieComms:PruneRemotePlayers())
+        end)
+
+        it("should restore Nearby data and remove unrelated group quests after party leave", function()
+            insertNearbyQuest(42, 101)
+            insertNearbyQuest(44, 404)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 202), playerName)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(43, 303), playerName)
             QuestieComms.remotePlayerEnabled[playerName] = true
+
+            QuestieComms.data.RegisterTooltip = spy.new(function() end)
+            QuestieComms.data.RemoveQuestFromPlayer = spy.new(function() end)
+            isPlayerInGroup = false
 
             local changed = QuestieComms:PruneRemotePlayers()
 
-            assert.is_false(changed)
-            assert.is_not_nil(QuestieComms.remoteQuestLogs[42][playerName])
+            assert.is_true(changed)
+            assert.are_equal(101, QuestieComms.remoteQuestLogs[42][playerName][1].id)
+            assert.is_nil(QuestieComms.remoteQuestLogs[43])
+            assert.are_equal(404, QuestieComms.remoteQuestLogs[44][playerName][1].id)
+            assert.are_equal(currentTime, QuestieComms.remotePlayerTimes[playerName])
             assert.is_true(QuestieComms.remotePlayerEnabled[playerName])
+            assert.spy(QuestieComms.data.RemoveQuestFromPlayer).was.called_with(QuestieComms.data, 42, playerName)
+            assert.spy(QuestieComms.data.RemoveQuestFromPlayer).was.called_with(QuestieComms.data, 43, playerName)
+            assert.spy(QuestieComms.data.RegisterTooltip).was.called_with(
+                QuestieComms.data,
+                42,
+                playerName,
+                QuestieComms.remoteQuestLogs[42][playerName]
+            )
+            assert.is_false(QuestieComms:PruneRemotePlayers())
+        end)
+
+        it("should replace stale tooltip keys when falling back to Nearby data", function()
+            QuestieLib.Count = function(_, values)
+                local count = 0
+                for _ in pairs(values) do
+                    count = count + 1
+                end
+                return count
+            end
+            QuestieComms.data = {}
+            dofile("Modules/Network/QuestieCommsData.lua")
+
+            insertNearbyQuest(42, 101)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 202), playerName)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(43, 303), playerName)
+
+            assert.is_false(QuestieComms.data:KeyExists("m_101"))
+            assert.is_true(QuestieComms.data:KeyExists("m_202"))
+            assert.is_true(QuestieComms.data:KeyExists("m_303"))
+
+            isPlayerInGroup = false
+            QuestieComms:PruneRemotePlayers()
+
+            assert.is_true(QuestieComms.data:KeyExists("m_101"))
+            assert.is_false(QuestieComms.data:KeyExists("m_202"))
+            assert.is_false(QuestieComms.data:KeyExists("m_303"))
+        end)
+
+        it("should restore Nearby data when the group removes the same quest", function()
+            insertNearbyQuest(42, 101)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 202), playerName)
+
+            QuestieComms.private.packets[2].read({
+                playerName = playerName,
+                id = 42,
+            })
+
+            assert.are_equal(101, QuestieComms.remoteQuestLogs[42][playerName][1].id)
+        end)
+
+        it("should keep group data when Nearby reports the quest complete", function()
+            insertNearbyQuest(42, 101)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 202), playerName)
+
+            QuestieComms:InsertQuestDataPacketV2(nearbyQuestPacket(42, 101, 1, 1), playerName, 1, true)
+
+            assert.are_equal(202, QuestieComms.remoteQuestLogs[42][playerName][1].id)
+        end)
+
+        it("should expire Nearby data without removing the group projection", function()
+            insertNearbyQuest(42, 101)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 202), playerName)
+            QuestieComms.remotePlayerTimes[playerName] = currentTime - (60 * 4) - 1
+
+            QuestieComms:SortRemotePlayers()
+
+            assert.are_equal(202, QuestieComms.remoteQuestLogs[42][playerName][1].id)
+            assert.is_nil(QuestieComms.remotePlayerTimes[playerName])
+            assert.is_nil(QuestieComms.remotePlayerClasses[playerName])
+        end)
+
+        it("should remove an expired Nearby-only projection", function()
+            insertNearbyQuest(42, 101)
+            QuestieComms.remotePlayerTimes[playerName] = currentTime - (60 * 4) - 1
+
+            QuestieComms:SortRemotePlayers()
+
+            assert.is_nil(QuestieComms.remoteQuestLogs[42])
+            assert.spy(QuestieComms.data.RemoveQuestFromPlayer).was.called_with(QuestieComms.data, 42, playerName)
+        end)
+
+        it("should remove all Nearby data without damaging group data", function()
+            insertNearbyQuest(42, 101)
+            insertNearbyQuest(43, 303)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 202), playerName)
+
+            QuestieComms:RemoveAllRemotePlayers()
+
+            assert.are_equal(202, QuestieComms.remoteQuestLogs[42][playerName][1].id)
+            assert.is_nil(QuestieComms.remoteQuestLogs[43])
+            assert.is_nil(QuestieComms.remotePlayerTimes[playerName])
+        end)
+
+        it("should remove all group data while preserving Nearby projections", function()
+            insertNearbyQuest(42, 101)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 202), playerName)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(43, 303), playerName)
+
+            QuestieComms:RemoveAllRemoteGroupPlayers()
+
+            assert.are_equal(101, QuestieComms.remoteQuestLogs[42][playerName][1].id)
+            assert.is_nil(QuestieComms.remoteQuestLogs[43])
+            assert.are_equal(currentTime, QuestieComms.remotePlayerTimes[playerName])
+            assert.is_false(QuestieComms:PruneRemotePlayers())
+        end)
+
+        it("should preserve current group data through the public removal API", function()
+            insertNearbyQuest(42, 101)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 202), playerName)
+
+            QuestieComms:RemoveRemotePlayer(playerName)
+
+            assert.are_equal(202, QuestieComms.remoteQuestLogs[42][playerName][1].id)
+            assert.is_nil(QuestieComms.remotePlayerTimes[playerName])
             assert.spy(QuestieComms.data.RemovePlayer).was.not_called()
+
+            isPlayerInGroup = false
+            QuestieComms:RemoveRemotePlayer(playerName)
+
+            assert.is_nil(QuestieComms.remoteQuestLogs[42])
+            assert.spy(QuestieComms.data.RemovePlayer).was.called_with(QuestieComms.data, playerName)
+            assert.is_false(QuestieComms:PruneRemotePlayers())
+        end)
+
+        it("should parse but not store a V2 group packet from a departed player", function()
+            isPlayerInGroup = false
+
+            local offset = QuestieComms:InsertQuestDataPacketV2_noclass_RenameMe(
+                groupQuestPacketV2(42, 123),
+                playerName,
+                1,
+                false
+            )
+
+            assert.are_equal(7, offset)
+            assert.is_nil(QuestieComms.remoteQuestLogs[42])
+        end)
+
+        it("should accumulate group quest-list blocks", function()
+            QuestieComms.private.packets[10].read({
+                playerName = playerName,
+                rawQuestList = {groupQuestPacket(42, 123)},
+            })
+            QuestieComms.private.packets[10].read({
+                playerName = playerName,
+                rawQuestList = {groupQuestPacket(43, 456)},
+            })
+
+            assert.are_equal(123, QuestieComms.remoteQuestLogs[42][playerName][1].id)
+            assert.are_equal(456, QuestieComms.remoteQuestLogs[43][playerName][1].id)
+        end)
+
+        it("should reset all source projections and Nearby metadata", function()
+            insertNearbyQuest(42, 101)
+            QuestieComms:InsertQuestDataPacket(groupQuestPacket(42, 202), playerName)
+            QuestieComms.remotePlayerEnabled[playerName] = true
+
+            QuestieComms:ResetAll()
+
+            assert.is_nil(next(QuestieComms.remoteQuestLogs))
+            assert.is_nil(next(QuestieComms.remotePlayerTimes))
+            assert.is_nil(next(QuestieComms.remotePlayerEnabled))
+            assert.is_nil(next(QuestieComms.remotePlayerClasses))
+            assert.spy(QuestieComms.data.ResetAll).was.called_with(QuestieComms.data)
+
+            isPlayerInGroup = false
+            assert.is_false(QuestieComms:PruneRemotePlayers())
+            assert.is_nil(next(QuestieComms.remoteQuestLogs))
         end)
     end)
 end)


### PR DESCRIPTION
## Issue references

Fixes #7780

## Proposed changes

- Remove departed members' group quest snapshots and tooltip registrations on roster updates, including same-size replacements and Name-Realm players.
- Track group and Nearby/YELL objectives independently per player and quest, keeping the group snapshot as the effective projection while grouped and restoring the exact Nearby snapshot when group data is removed.
- Remove only group-specific snapshots on `GROUP_LEFT`, while preserving existing Nearby/YELL completion and lazy four-minute pruning behavior.
- Reject late `PARTY`, `RAID`, `INSTANCE_CHAT`, and `WHISPER` packets from departed senders before deserialization; `YELL` and other non-group transports remain unchanged.
- Keep full quest-list blocks additive and make no comms protocol changes.

## Validation

- Lua 5.1 syntax check: passed for all four changed files
- Luacheck: 0 warnings / 0 errors in 365 files
- Targeted Busted: 22 successes / 0 failures
- Full Busted: 1799 successes / 0 failures (`TZ=Europe/Berlin`)
- `git diff --check`: passed

## Screenshots

Existing reproduction is in #7780. Live two-client verification remains pending.
