### PR TITLE
[fix] Improve map draw queue performance

### DIFF
--- a/Modules/FramePool/QuestieFramePool.lua
+++ b/Modules/FramePool/QuestieFramePool.lua
@@ -116,10 +116,10 @@ end
 function QuestieFramePool:UnloadFrame(frame)
     frame:Unload()
 
-    -- If the frame was queued for drawing but not yet processed by QuestieMap.ProcessQueue, Unload() defers and sets _needsUnload=true
+    -- If the frame was queued for drawing but not yet drawn by MapDrawQueue, Unload() defers and sets _needsUnload=true
     -- instead of doing a full cleanup. In that case we must not recycle yet: the draw call still holds a reference to this frame,
-    -- and recycling now would allow GetFrame() to hand it out again before ProcessQueue consumes the stale draw call, causing it
-    -- to draw the wrong frame. ProcessQueue detects _needsUnload after the HBDPins add and calls Unload() + recycles directly once it
+    -- and recycling now would allow GetFrame() to hand it out again before the queue consumes the stale draw call, causing it
+    -- to draw the wrong frame. The queued draw detects _needsUnload after the HBDPins add and calls Unload() + recycles directly once it
     -- is safe to do so.
     if (not frame._needsUnload) then
         usedFrames[frame.frameId] = nil

