### PR TITLE
[fix] Use API text for party objective tooltips

### DIFF
--- a/Modules/Network/QuestieCommsData.lua
+++ b/Modules/Network/QuestieCommsData.lua
@@ -19,22 +19,21 @@ local commsTooltipLookup = {}
 local playerRegisteredTooltips = {}
 
 ---@param questId QuestId
----@param objectiveIndex number
----@param objectivesByQuest table<QuestId, table|false>
----@return string?
-local function _GetApiObjectiveText(questId, objectiveIndex, objectivesByQuest)
-    local objectives = objectivesByQuest[questId]
-    if objectives == nil then
-        if HaveQuestData(questId) then
-            objectives = C_QuestLog.GetQuestObjectives(questId) or false
-        else
-            C_QuestLog.GetQuestObjectives(questId) -- Prime the client cache for the next tooltip update
-            objectives = false
-        end
-        objectivesByQuest[questId] = objectives
+---@return table
+local function _GetApiObjectives(questId)
+    if not HaveQuestData(questId) then
+        C_QuestLog.GetQuestObjectives(questId) -- Prime the client cache for the next tooltip update
+        return {}
     end
 
-    local objective = objectives and objectives ~= false and objectives[objectiveIndex]
+    return C_QuestLog.GetQuestObjectives(questId) or {}
+end
+
+---@param objectiveIndex number
+---@param objectives table
+---@return string?
+local function _GetApiObjectiveText(objectiveIndex, objectives)
+    local objective = objectives[objectiveIndex]
     local text = objective and objective.text
     if (not text) or text == "" or string.byte(text, 1) == 32 or (not objective.type) then
         return nil
@@ -67,25 +66,37 @@ function QuestieComms.data:GetTooltip(tooltipKey)
             if(not tooltipData[questId][playerName]) then
                 tooltipData[questId][playerName] = {};
             end
+            local apiObjectives = apiObjectivesByQuest[questId]
+            if not apiObjectives then
+                apiObjectives = _GetApiObjectives(questId)
+                apiObjectivesByQuest[questId] = apiObjectives
+            end
             for objectiveIndex, objective in pairs(objectives) do
                 if(not tooltipData[questId][playerName][objectiveIndex]) then
                     tooltipData[questId][playerName][objectiveIndex] = {};
                 end
-                local oName = _GetApiObjectiveText(questId, objectiveIndex, apiObjectivesByQuest)
-                if not oName then
+                local apiObjectiveText = _GetApiObjectiveText(objectiveIndex, apiObjectives)
+                local oName = ""
+                if apiObjectiveText then
+                    oName = apiObjectiveText
+                else
                     if((objective.type == "monster" or objective.type == "m") and objective.id) then
                         local npc = QuestieDB:GetNPC(objective.id)
-                        oName = npc and npc.name
+                        if npc and npc.name then
+                            oName = npc.name
+                        end
                     elseif((objective.type == "object" or objective.type == "o") and objective.id) then
                         local object = QuestieDB:GetObject(objective.id)
-                        oName = object and object.name
+                        if object and object.name then
+                            oName = object.name
+                        end
                     elseif((objective.type == "item" or objective.type == "i") and objective.id) then
                         local dbItem = QuestieDB:GetItem(objective.id);
                         if(dbItem and dbItem.name and (not dbItem.Hidden)) then
                             oName = dbItem.name;-- this is capital letters for some reason...
                         else
                             local itemName = GetItemInfo(objective.id)
-                            if(itemName) then
+                            if itemName then
                                 oName = itemName;
                             else
                                 oName = "Item missing from DB, fetching from server!";
@@ -99,7 +110,7 @@ function QuestieComms.data:GetTooltip(tooltipKey)
                         end
                     end
                 end
-                tooltipData[questId][playerName][objectiveIndex].text = oName or ""
+                tooltipData[questId][playerName][objectiveIndex].text = oName
                 tooltipData[questId][playerName][objectiveIndex].fulfilled = objective.fulfilled;
                 tooltipData[questId][playerName][objectiveIndex].required = objective.required;
             end

--- a/Modules/Network/QuestieCommsData.lua
+++ b/Modules/Network/QuestieCommsData.lua
@@ -18,6 +18,32 @@ local commsTooltipLookup = {}
 --}
 local playerRegisteredTooltips = {}
 
+---@param questId QuestId
+---@param objectiveIndex number
+---@param objectivesByQuest table<QuestId, table|false>
+---@return string?
+local function _GetApiObjectiveText(questId, objectiveIndex, objectivesByQuest)
+    local objectives = objectivesByQuest[questId]
+    if objectives == nil then
+        if HaveQuestData(questId) then
+            objectives = C_QuestLog.GetQuestObjectives(questId) or false
+        else
+            C_QuestLog.GetQuestObjectives(questId) -- Prime the client cache for the next tooltip update
+            objectives = false
+        end
+        objectivesByQuest[questId] = objectives
+    end
+
+    local objective = objectives and objectives ~= false and objectives[objectiveIndex]
+    local text = objective and objective.text
+    if (not text) or text == "" or string.byte(text, 1) == 32 or (not objective.type) then
+        return nil
+    end
+
+    text = QuestieLib.TrimObjectiveText(text, objective.type)
+    return text ~= "" and text or nil
+end
+
 ---@param tooltipKey string @A key in the form of "i_1337"
 ---@return boolean @true if exist false if not
 function QuestieComms.data:KeyExists(tooltipKey)
