### PR TITLE
feat: add asynchronous quest objective loading helper

### DIFF
--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -11,6 +11,8 @@ local QuestiePlayer = QuestieLoader:ImportModule("QuestiePlayer")
 local QuestieEvent = QuestieLoader:ImportModule("QuestieEvent")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
+---@type ThreadLib
+local ThreadLib = QuestieLoader:ImportModule("ThreadLib")
 
 QuestieLib.AddonPath = "Interface\\Addons\\Questie\\"
 
@@ -172,14 +174,14 @@ end
 ---@type Color[]
 local colors = {
     -- Light (200)         Standard (500)         -- Family
-    {0.99, 0.73, 0.73},    {0.94, 0.19, 0.19},    -- Red
-    {0.99, 0.81, 0.59},    {0.98, 0.46, 0.05},    -- Orange
-    {0.99, 0.93, 0.54},    {0.92, 0.68, 0.05},    -- Yellow
-    {0.73, 0.96, 0.80},    {0.13, 0.77, 0.36},    -- Green
-    {0.75, 0.87, 0.99},    {0.23, 0.55, 0.94},    -- Blue
-    {0.78, 0.82, 0.99},    {0.39, 0.45, 0.94},    -- Indigo
-    {0.87, 0.82, 1.00},    {0.55, 0.35, 0.96},    -- Violet
-    {0.99, 0.76, 0.89},    {0.93, 0.16, 0.55},    -- Pink
+    {0.99, 0.73, 0.73}, {0.94, 0.19, 0.19}, -- Red
+    {0.99, 0.81, 0.59}, {0.98, 0.46, 0.05}, -- Orange
+    {0.99, 0.93, 0.54}, {0.92, 0.68, 0.05}, -- Yellow
+    {0.73, 0.96, 0.80}, {0.13, 0.77, 0.36}, -- Green
+    {0.75, 0.87, 0.99}, {0.23, 0.55, 0.94}, -- Blue
+    {0.78, 0.82, 0.99}, {0.39, 0.45, 0.94}, -- Indigo
+    {0.87, 0.82, 1.00}, {0.55, 0.35, 0.96}, -- Violet
+    {0.99, 0.76, 0.89}, {0.93, 0.16, 0.55}, -- Pink
 }
 
 -- Shuffle colors on startup (Fisher-Yates)
@@ -315,23 +317,23 @@ function QuestieLib:GetRaceString(raceMask)
         local langCode = l10n:GetUILocale()
         local spaceString = ((langCode == "zhCN" or langCode == "zhTW") and "") or " " -- no spaces for chinese strings
         local stringTable = {
-            l10n("Human"),                                          -- 1
-            l10n("Orc"),                                            -- 2
-            l10n("Dwarf"),                                          -- 4
-            l10n("Night Elf"),                                      -- 8
-            l10n("Undead"),                                         -- 16
-            l10n("Tauren"),                                         -- 32
-            l10n("Gnome"),                                          -- 64
-            l10n("Troll"),                                          -- 128
-            l10n("Goblin"),                                         -- 256
-            l10n("Blood Elf"),                                      -- 512
-            l10n("Draenei"),                                        -- 1024
-            nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,                -- 2^11 -> 2^20
-            l10n("Worgen"),                                         -- 2097152
-            nil,                                                    -- 2^22
-            l10n("Pandaren"),                                       -- 8388608
-            l10n("Pandaren") .. spaceString .. l10n("Alliance"),    -- 16777216
-            l10n("Pandaren") .. spaceString .. l10n("Horde"),       -- 33554432
+            l10n("Human"), -- 1
+            l10n("Orc"), -- 2
+            l10n("Dwarf"), -- 4
+            l10n("Night Elf"), -- 8
+            l10n("Undead"), -- 16
+            l10n("Tauren"), -- 32
+            l10n("Gnome"), -- 64
+            l10n("Troll"), -- 128
+            l10n("Goblin"), -- 256
+            l10n("Blood Elf"), -- 512
+            l10n("Draenei"), -- 1024
+            nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, -- 2^11 -> 2^20
+            l10n("Worgen"), -- 2097152
+            nil, -- 2^22
+            l10n("Pandaren"), -- 8388608
+            l10n("Pandaren") .. spaceString .. l10n("Alliance"), -- 16777216
+            l10n("Pandaren") .. spaceString .. l10n("Horde"), -- 33554432
         }
         local firstRun = true
         for k, v in pairs(raceTable) do