--- a/Modules/Map/MapDrawQueue.lua
+++ b/Modules/Map/MapDrawQueue.lua
@@ -1,0 +1,202 @@
+---@class MapDrawQueue
+local MapDrawQueue = QuestieLoader:CreateModule("MapDrawQueue")
+
+-- Icons are published to HereBeDragons a batch at a time rather than all at once, so a large redraw does not
+-- land in a single frame. This file owns the two queues that hold the pending work and the policy that decides
+-- how much of it one cycle may do. What a published icon actually *is* stays in QuestieMap: this knows only
+-- that entries go in, come out in order, and that a cycle has a budget.
+--
+-- Keeping it to that is the point. There is nothing here but two tables and a clock, so the policy below can
+-- be tested for what it does at a deadline, at a floor and at a ceiling without standing up HereBeDragons, a
+-- frame pool, or a saved-variable profile first.
+
+local getTimePreciseSec = GetTimePreciseSec
+
+-------------------------
+-- Queue mechanics
+-------------------------
+-- O(1) FIFO. `table.remove(queue, 1)` shifts every remaining entry down one slot, so draining N icons costs
+-- O(N^2): measured on a real redraw of 877 queued pairs, the shifting alone was 0.83 ms per cycle and 46 ms
+-- across the drain, which was most of what the cycle spent. A head index costs one read and one nil write per
+-- pop no matter how deep the queue is.
+--
+-- `head > tail` means empty. Both rewind to 1/0 when the queue drains, so the indices cannot climb forever and
+-- the entries array never keeps a growing hole at the front.
+---@class QuestieDrawQueue
+---@field entries table<integer, table>
+---@field head integer @Next entry to pop
+---@field tail integer @Last entry pushed
+local worldQueue = {entries = {}, head = 1, tail = 0}
+local minimapQueue = {entries = {}, head = 1, tail = 0}
+
+---@param queue QuestieDrawQueue
+---@param drawCall table
+local function Push(queue, drawCall)
+    local tail = queue.tail + 1
+    queue.tail = tail
+    queue.entries[tail] = drawCall
+end
+
+---@param queue QuestieDrawQueue
+---@return table? drawCall
+local function Pop(queue)
+    local head = queue.head
+    if head > queue.tail then
+        return nil
+    end
+
+    local entries = queue.entries
+    local drawCall = entries[head]
+    entries[head] = nil
+    if head == queue.tail then
+        queue.head = 1
+        queue.tail = 0
+    else
+        queue.head = head + 1
+    end
+    return drawCall
+end
+
+---@param queue QuestieDrawQueue
+---@return integer
+local function Depth(queue)
+    return queue.tail - queue.head + 1
+end
+
+---@param drawCall table @Arguments for HBDPins:AddWorldMapIconMap
+function MapDrawQueue.PushWorld(drawCall)
+    Push(worldQueue, drawCall)
+end
+
+---@param drawCall table @Arguments for HBDPins:AddMinimapIconMap
+function MapDrawQueue.PushMinimap(drawCall)
+    Push(minimapQueue, drawCall)
+end
+
+---Both queues are empty. Callers wait on this rather than on a length, because a head index leaves the entries
+---array with a moving start and `#` cannot describe it.
+---@return boolean
+function MapDrawQueue.IsEmpty()
+    return worldQueue.head > worldQueue.tail and minimapQueue.head > minimapQueue.tail
+end
+
+---@return integer worldDepth
+---@return integer minimapDepth
+function MapDrawQueue.Depth()
+    return Depth(worldQueue), Depth(minimapQueue)
+end
+
+-------------------------
+-- Cycle policy
+-------------------------
+-- The floor is what a cycle publishes even when the clock says stop, so it is the one number here that is a
+-- cost rather than a limit: a cycle can never be cheaper than the floor, however slow the machine. 24 is what
+-- this addon has always published per cycle, so leaving it there is what makes the budget safe on hardware
+-- unlike the machine it was tuned on. A slower machine fits fewer iterations into the same time, so the
+-- adaptive part contributes less and less until it contributes nothing, at which point a cycle is exactly what
+-- it always was. The budget can only add work where there is room for it.
+MapDrawQueue.MIN_DRAWS_PER_CYCLE = 24
+
+-- Insurance against a clock that stops advancing, not a throughput control: with a working clock the budget
+-- always binds first. Measured on Era, the largest cycle any sane budget produced was 223 iterations at 16 ms,
+-- so this leaves room above every budget below while still bounding the pathological cycle.
+MapDrawQueue.MAX_DRAWS_PER_CYCLE = 250
+
+-- Measured on Era against a 952-deep queue: 4 ms drains it in 5.4 s with a 4.7 ms worst cycle, 8 ms in 1.8 s
+-- with 8.1 ms, and the old fixed 24 took 8.2 s at 3.4 ms. Anything at or below 2 ms is indistinguishable from
+-- no budget at all, because one floor cycle already costs more than that - a budget under the floor's own cost
+-- cannot do anything.
+MapDrawQueue.QUEUE_TIME_BUDGET = 0.008
+
+if Questie.IsHardcore then
+    -- Blizzard's addon watchdog is far stricter on HC realms, and the same reasoning as QuestieMap's
+    -- TICKS_PER_YIELD applies: give up drain speed rather than risk a less performant machine tripping it.
+    --
+    -- 4 ms rather than 2 because 2 buys nothing measurable - one floor cycle already costs more than that, so
+    -- the deadline is behind us by the time the floor releases. Measured back to back on Era: the fixed 24
+    -- drained in 4.15 s at 24 icons per cycle, 4 ms drained in 2.6 s at 40, for 0.7 ms on a typical cycle.
+    MapDrawQueue.QUEUE_TIME_BUDGET = 0.004
+
+    -- Halving the floor costs nothing on a machine with headroom and halves the guaranteed cost on one
+    -- without. Measured on Era at this budget, 12 and 24 were indistinguishable - 2.6-3.1 s to drain and
+    -- 35-38 icons per cycle either way - because the budget lets ~37 through and the floor never binds.
+    --
+    -- It only starts to matter about 1.6x slower than that, and by 3.2x slower a cycle is the floor and
+    -- nothing else: 12 icons for roughly 4 ms where 24 would have cost 8. Those clients draw their icons at
+    -- half the rate, which is the trade being made on purpose. Note this halves the exposure rather than
+    -- capping it - the floor is a count, not a duration, so a bad enough client can still overrun.
+    MapDrawQueue.MIN_DRAWS_PER_CYCLE = 12
+end
+
+---@alias MapDrawQueueDrawer fun(drawCall: table, context: any)
+
+---Draws one batch, pairing a world icon with a minimap icon per iteration the way the queues are filled.
+---
+---GetTimePreciseSec rather than debugprofilestop: any addon can reset the latter to zero, and a reset landing
+---mid-cycle would make the deadline unreachable and run the cycle out to its absolute maximum. A client with
+---no clock at all stops at the floor, which is the fixed behaviour this replaced.
+---@param drawWorldIcon MapDrawQueueDrawer
+---@param drawMinimapIcon MapDrawQueueDrawer
+---@param context any @Passed to both callbacks; the caller's per-cycle state, not the queue's business
+---@return integer processed @Iterations run, which is at most one publication of each kind
+function MapDrawQueue.RunCycle(drawWorldIcon, drawMinimapIcon, context)
+    local minimumDraws = MapDrawQueue.MIN_DRAWS_PER_CYCLE
+    local maximumDraws = MapDrawQueue.MAX_DRAWS_PER_CYCLE
+    local deadline = getTimePreciseSec and (getTimePreciseSec() + MapDrawQueue.QUEUE_TIME_BUDGET) or nil
+
+    local processed = 0
+    while (not MapDrawQueue.IsEmpty())
+        and processed < maximumDraws
+        and (processed < minimumDraws or (deadline ~= nil and getTimePreciseSec() < deadline)) do
+        processed = processed + 1
+
+        local worldCall = Pop(worldQueue)
+        if worldCall then
+            drawWorldIcon(worldCall, context)
+        end
+
+        local minimapCall = Pop(minimapQueue)
+        if minimapCall then
+            drawMinimapIcon(minimapCall, context)
+        end
+    end
+
+    return processed
+end
+
+-------------------------
+-- Scheduling
+-------------------------
+-- The ticker lives here rather than in QuestieMap because the tick rate and the cycle budget are one policy:
+-- how much drawing happens per unit of time. Splitting them across two files meant reading both to answer that.
+local drawTimer
+local drawQueueTickRate
+
+---Starts draining the queue on a timer. Safe to call repeatedly; the timer is created once.
+---@param drawWorldIcon MapDrawQueueDrawer
+---@param drawMinimapIcon MapDrawQueueDrawer
+---@param getContext fun(): any @Evaluated once per cycle and handed to both callbacks
+function MapDrawQueue.Start(drawWorldIcon, drawMinimapIcon, getContext)
+    local isInInstance, instanceType = IsInInstance()
+    -- Raids run the cycle half as often, having plenty else to do with the frame.
+    drawQueueTickRate = (isInInstance and instanceType == "raid") and 0.4 or 0.2
+
+    if drawTimer then
+        -- Behaviour preserved from before this was its own file: the rate above is recomputed on every
+        -- loading screen but an existing ticker keeps the interval it was created with, so entering a raid
+        -- mid-session does not actually slow the cycle down. Changing that is a behaviour change, not a move.
+        return
+    end
+
+    drawTimer = C_Timer.NewTicker(drawQueueTickRate, function()
+        if MapDrawQueue.IsEmpty() then
+            return
+        end
+        MapDrawQueue.RunCycle(drawWorldIcon, drawMinimapIcon, getContext())
+    end)
+end
+
+---@return number? tickRate @Seconds between cycles; nil before Start
+function MapDrawQueue.GetTickRate()
+    return drawQueueTickRate
+end