@@ -32,6 +58,7 @@ end
 ---@return table @tooltipData[questId][playerName][objectiveIndex].text
 function QuestieComms.data:GetTooltip(tooltipKey)
     local tooltipData = {}
+    local apiObjectivesByQuest = {}
     for playerName, questData in pairs(commsTooltipLookup[tooltipKey]) do
         for questId, objectives in pairs(questData) do
             if(not tooltipData[questId]) then
@@ -44,31 +71,35 @@ function QuestieComms.data:GetTooltip(tooltipKey)
                 if(not tooltipData[questId][playerName][objectiveIndex]) then
                     tooltipData[questId][playerName][objectiveIndex] = {};
                 end
-                local oName = "";
-                if((objective.type == "monster" or objective.type == "m") and objective.id) then
-                    oName = QuestieDB:GetNPC(objective.id).name;
-                elseif((objective.type == "object" or objective.type == "o") and objective.id) then
-                    oName = QuestieDB:GetObject(objective.id).name;
-                elseif((objective.type == "item" or objective.type == "i") and objective.id) then
-                    local dbItem = QuestieDB:GetItem(objective.id);
-                    if(dbItem and dbItem.name and (not dbItem.Hidden)) then
-                        oName = dbItem.name;-- this is capital letters for some reason...
-                    else
-                        local itemName = GetItemInfo(objective.id)
-                        if(itemName) then
-                            oName = itemName;
+                local oName = _GetApiObjectiveText(questId, objectiveIndex, apiObjectivesByQuest)
+                if not oName then
+                    if((objective.type == "monster" or objective.type == "m") and objective.id) then
+                        local npc = QuestieDB:GetNPC(objective.id)
+                        oName = npc and npc.name
+                    elseif((objective.type == "object" or objective.type == "o") and objective.id) then
+                        local object = QuestieDB:GetObject(objective.id)
+                        oName = object and object.name
+                    elseif((objective.type == "item" or objective.type == "i") and objective.id) then
+                        local dbItem = QuestieDB:GetItem(objective.id);
+                        if(dbItem and dbItem.name and (not dbItem.Hidden)) then
+                            oName = dbItem.name;-- this is capital letters for some reason...
                         else
-                            oName = "Item missing from DB, fetching from server!";
-                            local item = Item:CreateFromItemID(objective.id)
-                            item:ContinueOnItemLoad(function()
-                                local name = item:GetItemName();
-                                oName = name;
-                                tooltipData[questId][playerName][objectiveIndex].text = name;
-                            end)
+                            local itemName = GetItemInfo(objective.id)
+                            if(itemName) then
+                                oName = itemName;
+                            else
+                                oName = "Item missing from DB, fetching from server!";
+                                local item = Item:CreateFromItemID(objective.id)
+                                item:ContinueOnItemLoad(function()
+                                    local name = item:GetItemName();
+                                    oName = name;
+                                    tooltipData[questId][playerName][objectiveIndex].text = name;
+                                end)
+                            end
                         end
                     end
                 end
-                tooltipData[questId][playerName][objectiveIndex].text = oName
+                tooltipData[questId][playerName][objectiveIndex].text = oName or ""
                 tooltipData[questId][playerName][objectiveIndex].fulfilled = objective.fulfilled;
                 tooltipData[questId][playerName][objectiveIndex].required = objective.required;
             end