@@ -356,30 +358,30 @@ function QuestieLib:GetClassString(classMask)
         local classTable = QuestieLib:UnpackBinary(classMask)
         local classColors = {
             -- Class colors taken from RAID_CLASS_COLORS["WARRIOR"] etc
-            WARRIOR      = "|c" .. RAID_CLASS_COLORS["WARRIOR"].colorStr,
-            PALADIN      = "|c" .. RAID_CLASS_COLORS["PALADIN"].colorStr,
-            HUNTER       = "|c" .. RAID_CLASS_COLORS["HUNTER"].colorStr,
-            ROGUE        = "|c" .. RAID_CLASS_COLORS["ROGUE"].colorStr,
-            PRIEST       = "|c" .. RAID_CLASS_COLORS["PRIEST"].colorStr,
+            WARRIOR = "|c" .. RAID_CLASS_COLORS["WARRIOR"].colorStr,
+            PALADIN = "|c" .. RAID_CLASS_COLORS["PALADIN"].colorStr,
+            HUNTER = "|c" .. RAID_CLASS_COLORS["HUNTER"].colorStr,
+            ROGUE = "|c" .. RAID_CLASS_COLORS["ROGUE"].colorStr,
+            PRIEST = "|c" .. RAID_CLASS_COLORS["PRIEST"].colorStr,
             DEATH_KNIGHT = "|c" .. RAID_CLASS_COLORS["DEATHKNIGHT"].colorStr,
-            SHAMAN       = "|c" .. RAID_CLASS_COLORS["SHAMAN"].colorStr,
-            MAGE         = "|c" .. RAID_CLASS_COLORS["MAGE"].colorStr,
-            WARLOCK      = "|c" .. RAID_CLASS_COLORS["WARLOCK"].colorStr,
-            MONK         = "|c" .. RAID_CLASS_COLORS["MONK"].colorStr,
-            DRUID        = "|c" .. RAID_CLASS_COLORS["DRUID"].colorStr,
+            SHAMAN = "|c" .. RAID_CLASS_COLORS["SHAMAN"].colorStr,
+            MAGE = "|c" .. RAID_CLASS_COLORS["MAGE"].colorStr,
+            WARLOCK = "|c" .. RAID_CLASS_COLORS["WARLOCK"].colorStr,
+            MONK = "|c" .. RAID_CLASS_COLORS["MONK"].colorStr,
+            DRUID = "|c" .. RAID_CLASS_COLORS["DRUID"].colorStr,
         }
         local stringTable = {
-            classColors.WARRIOR .. l10n("Warrior") .. "|r",                 -- 1
-            classColors.PALADIN .. l10n("Paladin") .. "|r",                 -- 2
-            classColors.HUNTER .. l10n("Hunter") .. "|r",                   -- 4
-            classColors.ROGUE .. l10n("Rogue") .. "|r",                     -- 8
-            classColors.PRIEST .. l10n("Priest") .. "|r",                   -- 16
-            classColors.DEATH_KNIGHT .. l10n("Death Knight") .. "|r",       -- 32
-            classColors.SHAMAN .. l10n("Shaman") .. "|r",                   -- 64
-            classColors.MAGE .. l10n("Mage") .. "|r",                       -- 128
-            classColors.WARLOCK .. l10n("Warlock") .. "|r",                 -- 256
-            classColors.MONK .. l10n("Monk") .. "|r",                       -- 512
-            classColors.DRUID .. l10n("Druid") .. "|r",                     -- 1024
+            classColors.WARRIOR .. l10n("Warrior") .. "|r", -- 1
+            classColors.PALADIN .. l10n("Paladin") .. "|r", -- 2
+            classColors.HUNTER .. l10n("Hunter") .. "|r", -- 4
+            classColors.ROGUE .. l10n("Rogue") .. "|r", -- 8
+            classColors.PRIEST .. l10n("Priest") .. "|r", -- 16
+            classColors.DEATH_KNIGHT .. l10n("Death Knight") .. "|r", -- 32
+            classColors.SHAMAN .. l10n("Shaman") .. "|r", -- 64
+            classColors.MAGE .. l10n("Mage") .. "|r", -- 128
+            classColors.WARLOCK .. l10n("Warlock") .. "|r", -- 256
+            classColors.MONK .. l10n("Monk") .. "|r", -- 512
+            classColors.DRUID .. l10n("Druid") .. "|r", -- 1024
         }
         local firstRun = true
         for k, v in pairs(classTable) do
@@ -394,6 +396,46 @@ function QuestieLib:GetClassString(classMask)
         end
         return classString
     end