--- a/Modules/Map/MapDrawQueue.test.lua
+++ b/Modules/Map/MapDrawQueue.test.lua
@@ -1,0 +1,305 @@
+dofile("setupTests.lua")
+
+describe("MapDrawQueue", function()
+    ---@type MapDrawQueue
+    local MapDrawQueue
+    local originalGetTimePreciseSec
+    local clockSeconds
+    local publishedWorld
+    local publishedMinimap
+
+    ---The clock only moves when a test says so, so a cycle's stopping point is decided rather than raced.
+    ---@param seconds number
+    local function AdvanceClock(seconds)
+        clockSeconds = clockSeconds + seconds
+    end
+
+    ---A publisher that records what it was handed and optionally bills the clock for the work.
+    ---@param log table
+    ---@param secondsPerCall number?
+    local function Recorder(log, secondsPerCall)
+        return function(drawCall, context)
+            log[#log + 1] = {drawCall = drawCall, context = context}
+            if secondsPerCall then
+                AdvanceClock(secondsPerCall)
+            end
+        end
+    end
+
+    ---@param worldCount integer
+    ---@param minimapCount integer
+    local function Fill(worldCount, minimapCount)
+        for i = 1, worldCount do
+            MapDrawQueue.PushWorld({"world", i})
+        end
+        for i = 1, minimapCount do
+            MapDrawQueue.PushMinimap({"minimap", i})
+        end
+    end
+
+    before_each(function()
+        originalGetTimePreciseSec = _G.GetTimePreciseSec
+        clockSeconds = 0
+        _G.GetTimePreciseSec = function()
+            return clockSeconds
+        end
+        publishedWorld = {}
+        publishedMinimap = {}
+
+        -- Loaded with the stub in place: the module captures the clock at file scope.
+        dofile("Modules/Map/MapDrawQueue.lua")
+        MapDrawQueue = QuestieLoader:ImportModule("MapDrawQueue")
+        MapDrawQueue.MIN_DRAWS_PER_CYCLE = 24
+        MapDrawQueue.MAX_DRAWS_PER_CYCLE = 250
+        MapDrawQueue.QUEUE_TIME_BUDGET = 0.008
+    end)
+
+    after_each(function()
+        _G.GetTimePreciseSec = originalGetTimePreciseSec
+    end)
+
+    describe("queue mechanics", function()
+        it("pops in the order entries were pushed", function()
+            Fill(3, 0)
+
+            MapDrawQueue.RunCycle(Recorder(publishedWorld), Recorder(publishedMinimap))
+
+            assert.are_same({"world", 1}, publishedWorld[1].drawCall)
+            assert.are_same({"world", 2}, publishedWorld[2].drawCall)
+            assert.are_same({"world", 3}, publishedWorld[3].drawCall)
+        end)
+
+        it("reports depth per surface and emptiness across both", function()
+            assert.is_true(MapDrawQueue.IsEmpty())
+
+            Fill(2, 5)
+
+            local worldDepth, minimapDepth = MapDrawQueue.Depth()
+            assert.are_same(2, worldDepth)
+            assert.are_same(5, minimapDepth)
+            assert.is_false(MapDrawQueue.IsEmpty())
+        end)
+
+        it("is empty again once drained, with the indices rewound", function()
+            Fill(3, 3)
+            MapDrawQueue.RunCycle(Recorder(publishedWorld), Recorder(publishedMinimap))
+
+            assert.is_true(MapDrawQueue.IsEmpty())
+            assert.are_same({0, 0}, {MapDrawQueue.Depth()})
+        end)
+
+        it("keeps popping correctly when a drained queue is refilled", function()
+            Fill(2, 0)
+            MapDrawQueue.RunCycle(Recorder(publishedWorld), Recorder(publishedMinimap))
+            Fill(2, 0)
+            MapDrawQueue.RunCycle(Recorder(publishedWorld), Recorder(publishedMinimap))
+
+            assert.are_same(4, #publishedWorld)
+            assert.are_same({"world", 1}, publishedWorld[3].drawCall)
+        end)
+    end)
+
+    describe("cycle policy", function()
+        it("publishes at least the minimum even when the deadline has already passed", function()
+            Fill(100, 100)
+            -- Every call overruns the whole budget, so only the floor can be keeping this going.
+            MapDrawQueue.RunCycle(Recorder(publishedWorld, 1), Recorder(publishedMinimap, 0))
+
+            assert.are_same(24, #publishedWorld)
+        end)
+
+        it("continues past the minimum while time remains", function()
+            Fill(100, 100)
+            -- 0.0001s per iteration against a 0.008s budget: the deadline is what stops this, not the floor.
+            local processed = MapDrawQueue.RunCycle(Recorder(publishedWorld, 0.0001), Recorder(publishedMinimap))
+
+            assert.is_true(processed > 24)
+            assert.are_same(processed, #publishedWorld)
+        end)
+
+        it("stops at the deadline once the minimum is met", function()
+            Fill(100, 100)
+            -- 0.001s each: the floor's 24 already overshoot the 0.008s budget, so nothing follows them.
+            local processed = MapDrawQueue.RunCycle(Recorder(publishedWorld, 0.001), Recorder(publishedMinimap))
+
+            assert.are_same(24, processed)
+        end)
+
+        it("stops at the absolute maximum when the clock never advances", function()
+            Fill(1000, 1000)
+            -- A frozen clock leaves the deadline permanently in the future; only the cap can end this.
+            local processed = MapDrawQueue.RunCycle(Recorder(publishedWorld), Recorder(publishedMinimap))
+
+            assert.are_same(250, processed)
+            assert.are_same(250, #publishedWorld)
+        end)
+
+        it("drains a short queue completely rather than running to the minimum", function()
+            Fill(5, 5)
+
+            local processed = MapDrawQueue.RunCycle(Recorder(publishedWorld), Recorder(publishedMinimap))
+
+            assert.are_same(5, processed)
+            assert.is_true(MapDrawQueue.IsEmpty())
+        end)
+
+        it("keeps draining the longer surface when the two are uneven", function()
+            Fill(6, 2)
+
+            MapDrawQueue.RunCycle(Recorder(publishedWorld), Recorder(publishedMinimap))
+
+            assert.are_same(6, #publishedWorld)
+            assert.are_same(2, #publishedMinimap)
+            assert.is_true(MapDrawQueue.IsEmpty())
+        end)
+
+        it("hands the caller's context to both publishers", function()
+            Fill(1, 1)
+
+            MapDrawQueue.RunCycle(Recorder(publishedWorld), Recorder(publishedMinimap), 0.85)
+
+            assert.are_same(0.85, publishedWorld[1].context)
+            assert.are_same(0.85, publishedMinimap[1].context)
+        end)
+
+        it("stops at the minimum on a client with no clock at all", function()
+            _G.GetTimePreciseSec = nil
+            dofile("Modules/Map/MapDrawQueue.lua")
+            MapDrawQueue = QuestieLoader:ImportModule("MapDrawQueue")
+            MapDrawQueue.MIN_DRAWS_PER_CYCLE = 24
+            MapDrawQueue.MAX_DRAWS_PER_CYCLE = 250
+            Fill(100, 100)
+
+            -- No deadline can be built, so the cycle is the fixed floor this replaced.
+            assert.are_same(24, MapDrawQueue.RunCycle(Recorder(publishedWorld), Recorder(publishedMinimap)))
+        end)
+    end)
+
+    describe("scheduling", function()
+        local tickers
+        local originalTimerAPI
+        local originalIsInInstance
+
+        before_each(function()
+            originalTimerAPI = _G.C_Timer
+            originalIsInInstance = _G.IsInInstance
+            tickers = {}
+            _G.C_Timer = {
+                NewTicker = function(interval, callback)
+                    tickers[#tickers + 1] = {interval = interval, callback = callback}
+                    return {Cancel = function() end}
+                end,
+            }
+            _G.IsInInstance = function() return false, "none" end
+            dofile("Modules/Map/MapDrawQueue.lua")
+            MapDrawQueue = QuestieLoader:ImportModule("MapDrawQueue")
+        end)
+
+        after_each(function()
+            _G.C_Timer = originalTimerAPI
+            _G.IsInInstance = originalIsInInstance
+        end)
+
+        it("ticks every 0.2 seconds outside a raid", function()
+            MapDrawQueue.Start(Recorder(publishedWorld), Recorder(publishedMinimap), function() end)
+
+            assert.are_same(0.2, MapDrawQueue.GetTickRate())
+            assert.are_same(0.2, tickers[1].interval)
+        end)
+
+        it("halves the rate in a raid, which has plenty else to do with the frame", function()
+            _G.IsInInstance = function() return true, "raid" end
+
+            MapDrawQueue.Start(Recorder(publishedWorld), Recorder(publishedMinimap), function() end)
+
+            assert.are_same(0.4, MapDrawQueue.GetTickRate())
+        end)
+
+        it("creates the ticker once however often it is started", function()
+            local start = function()
+                MapDrawQueue.Start(Recorder(publishedWorld), Recorder(publishedMinimap), function() end)
+            end
+            start() start() start()
+
+            assert.are_same(1, #tickers)
+        end)
+
+        it("draws a batch when the ticker fires, with the context evaluated per cycle", function()
+            local contexts = 0
+            MapDrawQueue.Start(Recorder(publishedWorld), Recorder(publishedMinimap), function()
+                contexts = contexts + 1
+                return contexts
+            end)
+            Fill(3, 3)
+
+            tickers[1].callback()
+
+            assert.are_same(3, #publishedWorld)
+            assert.are_same(1, publishedWorld[1].context)
+            -- One evaluation for the whole batch, not one per icon.
+            assert.are_same(1, contexts)
+        end)
+
+        it("does no work and reads no context when the queue is empty", function()
+            local contexts = 0
+            MapDrawQueue.Start(Recorder(publishedWorld), Recorder(publishedMinimap), function()
+                contexts = contexts + 1
+            end)
+
+            tickers[1].callback()
+
+            assert.are_same(0, contexts)
+            assert.are_same(0, #publishedWorld)
+        end)
+    end)
+    describe("shipping defaults", function()
+        local originalIsHardcore
+
+        before_each(function()
+            originalIsHardcore = Questie.IsHardcore
+        end)
+
+        after_each(function()
+            Questie.IsHardcore = originalIsHardcore
+        end)
+
+        ---@param hardcore boolean?
+        local function LoadFor(hardcore)
+            Questie.IsHardcore = hardcore
+            dofile("Modules/Map/MapDrawQueue.lua")
+            return QuestieLoader:ImportModule("MapDrawQueue")
+        end
+
+        it("publishes 24 per cycle within an 8 ms budget on a normal realm", function()
+            local queue = LoadFor(nil)
+
+            assert.are_same(24, queue.MIN_DRAWS_PER_CYCLE)
+            assert.are_same(0.008, queue.QUEUE_TIME_BUDGET)
+        end)
+
+        it("halves both the floor and the budget on hardcore", function()
+            local queue = LoadFor(true)
+
+            -- Deliberate, not incidental: the watchdog is stricter there, so drain speed is given up first.
+            assert.are_same(12, queue.MIN_DRAWS_PER_CYCLE)
+            assert.are_same(0.004, queue.QUEUE_TIME_BUDGET)
+        end)
+
+        it("keeps a budget that outlives its own floor, or it would do nothing", function()
+            for _, hardcore in ipairs({false, true}) do
+                local queue = LoadFor(hardcore)
+                -- One floor cycle measured at ~0.105 ms per icon on the machine this was tuned on. A budget
+                -- below that cost is spent before the floor releases, which makes the whole mechanism inert.
+                local floorCost = queue.MIN_DRAWS_PER_CYCLE * 0.000105
+                assert.is_true(queue.QUEUE_TIME_BUDGET > floorCost,
+                    "budget must exceed the floor's own cost, hardcore=" .. tostring(hardcore))
+            end
+        end)
+
+        it("caps a cycle well above anything the budget can reach", function()
+            local queue = LoadFor(nil)
+
+            assert.is_true(queue.MAX_DRAWS_PER_CYCLE > 223)
+        end)
+    end)
+end)

--- a/Modules/Map/QuestieMap.lua
+++ b/Modules/Map/QuestieMap.lua
@@ -22,6 +22,8 @@ local l10n = QuestieLoader:ImportModule("l10n")
 local WeaponMasterSkills = QuestieLoader:ImportModule("WeaponMasterSkills")
 ---@type Phasing
 local Phasing = QuestieLoader:ImportModule("Phasing")
+---@type MapDrawQueue
+local MapDrawQueue = QuestieLoader:ImportModule("MapDrawQueue")
 
 QuestieMap.ICON_MAP_TYPE = "MAP";
 QuestieMap.ICON_MINIMAP_TYPE = "MINIMAP";
@@ -69,8 +71,7 @@ if Questie.IsHardcore then
 end
 
 
-local drawTimer
-local drawQueueTickRate
+local fadeTicker
 local fadeLogicCoroutine
 
 local _MinimapIconSetFade, _MinimapIconFadeLogic
@@ -196,26 +197,54 @@ function QuestieMap:RescaleTownsfolkIcons()
     end
 end
 
-local mapDrawQueue = {};
-local minimapDrawQueue = {};
+-- What drawing one queued icon means. Handed to MapDrawQueue rather than written inside it: the queue's
+-- business is ordering and budget, while this is HereBeDragons, icon scale and frame lifecycle, which is
+-- QuestieMap's. Named to pair with QueueDraw above - queued on the way in, drawn on the way out. File-scope
+-- rather than closures rebuilt per cycle, so a cycle allocates nothing.
 
-QuestieMap._mapDrawQueue = mapDrawQueue
-QuestieMap._minimapDrawQueue = minimapDrawQueue
+---@param drawCall table
+---@param scaleValue number
+local function DrawQueuedWorldIcon(drawCall, scaleValue)
+    local frame = drawCall[2];
+    HBDPins:AddWorldMapIconMap(tunpack(drawCall));
+
+    --? If you ever chanage this logic, make sure you change the logic in QuestieMap.utils:RescaleIcon function too!
+    -- Use globalTownsfolkScale for townsfolk icons, globalScale for quest icons
+    local scaleProfile = frame.isManualIcon and Questie.db.profile.globalTownsfolkScale or Questie.db.profile.globalScale
+    local size = (16 * (frame.data.IconScale or 1) * (scaleProfile or 0.7)) * scaleValue;
+    frame:SetSize(size, size)
+
+    QuestieMap.utils.SetDrawOrder(frame);
+
+    frame._loaded = true
+    if frame._needsUnload then
+        QuestieFramePool:UnloadFrame(frame)
+    end
+end
+
+---@param drawCall table
+local function DrawQueuedMinimapIcon(drawCall)
+    local frame = drawCall[2];
+    HBDPins:AddMinimapIconMap(tunpack(drawCall));
+
+    QuestieMap.utils.SetDrawOrder(frame);
+
+    frame._loaded = true
+    if frame._needsUnload then
+        QuestieFramePool:UnloadFrame(frame)
+    end
+end
 
 function QuestieMap:InitializeQueue() -- now called on every loading screen
     Questie.Debug(Questie.DEBUG_DEVELOP, "[QuestieMap] Starting draw queue timer!")
-    local isInInstance, instanceType = IsInInstance()
+    -- GetScaleValue rather than its result: it reaches through HBD into C_Map and is read once per cycle.
+    MapDrawQueue.Start(DrawQueuedWorldIcon, DrawQueuedMinimapIcon, QuestieMap.GetScaleValue)
 
-    if isInInstance and instanceType == "raid" then
-        drawQueueTickRate = 0.4 -- slower update rate in raids
-    else
-        drawQueueTickRate = 0.2
-    end
-
-    if not drawTimer then
-        drawTimer = C_Timer.NewTicker(drawQueueTickRate, QuestieMap.ProcessQueue)
+    -- Minimap fading is a separate subsystem that merely starts in the same place. It has nothing to do with
+    -- the draw queue beyond both being work this addon spreads over time.
+    if not fadeTicker then
         -- ! Remember to update the distance variable in ProcessShownMinimapIcons if you change the timer
-        C_Timer.NewTicker(0.1, function()
+        fadeTicker = C_Timer.NewTicker(0.1, function()
             if fadeLogicCoroutine and coroutine.status(fadeLogicCoroutine) == "suspended" then
                 local success, errorMsg = coroutine.resume(fadeLogicCoroutine)
                 if (not success) then
@@ -327,51 +356,9 @@ end
 
 function QuestieMap:QueueDraw(drawType, ...)
     if (drawType == QuestieMap.ICON_MAP_TYPE) then
-        tinsert(mapDrawQueue, {...});
+        MapDrawQueue.PushWorld({...});
     elseif (drawType == QuestieMap.ICON_MINIMAP_TYPE) then
-        tinsert(minimapDrawQueue, {...});
-    end
-end
-
-function QuestieMap.ProcessQueue()
-    if (not next(mapDrawQueue) and (not next(minimapDrawQueue))) then
-        -- Nothing to process
-        return
-    end
-
-    local scaleValue = QuestieMap.GetScaleValue()
-    for _ = 1, math.min(24, math.max(#mapDrawQueue, #minimapDrawQueue)) do
-        local mapDrawCall = tremove(mapDrawQueue, 1);
-        if mapDrawCall then
-            local frame = mapDrawCall[2];
-            HBDPins:AddWorldMapIconMap(tunpack(mapDrawCall));
-
-            --? If you ever chanage this logic, make sure you change the logic in QuestieMap.utils:RescaleIcon function too!
-            -- Use globalTownsfolkScale for townsfolk icons, globalScale for quest icons
-            local scaleProfile = frame.isManualIcon and Questie.db.profile.globalTownsfolkScale or Questie.db.profile.globalScale
-            local size = (16 * (frame.data.IconScale or 1) * (scaleProfile or 0.7)) * scaleValue;
-            frame:SetSize(size, size)
-
-            QuestieMap.utils.SetDrawOrder(frame)
-
-            mapDrawCall[2]._loaded = true
-            if mapDrawCall[2]._needsUnload then
-                QuestieFramePool:UnloadFrame(mapDrawCall[2])
-            end
-        end
-
-        local minimapDrawCall = tremove(minimapDrawQueue, 1);
-        if minimapDrawCall then
-            local frame = minimapDrawCall[2];
-            HBDPins:AddMinimapIconMap(tunpack(minimapDrawCall));
-
-            QuestieMap.utils.SetDrawOrder(frame)
-
-            minimapDrawCall[2]._loaded = true
-            if minimapDrawCall[2]._needsUnload then
-                QuestieFramePool:UnloadFrame(minimapDrawCall[2])
-            end
-        end
+        MapDrawQueue.PushMinimap({...});
     end
 end
 

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -125,7 +125,7 @@ function QuestieMap.utils.RescaleIcon(frameRef, mapScale)
                 local scaleProfile = frame.isManualIcon and Questie.db.profile.globalMiniMapTownsfolkScale or Questie.db.profile.globalMiniMapScale
                 scale = 16 * (frame.data.IconScale or 1) * (scaleProfile or 0.7);
             else
-                --? If you ever chanage this logic, make sure you change the logic in QuestieMap:ProcessQueue() too!
+                --? If you ever chanage this logic, make sure you change the logic in DrawQueuedWorldIcon too!
                 local scaleProfile = frame.isManualIcon and Questie.db.profile.globalTownsfolkScale or Questie.db.profile.globalScale
                 scale = (16 * (frame.data.IconScale or 1) * (scaleProfile or 0.7)) * iconScale;
             end

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -18,6 +18,8 @@ local QuestieTracker = QuestieLoader:ImportModule("QuestieTracker")
 local QuestieDBMIntegration = QuestieLoader:ImportModule("QuestieDBMIntegration")
 ---@type QuestieMap
 local QuestieMap = QuestieLoader:ImportModule("QuestieMap")
+---@type MapDrawQueue
+local MapDrawQueue = QuestieLoader:ImportModule("MapDrawQueue")
 ---@type QuestieFramePool
 local QuestieFramePool = QuestieLoader:ImportModule("QuestieFramePool")
 ---@type QuestieLib
@@ -351,7 +353,7 @@ function QuestieQuest:SmoothReset()
             return QuestLogCache.TestGameCache()
         end,
         function()
-            return #QuestieMap._mapDrawQueue == 0 and #QuestieMap._minimapDrawQueue == 0 -- wait until draw queue is finished
+            return MapDrawQueue.IsEmpty() -- wait until draw queue is finished
         end,
         function()
             QuestieQuest._clearAllNotesDone = false
@@ -371,7 +373,7 @@ function QuestieQuest:SmoothReset()
             return true
         end,
         function()
-            return #QuestieMap._mapDrawQueue == 0 and #QuestieMap._minimapDrawQueue == 0 -- wait until draw queue is finished
+            return MapDrawQueue.IsEmpty() -- wait until draw queue is finished
         end,
         function()
             -- reset quest log
@@ -417,7 +419,7 @@ function QuestieQuest:SmoothReset()
             return not QuestieQuest._nextRestQuest
         end,
         function()
-            return (not QuestieQuest._resetNeedsAvailables) and #QuestieMap._mapDrawQueue == 0 and #QuestieMap._minimapDrawQueue == 0
+            return (not QuestieQuest._resetNeedsAvailables) and MapDrawQueue.IsEmpty()
         end,
         function()
             QuestieQuest._isResetting = nil

--- a/Questie-BCC.toc
+++ b/Questie-BCC.toc
@@ -194,6 +194,7 @@ Modules\FramePool\QuestieFramePool.lua
 Modules\FramePool\QuestieFrame.lua
 
 # Map
+Modules\Map\MapDrawQueue.lua
 Modules\Map\QuestieMap.lua
 Modules\Map\QuestieMapUtils.lua
 Modules\Map\HBDHooks.lua

--- a/Questie-Cata.toc
+++ b/Questie-Cata.toc
@@ -208,6 +208,7 @@ Modules\FramePool\QuestieFramePool.lua
 Modules\FramePool\QuestieFrame.lua
 
 # Map
+Modules\Map\MapDrawQueue.lua
 Modules\Map\QuestieMap.lua
 Modules\Map\QuestieMapUtils.lua
 Modules\Map\HBDHooks.lua

--- a/Questie-Classic.toc
+++ b/Questie-Classic.toc
@@ -202,6 +202,7 @@ Modules\FramePool\QuestieFramePool.lua
 Modules\FramePool\QuestieFrame.lua
 
 # Map
+Modules\Map\MapDrawQueue.lua
 Modules\Map\QuestieMap.lua
 Modules\Map\QuestieMapUtils.lua
 Modules\Map\HBDHooks.lua

--- a/Questie-Mists.toc
+++ b/Questie-Mists.toc
@@ -219,6 +219,7 @@ Modules\FramePool\QuestieFramePool.lua
 Modules\FramePool\QuestieFrame.lua
 
 # Map
+Modules\Map\MapDrawQueue.lua
 Modules\Map\QuestieMap.lua
 Modules\Map\QuestieMapUtils.lua
 Modules\Map\HBDHooks.lua

--- a/Questie-WOTLKC.toc
+++ b/Questie-WOTLKC.toc
@@ -210,6 +210,7 @@ Modules\FramePool\QuestieFramePool.lua
 Modules\FramePool\QuestieFrame.lua
 
 # Map
+Modules\Map\MapDrawQueue.lua
 Modules\Map\QuestieMap.lua
 Modules\Map\QuestieMapUtils.lua
 Modules\Map\HBDHooks.lua


### PR DESCRIPTION
## Issue references

None.

## Proposed changes

The map draw queue previously removed entries from the front of Lua arrays, which shifted the remaining entries on every draw. It also processed a fixed number of entries per tick regardless of how much rendering time they consumed.

- Move map and minimap draw scheduling into a dedicated `MapDrawQueue` module backed by O(1) FIFO queues.
- Process at least 24 queue iterations per cycle (12 on Hardcore), then continue within an 8 ms time budget (4 ms on Hardcore), with a hard cap of 250 iterations.
- Keep the existing rendering and deferred frame-unload behavior in `QuestieMap` while allowing world-map and minimap queues to drain independently.
- Update smooth reset handling to wait until both draw queues are empty.
- Load the new module in every supported expansion and add focused tests for ordering, queue depth, timing limits, caps, Hardcore settings, and ticker setup.

## Validation

- `busted -p ".test.lua" .` — 1,798 successes
- Targeted Luacheck — no warnings or errors
- Loader usage validation — passed
- `git diff --check` — passed

## Screenshots

Not applicable; this changes map icon scheduling without changing their appearance.