--- a/Modules/Network/QuestieCommsData.test.lua
+++ b/Modules/Network/QuestieCommsData.test.lua
@@ -7,8 +7,16 @@ describe("QuestieCommsData", function()
     ---@type QuestieDB
     local QuestieDB
 
+    ---@type QuestieLib
+    local QuestieLib
+
     local originalData
     local originalGetItem
+    local originalGetNpc
+    local originalGetObject
+    local originalGetQuestObjectives
+    local originalHaveQuestData
+    local originalTrimObjectiveText
 
     local questId = 42
     local playerName = "OtherPlayer"
@@ -33,12 +41,23 @@ describe("QuestieCommsData", function()
     before_each(function()
         QuestieComms = QuestieLoader:ImportModule("QuestieComms")
         QuestieDB = QuestieLoader:ImportModule("QuestieDB")
+        QuestieLib = QuestieLoader:ImportModule("QuestieLib")
 
         originalData = QuestieComms.data
         originalGetItem = QuestieDB.GetItem
+        originalGetNpc = QuestieDB.GetNPC
+        originalGetObject = QuestieDB.GetObject
+        originalGetQuestObjectives = C_QuestLog.GetQuestObjectives
+        originalHaveQuestData = HaveQuestData
+        originalTrimObjectiveText = QuestieLib.TrimObjectiveText
 
         QuestieComms.data = {}
         mockItemDb({})
+        _G.HaveQuestData = function() return true end
+        C_QuestLog.GetQuestObjectives = function() return nil end
+        QuestieLib.TrimObjectiveText = function(text)
+            return text:match("^(.*):%s*%d+/%d+$") or text
+        end
 
         -- Loading the file gives it fresh lookup tables, so each test starts with empty tooltip data
         dofile("Modules/Network/QuestieCommsData.lua")
@@ -47,6 +66,70 @@ describe("QuestieCommsData", function()
     after_each(function()
         QuestieComms.data = originalData
         QuestieDB.GetItem = originalGetItem
+        QuestieDB.GetNPC = originalGetNpc
+        QuestieDB.GetObject = originalGetObject
+        C_QuestLog.GetQuestObjectives = originalGetQuestObjectives
+        _G.HaveQuestData = originalHaveQuestData
+        QuestieLib.TrimObjectiveText = originalTrimObjectiveText
+    end)
+
+    describe("GetTooltip", function()
+        it("should prefer the Blizzard API objective text", function()
+            QuestieDB.GetNPC = spy.new(function()
+                return {name = "Goliathon"}
+            end)
+            C_QuestLog.GetQuestObjectives = spy.new(function(requestedQuestId)
+                assert.equals(questId, requestedQuestId)
+                return {{text = "Fallen Sky Ridge Revitalized: 1/1", type = "monster"}}
+            end)
+
+            QuestieComms.data:RegisterTooltip(questId, playerName, {objective("m", 19305)})
+            QuestieComms.data:RegisterTooltip(questId, "AnotherPlayer", {objective("m", 19305)})
+
+            local result = QuestieComms.data:GetTooltip("m_19305")
+
+            assert.equals("Fallen Sky Ridge Revitalized", result[questId][playerName][1].text)
+            assert.equals("Fallen Sky Ridge Revitalized", result[questId]["AnotherPlayer"][1].text)
+            assert.spy(C_QuestLog.GetQuestObjectives).was.called(1)
+            assert.spy(QuestieDB.GetNPC).was.not_called()
+        end)
+
+        it("should request uncached quest data and fall back to the entity name", function()
+            _G.HaveQuestData = function() return false end
+            C_QuestLog.GetQuestObjectives = spy.new(function() return nil end)
+            QuestieDB.GetNPC = function()
+                return {name = "Goliathon"}
+            end
+
+            QuestieComms.data:RegisterTooltip(questId, playerName, {objective("m", 19305)})
+
+            local result = QuestieComms.data:GetTooltip("m_19305")
+
+            assert.equals("Goliathon", result[questId][playerName][1].text)
+            assert.spy(C_QuestLog.GetQuestObjectives).was.called_with(questId)
+        end)
+
+        it("should safely fall back when API and entity data are unavailable", function()
+            C_QuestLog.GetQuestObjectives = function()
+                return {
+                    {text = " ", type = "monster"},
+                    {text = "Activate the object: 0/1"},
+                }
+            end
+            QuestieDB.GetNPC = function() return nil end
+            QuestieDB.GetObject = function() return nil end
+
+            QuestieComms.data:RegisterTooltip(questId, playerName, {
+                objective("m", 19305),
+                objective("o", 12345),
+            })
+
+            local monsterResult = QuestieComms.data:GetTooltip("m_19305")
+            local objectResult = QuestieComms.data:GetTooltip("o_12345")
+
+            assert.equals("", monsterResult[questId][playerName][1].text)
+            assert.equals("", objectResult[questId][playerName][2].text)
+        end)
     end)
 
     describe("RegisterTooltip", function()

--- a/Modules/Network/QuestieCommsData.test.lua
+++ b/Modules/Network/QuestieCommsData.test.lua
@@ -102,10 +102,13 @@ describe("QuestieCommsData", function()
             end
 
             QuestieComms.data:RegisterTooltip(questId, playerName, {objective("m", 19305)})
+            QuestieComms.data:RegisterTooltip(questId, "AnotherPlayer", {objective("m", 19305)})
 
             local result = QuestieComms.data:GetTooltip("m_19305")
 
             assert.equals("Goliathon", result[questId][playerName][1].text)
+            assert.equals("Goliathon", result[questId]["AnotherPlayer"][1].text)
+            assert.spy(C_QuestLog.GetQuestObjectives).was.called(1)
             assert.spy(C_QuestLog.GetQuestObjectives).was.called_with(questId)
         end)
 


### PR DESCRIPTION
## Issue references

Fixes #7763

## Proposed changes

- Prefer localized Blizzard API objective text when rendering remote party progress in entity tooltips.
- Prime uncached quest data and retain the existing NPC, object, and item fallback without changing the comms protocol.
- Reuse the API result per quest during one tooltip build and safely handle missing API or database data.

## Validation

- Targeted Busted: 8 successes, 0 failures
- Full Busted: 1780 successes, 0 failures
- Luacheck: 0 warnings, 0 errors
- Lua 5.1 syntax and `git diff --check`

## Screenshots

The existing reproduction screenshot is in #7763. Live two-client verification was not performed.