+end
+
+---Polls every 0.1 seconds, up to 20 attempts. Calls back once only if every objective has loaded text and type.
+---The callback is asynchronous and is not called on exhaustion or cancellation. Loaded quests may have zero objectives.
+---@param questId QuestId
+---@param callback fun(objectives: QuestObjectiveInfo[])
+---@param tickSpeed? number @Optional, defaults to 0.1 seconds
+---@return Ticker timer @Call timer:Cancel() if the consumer no longer needs the result
+---@return thread thread
+function QuestieLib.ContinueOnQuestObjectivesLoad(questId, callback, tickSpeed)
+    return ThreadLib.Thread(function()
+        local attempts = 0
+        local objectives
+        local ready
+        repeat
+            attempts = attempts + 1
+            local haveQuestData = HaveQuestData(questId)
+            -- Fetch even when quest data is missing: this also requests objective data from the client.
+            objectives = C_QuestLog.GetQuestObjectives(questId)
+            ready = haveQuestData and objectives ~= nil
+            if ready then
+                for objectiveIndex = 1, #objectives do
+                    local objective = objectives[objectiveIndex]
+                    local text = objective.text
+                    if (not text) or text == "" or string.byte(text, 1) == 32 or (not objective.type) then
+                        ready = false
+                        break
+                    end
+                end
+            end
+
+            if (not ready) and attempts < 20 then
+                coroutine.yield()
+            end
+        until ready or attempts >= 20
+
+        if ready then
+            callback(objectives)
+        end
+    end, tickSpeed or 0.1)
 end
 
 function QuestieLib:CacheItemNames(questId)
@@ -722,7 +764,7 @@ function QuestieLib.FormatDate(timeStamp)
     elseif langCode == "frFR" then
         return date(weekDay .. " %d " .. monthName .. " %Y à %H:%M", timeStamp)
     elseif langCode == "koKR" then
-        return date("%Y년 " .. monthName .. " %d일" .. " " .. weekDay .." %H:%M", timeStamp)
+        return date("%Y년 " .. monthName .. " %d일" .. " " .. weekDay .. " %H:%M", timeStamp)
     elseif langCode == "ptBR" then
         return date(weekDay .. ", %d de " .. monthName .. " de %Y às %H:%M", timeStamp)
     elseif langCode == "ruRU" then

--- a/Modules/Libs/QuestieLib.test.lua
+++ b/Modules/Libs/QuestieLib.test.lua
@@ -282,6 +282,139 @@ describe("QuestieLib", function()
         end)
     end)
 
+    describe("ContinueOnQuestObjectivesLoad", function()
+        local ThreadLib
+        local originalThread
+        local originalHaveQuestData
+        local originalGetQuestObjectives
+        local thread
+        local timer
+        local callback
+        local objectives
+
+        ---@return nil
+        local function Tick()
+            local success, err = coroutine.resume(thread)
+            assert.is_true(success, err)
+        end
+
+        before_each(function()
+            ThreadLib = QuestieLoader:ImportModule("ThreadLib")
+            originalThread = ThreadLib.Thread
+            originalHaveQuestData = _G.HaveQuestData
+            originalGetQuestObjectives = _G.C_QuestLog.GetQuestObjectives
+            timer = {}
+            ThreadLib.Thread = spy.new(function(body, delay)
+                assert.are_same(0.1, delay)
+                thread = coroutine.create(body)
+                return timer, thread
+            end)
+            objectives = {{text = "Wolf slain: 0/1", type = "monster"}}
+            _G.HaveQuestData = function() return true end
+            _G.C_QuestLog.GetQuestObjectives = spy.new(function() return objectives end)
+            callback = spy.new(function() end)
+        end)
+
+        after_each(function()
+            ThreadLib.Thread = originalThread
+            _G.HaveQuestData = originalHaveQuestData
+            _G.C_QuestLog.GetQuestObjectives = originalGetQuestObjectives
+        end)
+
+        it("should asynchronously deliver the loaded array once and return the thread handles", function()
+            local returnedTimer, returnedThread = QuestieLib.ContinueOnQuestObjectivesLoad(QUEST_ID, callback)
+
+            assert.are.equal(timer, returnedTimer)
+            assert.are.equal(thread, returnedThread)
+            assert.spy(callback).was.not_called()
+            Tick()
+
+            assert.spy(callback).was.called(1)
+            assert.spy(callback).was.called_with(objectives)
+            assert.spy(_G.C_QuestLog.GetQuestObjectives).was.called_with(QUEST_ID)
+            assert.are_same("dead", coroutine.status(thread))
+        end)
+
+        local incompleteObjectives = {
+            {name = "missing text", objective = {type = "item"}},
+            {name = "empty text", objective = {text = "", type = "item"}},
+            {name = "leading-space text", objective = {text = " : 0/1", type = "item"}},
+            {name = "missing type", objective = {text = "Item: 0/1"}},
+        }
+        for _, case in ipairs(incompleteObjectives) do
+            it("should refetch all objectives when a later objective has " .. case.name, function()
+                objectives[2] = case.objective
+                QuestieLib.ContinueOnQuestObjectivesLoad(QUEST_ID, callback)
+                Tick()
+                assert.spy(callback).was.not_called()
+
+                objectives = {
+                    {text = "Wolf slain: 1/1", type = "monster"},
+                    {text = "Item: 0/1", type = "item"},
+                }
+                Tick()
+
+                assert.spy(callback).was.called(1)
+                assert.spy(callback).was.called_with(objectives)
+                assert.spy(_G.C_QuestLog.GetQuestObjectives).was.called(2)
+                assert.are_same("dead", coroutine.status(thread))
+            end)
+        end
+
+        it("should retry nil API results", function()
+            objectives = nil
+            QuestieLib.ContinueOnQuestObjectivesLoad(QUEST_ID, callback)
+            Tick()
+            assert.spy(callback).was.not_called()
+
+            objectives = {{text = "Wolf slain: 0/1", type = "monster"}}
+            Tick()
+            assert.spy(callback).was.called_with(objectives)
+        end)
+
+        it("should prime objectives while quest data is missing and accept a loaded quest with no objectives", function()
+            objectives = {}
+            _G.HaveQuestData = function() return false end
+            QuestieLib.ContinueOnQuestObjectivesLoad(QUEST_ID, callback)
+            Tick()
+            assert.spy(_G.C_QuestLog.GetQuestObjectives).was.called_with(QUEST_ID)
+            assert.spy(callback).was.not_called()
+
+            _G.HaveQuestData = function() return true end
+            Tick()
+            assert.spy(callback).was.called_with({})
+            assert.are_same("dead", coroutine.status(thread))
+        end)
+
+        it("should stop after 20 unsuccessful attempts without calling back", function()
+            objectives = {{text = "", type = "event"}}
+            QuestieLib.ContinueOnQuestObjectivesLoad(QUEST_ID, callback)
+            for _ = 1, 20 do
+                Tick()
+            end
+
+            assert.spy(_G.C_QuestLog.GetQuestObjectives).was.called(20)
+            assert.spy(callback).was.not_called()
+            assert.are_same("dead", coroutine.status(thread))
+        end)
+
+        it("should still call back if objectives load on the twentieth attempt", function()
+            objectives = nil
+            QuestieLib.ContinueOnQuestObjectivesLoad(QUEST_ID, callback)
+            for _ = 1, 19 do
+                Tick()
+            end
+            assert.spy(callback).was.not_called()
+
+            objectives = {{text = "Wolf slain: 0/1", type = "monster"}}
+            Tick()
+
+            assert.spy(_G.C_QuestLog.GetQuestObjectives).was.called(20)
+            assert.spy(callback).was.called_with(objectives)
+            assert.are_same("dead", coroutine.status(thread))
+        end)
+    end)
+
     describe("DidDailyResetHappenSinceLastLogin", function()
         it("should return true when last login is not set", function()
             _G.GetRealmName = function() return "Ook Ook" end


### PR DESCRIPTION
## Issue references

None.

## Proposed changes

`C_QuestLog.GetQuestObjectives` can return missing or incomplete objective data, even when `HaveQuestData` succeeds. Add `QuestieLib.ContinueOnQuestObjectivesLoad` so callers can wait for all objective text and types through one bounded retry helper. This PR adds the helper and tests only; existing callers are unchanged.

### Before

```text
Caller -> fetch objectives -> incomplete text/type
       -> implement its own readiness checks and retries
```

### After

```text
Caller -> ContinueOnQuestObjectivesLoad
       -> ThreadLib polls all objectives, every 0.1 seconds by default
       -> all ready: callback receives the loaded array
       -> still incomplete after 20 attempts: stop without callback
```

The optional `tickSpeed` argument changes the polling interval. The returned timer lets callers cancel requests they no longer need. Loaded quests with no objectives are accepted.

### Example

If the first objective has loaded but the second still reads `" : 0/1"`, the helper waits and refetches the whole array. Once both objectives have valid text and types, it calls back once with the latest array rather than passing partial data to the consumer.

### Responsibility / ownership

`QuestieLib` owns objective readiness checks and the retry limit; `ThreadLib` owns coroutine scheduling. Consumers own what the callback updates and when to cancel. Adopting the helper in existing consumers is separate work.

### Validation

- `busted Modules/Libs/QuestieLib.test.lua`: 55 passing tests on the committed version.
- `luacheck -q Modules/Libs/QuestieLib.lua Modules/Libs/QuestieLib.test.lua`: no warnings or errors.
- Full suite during implementation: 1,805 passing tests, before the optional polling interval was added.
- Fresh `origin/master` check: branch is already based on latest master.
- No in-game validation performed.

## Screenshots

Not applicable; no UI changes.
